### PR TITLE
OP_RETURN

### DIFF
--- a/scripts/0018.md
+++ b/scripts/0018.md
@@ -1,4 +1,4 @@
-# BRC-18: Pay to False Return
+# BRC-18: False Return
 
 ## Abstract
 
@@ -26,6 +26,7 @@ For example:
 
 Several implementations and protocols make use of the OP_RETURN script template, including the [RUN protocol](https://run.network/docs/#introduction) and [Bitcoin OP_RETURN Bytecode (BOB)](https://medium.com/@_unwriter/hello-bob-94701d278afb).
 
-## Risks and Limitations
 
-The main limitation of using OP_FALSE OP_RETURN is the non-spendability of these outputs and their ability to be pruned by miners. Alternatives to OP_FALSE OP_RETURN include BRC-48 Push Drop tokens and some systems that do not recognize OP_FALSE OP_RETURN convert it into BRC-19 OP_TRUE OP_RETURN instead.
+## Limitations
+
+The main limitation of using OP_FALSE OP_RETURN is the non-spendability of these outputs and their ability to be pruned by miners. They are records rather than tokens. Artefacts predominantly as a proof of existence of data at a certain time - timestamped by the Bitcoin system as a hash with a merkleproof to a block, even if miners themselves prune the data.


### PR DESCRIPTION
Name update.
No need to include alternatives at the end. There are uses for false return records, despite the fact they are not tokens.