### PR TITLE
BEEF Transactions & Compound Merkle Paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ BRC | Standard
 59   | [Security and Scalability Benefits of UTXO-based Overlay Networks](./opinions/0059.md)
 60   | [Simplifying State Machine Event Chains in Bitcoin](./state-machines/0060.md)
 60   | [Compound Merkle Path Format](./transactions/0061.md)
-60   | [Background Evaluation Extended Format (BEEF) Transaction](./transactions/0062.md)
+60   | [Background Evaluation Extended Format (BEEF) Transactions](./transactions/0062.md)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ BRC | Standard
 58   | [Merkle Path JSON format](./transactions/0058.md)
 59   | [Security and Scalability Benefits of UTXO-based Overlay Networks](./opinions/0059.md)
 60   | [Simplifying State Machine Event Chains in Bitcoin](./state-machines/0060.md)
+60   | [Compound Merkle Path Format](./transactions/0061.md)
+60   | [Background Evaluation Extended Format (BEEF) Transaction](./transactions/0062.md)
 
 ## License
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -27,7 +27,9 @@
 * [Raw Transaction Format](./transactions/0012.md)
 * [TXO Transaction Object Format](./transactions/0013.md)
 * [Transaction Extended Format (EF)](./transactions/0030.md)
-* [Merkle Path JSON format](./transactions/0058.md)
+* [Merkle Path Data Model](./transactions/0058.md)
+* [Compound Merkle Path Format](./transactions/0061.md)
+* [Background Evaluation Extended Format (BEEF) Transaction](./transactions/0062.md)
 
 ## Scripts
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -29,7 +29,7 @@
 * [Transaction Extended Format (EF)](./transactions/0030.md)
 * [Merkle Path Data Model](./transactions/0058.md)
 * [Compound Merkle Path Format](./transactions/0061.md)
-* [Background Evaluation Extended Format (BEEF) Transaction](./transactions/0062.md)
+* [Background Evaluation Extended Format (BEEF) Transactions](./transactions/0062.md)
 
 ## Scripts
 

--- a/transactions/0058.md
+++ b/transactions/0058.md
@@ -11,14 +11,15 @@ The name Merkle Proof suggests that it can on its own prove something. I don't t
 
 ## Specification
 
-A Merkle Path needs to indicate the txid of the transaction in question, as well as the index number with respect to a block which contains it, as well as the block's hash.
+A Merkle Path needs to indicate the txid of the transaction in question, but this is assumed to be the key of the object rather than contained within the object itself. Also needed is an index number which indicates position with a block.
+
 The proposed JSON is:
 
 ```json
+// filename or key is a 32 byte txid in hex
+
 { 
-   "txid": "...a transaction id in hex", // hex string 32 bytes
-   "blockhash": "...the block hash in which this tx resides", // hex string 32 bytes
-   "index": "12", // String rather than number to avoid JSON parsing issues.
+   "index": 12, // JSON Number - technically has no MAX size
    "path": [
       "...leaf of the merkle path", // hex string 32 bytes
       "...leaf of the merkle path",
@@ -27,23 +28,57 @@ The proposed JSON is:
    ]
 }
 ```
+
 ## Use
 
 The idea is to use the Merkle Path like so:
 
-1. Verify the txid is as expected.
-2. Lookup the block header by hash provided using your headers service ([Pulse](https://github.com/libsv/pulse/))
-3. Calculate the Merkle root from the txid and path.
-4. Verify that the Merkle root matches that in your block header.
-5. If all matches then store the Merkle path along side your transaction in your database for future use.
+1. Convert all hex string into reverse bytes, txid and all leaves.
+2. Calculate the Merkle root by hashing the txid with each element in the path.
+   1. Checking the last bit of the index number, if it's 1 then the txid should be on the right `workingHash = sha256d([...leaf, ...txid])` else other way around `workingHash = sha256d([...txid, ...leaf])`
+   2. Right shift the index number
+   3. Check the new last bit, if it's 1 then the workingHash should be on the right `workingHash = sha256d([...leaf, ...workingHash])` else other way round `workingHash = sha256d([...workingHash, ...leaf])`
+4. Once all leaves are accumulated into a single hash with the above method - we have the Merkle root which we reverse and convert back into a hex string.
+5. This root can be used to look up a block header.
+6. If the blockheader is part of the longest chain of work then we have a "Merkle Proof" that the tx is included in that block.
+
+### Merkle Proof JSON
+
+You would only likely see a Merkle Proof when you are in a position where you have to present evidence to a court for dispute resolution or something to that effect. In day to day use the Merkle Path format detailed above is all that need be kept within the transaction store, the block header information can be kept separately.
+
+```json
+// fake data example merkle proof
+{
+   "txid": "cefffc5415620292081f7e941bb74d11a3188144312c4d7550c462b2a151c64d", 
+   "index": 657813,
+   "path": [
+      "0c82025f47b31054e9ad52109ef25b00fd9aaae7153564619bab031d4112f56c",
+      "3b6ea708d7b84a078179b53cf2cb2f0636162ffd60a96f81815564bbc6c073cd",
+      "efac0f077fca2a10730400da62ebaebaba852bd5fc3fb7770e090a1919d9c8b4",
+      "1e81e396da7f63e3989a8bc9bdbefddf95c75da1eb3936944b6a55cf82d87034"
+   ]
+   "block": {
+      "header": {
+         "version": 536870912,
+         "prevBlockHash": "0000000000000000005d2328b618e043d80d0e5cd33f79b8351965305482cb6b",
+         "merkleRoot": "d66e56fb408763e36e8622eb56a8a1072ccc606476fe9e0765cca0dff95949b1",
+         "creationTimestamp": 1534851560,
+         "difficultyTarget": 402787433,
+         "nonce": 3785175761,
+      },
+      "hash": "000000000000000001fc2f61db1087c820da44599a82bda8ede1f3c82f67098c",
+      "work": 2305305885491475308752,
+      "height": 544379
+   }
+```
 
 ## Discussion
 
 The main difference between this and the TSC Merkle Proof Standard Format is renaming a few labels:
 
-### labels
+### Labels
 - `txOrId` is dropped in favor of `txid` because the ambiguity is unnecessary, and full transactions have their own format considerations to focus on, hence separation of concerns.
 - `nodes` are renamed to `path` because this more accurately describes the specific hashes we are referring to as those without children in a Merkle tree, and also disambiguates between these and bitcoin nodes or network nodes in general.  Citing the original [Merkle Tree patent](https://worldwide.espacenet.com/patent/search/family/022107098/publication/US4309569A?q=pn%3DUS4309569) we see this referred to as "path", with no mention of nodes anywhere.
 
-### order
+### Order
 The order of items in the JSON is not strict but does imply a better general understanding. As a sentence: This transaction in this block is at index 12 with path... etc.

--- a/transactions/0058.md
+++ b/transactions/0058.md
@@ -1,5 +1,7 @@
 # BRC-58: Merkle Path Data Model
 
+Deggen (deggen@kschw.com)
+
 ## Abstract
 We present a data model and JSON format for a Merkle Path which will be passed from a Transaction Lookup service to a Lite Client via web API.
 

--- a/transactions/0061.md
+++ b/transactions/0061.md
@@ -27,39 +27,44 @@ Compound Path
 ### Example
 
 ```javascript
-nLeafs // repeat for each path
-  height offset leaf...  // repeat for each leaf
-  height offset leaf...  // repeat for each leaf
-  height offset leaf...  // repeat for each leaf
-  height offset leaf...  // repeat for each leaf
-  height offset leaf...  // repeat for each leaf
+height offset leaf...  // repeat for each leaf
+height offset leaf...  // repeat for each leaf
+height offset leaf...  // repeat for each leaf
+height offset leaf...  // repeat for each leaf
+height offset leaf...  // repeat for each leaf
 // ...etc.
 ```
 
 ## Hex Example
 
 ```javascript
-05 // nLeafs VarInt
-// ----------------------
 02 // height 1 byte
-01 // offset VarInt
-cd73c0c6bb645581816fa960fd2f1636062fcbf23cb57981074ab8d708a76e3b
+01 // nLeafs at this height VarInt
 // ----------------------
-01 // height 1 byte
+01 // offset VarInt
+cd73c0c6bb645581816fa960fd2f1636062fcbf23cb57981074ab8d708a76e3b // hash
+// ----------------------
+// implied end of leaves at this height
+// height of next leaves is one less than the height of the above leaves
+02 // nLeafs at this height VarInt
+// ----------------------
 00 // offset VarInt
 3470d882cf556a4b943639eba15dc795dffdbebdc98b9a98e3637fda96e3811e
 // ----------------------
-01 // height 1 byte
 01 // offset VarInt
 c58e40f22b9e9fcd05a09689a9b19e6e62dbfd3335c5253d09a7a7cd755d9a3c
 // ----------------------
-00 // height 1 byte
+// implied end of leaves at this height
+// height of next leaves is one less than the height of the above leaves
+02 // nLeafs at this height VarInt
+// ----------------------
 01 // offset VarInt
 da256f78ae0ad74bbf539662cdb9122aa02ba9a9d883f1d52468d96290515adb
 // ----------------------
-00 // height 1 byte
 02 // offset VarInt
 b4c8d919190a090e77b73ffcd52b85babaaeeb62da000473102aca7f070facef
+// ----------------------
+// implied end of data because previous leaves were at height 0
 ```
 
 ## Implementation
@@ -69,27 +74,48 @@ Let's start by dumping this format as hex into a Buffer and parsing it into an o
 ```javascript
 const { Br } = require('openspv')
 const reader = new Br()
-reader.buf = Buffer.from('050201cd73c0c6bb645581816fa960fd2f1636062fcbf23cb57981074ab8d708a76e3b01003470d882cf556a4b943639eba15dc795dffdbebdc98b9a98e3637fda96e3811e0101c58e40f22b9e9fcd05a09689a9b19e6e62dbfd3335c5253d09a7a7cd755d9a3c0001da256f78ae0ad74bbf539662cdb9122aa02ba9a9d883f1d52468d96290515adb0002b4c8d919190a090e77b73ffcd52b85babaaeeb62da000473102aca7f070facef', 'hex')
+reader.buf = Buffer.from('020101cd73c0c6bb645581816fa960fd2f1636062fcbf23cb57981074ab8d708a76e3b02003470d882cf556a4b943639eba15dc795dffdbebdc98b9a98e3637fda96e3811e01c58e40f22b9e9fcd05a09689a9b19e6e62dbfd3335c5253d09a7a7cd755d9a3c0201da256f78ae0ad74bbf539662cdb9122aa02ba9a9d883f1d52468d96290515adb02b4c8d919190a090e77b73ffcd52b85babaaeeb62da000473102aca7f070facef', 'hex')
 
-const nLeaves = reader.readVarIntNum()
-const leaves = []
-for (let x = 0; x < nLeaves; x++) {
-  height = parseInt(reader.read(1).toString('hex'), 16)
+let maxHeight = parseInt(reader.read(1).toString('hex'), 16)
+let compoundPath = Array(maxHeight + 1).fill(0).map(() => ({}))
+let height = maxHeight
+let x = 0
+let nLeavesAtThisHeight = reader.readVarIntNum()
+let startOfNextHeight = nLeavesAtThisHeight
+while (height >= 0) {
   offset = reader.readVarIntNum()
   hash = reader.read(32).reverse().toString('hex')
-  leaves.push({ height, offset, hash })
+  console.log({ compoundPath, height, hash })
+  compoundPath[height][hash] = offset
+  x++
+  if (x == startOfNextHeight) {
+    height--
+    if (height < 0) break
+    nLeavesAtThisHeight = reader.readVarIntNum()
+    console.log({ nLeavesAtThisHeight })
+    startOfNextHeight = nLeavesAtThisHeight + x
+    console.log({ startOfNextHeight })
+  }
 }
 ```
 
-If we JSON encode the leaves we get the following:
+### JSON Encoding of a Compound Merkle Path
+
+If we JSON encode the leaves we get the following. Height is encoded as the position of the leaf object within the outermost array.
 
 ```json
-[
-  { "height": 2, "offset": 1, "hash": "3b6ea708d7b84a078179b53cf2cb2f0636162ffd60a96f81815564bbc6c073cd" },
-  { "height": 1, "offset": 0, "hash": "1e81e396da7f63e3989a8bc9bdbefddf95c75da1eb3936944b6a55cf82d87034" },
-  { "height": 1, "offset": 1, "hash": "3c9a5d75cda7a7093d25c53533fddb626e9eb1a98996a005cd9f9e2bf2408ec5" },
-  { "height": 0, "offset": 1, "hash": "db5a519062d96824d5f183d8a9a92ba02a12b9cd629653bf4bd70aae786f25da" },
-  { "height": 0, "offset": 2, "hash": "efac0f077fca2a10730400da62ebaebaba852bd5fc3fb7770e090a1919d9c8b4" }
+[ // index within the outer array corresponds to the height
+  { // within each height there must be one or more hashes with their corresponding offsets { [hash]: offset }
+    "db5a519062d96824d5f183d8a9a92ba02a12b9cd629653bf4bd70aae786f25da": 1,
+    "efac0f077fca2a10730400da62ebaebaba852bd5fc3fb7770e090a1919d9c8b4": 2
+  },
+  {
+    "1e81e396da7f63e3989a8bc9bdbefddf95c75da1eb3936944b6a55cf82d87034": 0, 
+    "3c9a5d75cda7a7093d25c53533fddb626e9eb1a98996a005cd9f9e2bf2408ec5": 1
+  },
+  {
+    "3b6ea708d7b84a078179b53cf2cb2f0636162ffd60a96f81815564bbc6c073cd": 1
+  }
 ]
 ```
 
@@ -102,7 +128,7 @@ const example = {
   path: []
 }
 
-let maxHeight = paths[0].height
+let maxHeight = compoundPath.length - 1
 for (let x = maxHeight; x >= 0; x--) {
   for (const leaf of path) {
     if (leaf.height !== x) continue

--- a/transactions/0061.md
+++ b/transactions/0061.md
@@ -2,7 +2,7 @@
 
 ## Abstract
 
-We propose a binary format for compound Merkle Path data.
+We propose a binary format for Compound Merkle Paths optimized for minimal data bandwidth during transmission.
 
 ## Copyright
 
@@ -10,35 +10,134 @@ This BRC is licensed under the Open BSV license.
 
 ## Motivation
 
-Blah
+Current format standards are JSON because it's easier to read. However, it is extremely unlikely that a human need ever read the actual data as a use case - therefore a binary data type shall be put forward here for consideration. Secondarily, there is no data model thus far proposed for compound merkle paths for multiple txids within the same block. This would help reduce the overall size of data needed to express a set of paths.
 
 ## Specification
 
 Compound Path
 
-| Field                     | Description                                                                        |        Size          |
-|---------------------------|------------------------------------------------------------------------------------|----------------------|
-| nIndices                  | VarInt number of paths contained within                                            | 1-9 bytes            |
-||
-| index                     | VarInt index of path included                                                      | 1-9 bytes x nIndices |
-| **repeat x nIndices** |
-| nLeaves                   | VarInt number of leaves which follow in the path                                   | 1-9 bytes            |
-||
-| leaf                      | Each leaf is a 32 byte hash                                                        | 32 bytes             |
-| path mask                 | One byte as the exponent of a 2^N mask for path inclusion                          | 1 byte               |
-| **repeat x nLeaves** |
-
+| Field                | Description                                                                      |        Size          |
+|----------------------|----------------------------------------------------------------------------------|----------------------|
+| nLeaves              | VarInt number of leaves which follow                                             | 1-9 bytes            |
+| height               | The height of the leaf of the tree up to a max 64                                | 1 byte               |
+| offset               | The offset from left hand side at the height of the leaf in the tree             | 1-9 bytes            |
+| leaf                 | Each leaf is a 32 byte hash                                                      | 32 bytes             |
+| **repeat height offset and leaf for the total number of leaves** |
 
 ### Example
 
 ```javascript
-version
-00000000BEEF
-nPaths // paths first
-index
-nLeaves
-leaves... // repeat for each path
+nLeafs // repeat for each path
+  height offset leaf...  // repeat for each leaf
+  height offset leaf...  // repeat for each leaf
+  height offset leaf...  // repeat for each leaf
+  height offset leaf...  // repeat for each leaf
+  height offset leaf...  // repeat for each leaf
+// ...etc.
+```
+
+## Hex Example
+
+```javascript
+05 // nLeafs VarInt
+// ----------------------
+02 // height 1 byte
+01 // offset VarInt
+cd73c0c6bb645581816fa960fd2f1636062fcbf23cb57981074ab8d708a76e3b
+// ----------------------
+01 // height 1 byte
+00 // offset VarInt
+3470d882cf556a4b943639eba15dc795dffdbebdc98b9a98e3637fda96e3811e
+// ----------------------
+01 // height 1 byte
+01 // offset VarInt
+c58e40f22b9e9fcd05a09689a9b19e6e62dbfd3335c5253d09a7a7cd755d9a3c
+// ----------------------
+00 // height 1 byte
+01 // offset VarInt
+da256f78ae0ad74bbf539662cdb9122aa02ba9a9d883f1d52468d96290515adb
+// ----------------------
+00 // height 1 byte
+02 // offset VarInt
+b4c8d919190a090e77b73ffcd52b85babaaeeb62da000473102aca7f070facef
 ```
 
 ## Implementation
 
+Let's start by dumping this format as hex into a Buffer and parsing it into an object with a Buffer Reader. 
+
+```javascript
+const { Br } = require('openspv')
+const reader = new Br()
+reader.buf = Buffer.from('050201cd73c0c6bb645581816fa960fd2f1636062fcbf23cb57981074ab8d708a76e3b01003470d882cf556a4b943639eba15dc795dffdbebdc98b9a98e3637fda96e3811e0101c58e40f22b9e9fcd05a09689a9b19e6e62dbfd3335c5253d09a7a7cd755d9a3c0001da256f78ae0ad74bbf539662cdb9122aa02ba9a9d883f1d52468d96290515adb0002b4c8d919190a090e77b73ffcd52b85babaaeeb62da000473102aca7f070facef', 'hex')
+
+const nLeaves = reader.readVarIntNum()
+const leaves = []
+for (let x = 0; x < nLeaves; x++) {
+  height = parseInt(reader.read(1).toString('hex'), 16)
+  offset = reader.readVarIntNum()
+  hash = reader.read(32).reverse().toString('hex')
+  leaves.push({ height, offset, hash })
+}
+```
+
+If we JSON encode the leaves we get the following:
+
+```json
+[
+  { "height": 2, "offset": 1, "hash": "3b6ea708d7b84a078179b53cf2cb2f0636162ffd60a96f81815564bbc6c073cd" },
+  { "height": 1, "offset": 0, "hash": "1e81e396da7f63e3989a8bc9bdbefddf95c75da1eb3936944b6a55cf82d87034" },
+  { "height": 1, "offset": 1, "hash": "3c9a5d75cda7a7093d25c53533fddb626e9eb1a98996a005cd9f9e2bf2408ec5" },
+  { "height": 0, "offset": 1, "hash": "db5a519062d96824d5f183d8a9a92ba02a12b9cd629653bf4bd70aae786f25da" },
+  { "height": 0, "offset": 2, "hash": "efac0f077fca2a10730400da62ebaebaba852bd5fc3fb7770e090a1919d9c8b4" }
+]
+```
+
+You can derive individual paths for particular transaction indices as necessary using the following algorithm:
+
+Reading index 3 from the Compound Merkle Path.
+```javascript
+const example = {
+  index: 3,
+  path: []
+}
+
+let maxHeight = paths[0].height
+for (let x = maxHeight; x >= 0; x--) {
+  for (const leaf of path) {
+    if (leaf.height !== x) continue
+    indexOffset = example.index >> leaf.height ^ 1
+    if (indexOffset === leaf.offset) example.path.push(leaf.hash)
+  }
+}
+```
+
+Which yields:
+```javascript
+{
+  index: 3,
+  path: [
+    '3b6ea708d7b84a078179b53cf2cb2f0636162ffd60a96f81815564bbc6c073cd',
+    '1e81e396da7f63e3989a8bc9bdbefddf95c75da1eb3936944b6a55cf82d87034',
+    'efac0f077fca2a10730400da62ebaebaba852bd5fc3fb7770e090a1919d9c8b4'
+  ]
+}
+```
+
+### Merkle Proof
+
+We use this to prove inclusion in a block by running a Merkle Proof algorithm on the txid, index, and path. We arrive at a Merkle root hash. This can then be used as the key in a Block Header lookup to determine whether the txid is included within a block which is part of the longest chain of work.
+
+```javascript
+function merkleProof(txid, index, path) {
+  try {
+    const root = deriveRootFromPath(txid, index, path)
+    const blockHeader = await lookupHeaderByRoot(root)
+    if (blockHeader.state === 'LONGEST_CHAIN') return true
+    else return false
+  } catch (error) {
+    console.log({ error })
+    return false
+  }
+}
+```

--- a/transactions/0061.md
+++ b/transactions/0061.md
@@ -1,5 +1,7 @@
 # BRC-61: Compound Merkle Path Format
 
+Deggen (deggen@kschw.com)
+
 ## Abstract
 
 We propose a binary format for Compound Merkle Paths optimized for minimal data bandwidth during transmission.

--- a/transactions/0061.md
+++ b/transactions/0061.md
@@ -1,8 +1,8 @@
-# BRC-61: Background Evaluation Extended Format (BEEF) Transaction
+# BRC-61: Compound Merkle Path Format
 
 ## Abstract
 
-We propose further extension to the existing Extended Format [BRC-30](./0030.md) to allow Simple Payment Verification (SPV). Specifically we aim to validate that all inputs to a transaction come from transactions which are already in a block which exists within the longest chain of work, and if not then the chain is followed backwards through history to arrive at a place where all inputs are as such.
+We propose a binary format for compound Merkle Path data.
 
 ## Copyright
 
@@ -10,64 +10,9 @@ This BRC is licensed under the Open BSV license.
 
 ## Motivation
 
-There are currently two approaches to this in the wild. First is Extended Format [BRC-30](./0030.md) which incorporates the script and satoshis of the input for script evaluation and checking fee rates and the transfer amounts of a tx. The second is Tx Ancestry which is a TSC format which was created for use within DPP, this uses an array of rawtxs, merkle proofs, and Mapi responses to transport the data required for SPV. Mapi responses are essentially deprecated, so those should be discarded. The array of rawtxs makes some sense in that there are strange cases where the same rawtx has two outputs which are spent in different transactions, both within the ancestry of the tx we are validating. You don't want to have embedded a copy of the same proof twice, hence a hash map would make more sense than just including the merkle path bytes in the tx itself.
-
-We want to unify theses standards into one idea which covers edge cases and optimizes for smallest format with the least amount of data while allowing counterparties to verify the tx to the fullest.
-
-The idea is in effect to start by listing merkle paths for each input, and simply use the Extended Format [BRC-30](./0030.md) thereafter. The difference comes up when there are unconfirmed inputs, in which case we include a standard RawTx encoding of that input, and the whole Extended format of the parent transaction. This continues all the way back until all inputs have Merkle paths or parents included.
+Blah
 
 ## Specification
-
-Raw Transaction format:
-
-| Field           | Description                                          | Size                                             |
-|-----------------|------------------------------------------------------|--------------------------------------------------|
-| Version no      | currently 2                                          | 4 bytes                                          |
-| In-counter      | positive integer VI = [[VarInt]]                     | 1 - 9 bytes                                      |
-| list of inputs  | Transaction Input  Structure                         | <in-counter> qty with variable length per input  |
-| Out-counter     | positive integer VI = [[VarInt]]                     | 1 - 9 bytes                                      |
-| list of outputs | Transaction Output Structure                         | <out-counter> qty with variable length per output |
-| nLocktime       | if non-zero and sequence numbers are < 0xFFFFFFFF: block height or timestamp when transaction is final | 4 bytes                                          |
-
-BEEF adds a marker to the transaction format:
-
-| Field            | Description                                                                                            | Size                                              |
-|------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------|
-| Version no       | currently 2                                                                                            | 4 bytes                                           |
-| **BEEF marker**  | **marker for Background Evaluation Extended Format**                                                   | **00000000BEEF**                                  |
-| In-counter       | positive integer VI = [[VarInt]]                                                                       | 1 - 9 bytes                                       |
-| list of inputs   | **BEEF** transaction Input Structure                                                                   | <in-counter> qty with variable length per input   |
-| Out-counter      | positive integer VI = [[VarInt]]                                                                       | 1 - 9 bytes                                       |
-| list of outputs  | Transaction Output Structure                                                                           | <out-counter> qty with variable length per output |
-| nLocktime        | if non-zero and sequence numbers are < 0xFFFFFFFF: block height or timestamp when transaction is final | 4 bytes                                           |
-
-The BEEF marker allows a library that supports the format to recognize that it is dealing with a transaction in extended format, while a library that does not support extended format will read the transaction as having 0 inputs, 0 outputs and a future nLock time. This has been done to minimize the possible problems a legacy library will have when reading the extended format. It can in no way be recognized as a valid transaction.
-
-RawTx standard uses the following input structure:
-
-| Field                     | Description                                                                                 | Size        |
-|---------------------------|---------------------------------------------------------------------------------------------|-------------|
-| Previous Transaction hash | TXID of the transaction the output was created in                                           | 32 bytes    |
-| Previous Txout-index      | Index of the output (Non negative integer)                                                  | 4 bytes     |
-| Txin-script length        | Non negative integer VI = VarInt                                                            | 1 - 9 bytes |
-| Txin-script / scriptSig   | Script                                                                                      | many bytes  | 
-| Sequence_no               | Used to iterate inputs inside a payment channel. Input is final when nSequence = 0xFFFFFFFF | 4 bytes     |
-
-In BEEF, we extend the input structure to include satoshi amount, the previous locking script, index number which points to the particular path associated with the txid in the path array:
-
-| Field                          | Description                                                                                 | Size             |
-|--------------------------------|---------------------------------------------------------------------------------------------|------------------|
-| Previous Transaction hash      | TXID of the transaction the output was created in                                           | 32 bytes         |
-| Previous Txout-index           | Index of the output (Non negative integer)                                                  | 4 bytes          |
-| Txin-script length             | VarInt Unlocking Script Length                                                              | 1 - 9 bytes      |
-| Txin-script / scriptSig        | Unlocking Script                                                                            | many bytes       | 
-| Sequence_no                    | Used to iterate inputs inside a payment channel. Input is final when nSequence = 0xFFFFFFFF | 4 bytes          |
-| **UTXO satoshi amount**        | **Output value in satoshis of previous input - uint64le**                                   | **8 bytes**      |
-| **UTXO locking script length** | **VarInt length of locking script OR 00 which indicates there is a "local anchor"**         | **1 - 9 bytes**  |
-| **UTXO locking script**        | **Script**                                                                                  | **many bytes**   |
-| **path pointer**               | **VarInt points to a particular path from the array**                                       | **1 - 9 bytes**  |
-
-The overall structure starts with the paths of all txids corresponding to their place within the blockchain. Blockhashes are not included. Instead the validator is to calculate the merkle root and lookup thier own header store by that to verify the tx appears within the valid chain of blocks.
 
 Compound Path
 
@@ -84,15 +29,7 @@ Compound Path
 | **repeat x nLeaves** |
 
 
-
-### Local Anchor
-
-When the VarInt following the satoshi amount of an input is "00" zero - this indicates that the input is has a local anchor. This means that the txid in the input points to a previous transactions which exists within the array of transactions in the data shared. For this reason, no further data is shared since this would be repeatition of early bytes. The process a validator would take is to at this point lookup the hashmap of validated previous transactions to determine whether to continue.
-
-Order is important - we must ensure that we end with the tx being evaluated, and its inputs are above, and their inputs are above that. This will allow us to sequentially validate a stream of transactions as they come in without depending on data which hasn't arrived yet. For the same reason, we have to start the stream with the paths of the transactions first, prior to any tx data.
-This makes the overall structure look something like:
-
-### Overall Structure of the Transmitted Data
+### Example
 
 ```javascript
 version
@@ -100,106 +37,8 @@ version
 nPaths // paths first
 index
 nLeaves
-leaves... // repeat for each path, then ancestry starting oldest first
-nTransactions // 2 in this case
-// example a tx with a merkle proof anchor
-  version
-  0000000000EF // extended format follows
-  nInputs
-  outpoint lenUnlockScript unlockingScript nSequence satoshis lenLockingScript lockingScript // txid maps to the path above based on index of a Set of unique values.
-  nOutputs
-  outputs...
-  nLocktime
-// for example a tx with local anchor
-  version
-  nInputs
-  outpoint lenUnlockScript unlockingScript nSequence // no extended data hence no EF tag indicates a local parent above somewhere.
-  nOutputs
-  outputs...
-  nLocktime
+leaves... // repeat for each path
 ```
-
-## Backward compatibility
-
-The Background Evaluation Extended Format is not backwards compatible, but has been designed in such a way that existing software should not read a transaction in Background Evaluation Extended Format as a valid (partial) transaction. The Background Evaluation Extended Format header (00000000BEEF) will be read as an empty transaction with a future nLock time in a library that does not support the Background Evaluation Extended Format.
 
 ## Implementation
 
-### Transaction Order
-Step one is to ensure the transactions are in topological order. Running Khan's algorithm on the transaction DAG subset would be preferred if order is ever in doubt for complex transaction chains. Example below to demonstrate with easily identifyable txids.
-
-```javascript
-// khan's algorithm
-function khanTopologicalSort(graph) {
-    const inDegree = {}
-    const queue = []
-    const result = []
-    for (let node in graph) {
-        inDegree[node] = 0
-    }
-    for (let node in graph) {
-        for (let neighbor in graph[node]) {
-            inDegree[neighbor]++
-        }
-    }
-    for (let node in inDegree) {
-        if (inDegree[node] === 0) {
-            queue.push(node)
-        }
-    }
-    while (queue.length) {
-        let node = queue.shift()
-        result.push(node)
-        for (let neighbor in graph[node]) {
-            inDegree[neighbor]--
-            if (inDegree[neighbor] === 0) {
-                queue.push(neighbor)
-            }
-        }
-    }
-    return result.reverse()
-}
-
-const txs = [
-    {
-        txid: '2222222222222222222222222222222222222222222222222222222222222222',
-        inputs: ['1111111111111111111111111111111111111111111111111111111111111111'],
-    },
-    {
-        txid: '1111111111111111111111111111111111111111111111111111111111111111',
-        inputs: ['0000000000000000000000000000000000000000000000000000000000000000'],
-    },
-    {
-        txid: '0000000000000000000000000000000000000000000000000000000000000000',
-        inputs: [],
-    },
-    {
-        txid: '4444444444444444444444444444444444444444444444444444444444444444',
-        inputs: [
-            '3333333333333333333333333333333333333333333333333333333333333333',
-            '2222222222222222222222222222222222222222222222222222222222222222',
-        ],
-    },
-    {
-        txid: '3333333333333333333333333333333333333333333333333333333333333333',
-        inputs: [
-            '2222222222222222222222222222222222222222222222222222222222222222',
-            '1111111111111111111111111111111111111111111111111111111111111111',
-        ],
-    },
-]
-
-const graph = {}
-for (let tx of txs) {
-    graph[tx.txid] = {}
-    for (let input of tx.inputs) {
-        graph[tx.txid][input] = true
-    }
-}
-console.log({ graph })
-console.log({ correctOrder: khanTopologicalSort(graph) })
-```
-
-### Paths
-
-The next step of constructing a BEEF Tx would be to gather tha Merkle Path data for each input of the transaction we'd like to send. If we have the full set, then no additional transactions need be included.

--- a/transactions/0061.md
+++ b/transactions/0061.md
@@ -12,7 +12,9 @@ This BRC is licensed under the Open BSV license.
 
 There are currently two approaches to this in the wild. First is Extended Format [BRC-30](./0030.md) which incorporates the script and satoshis of the input for script evaluation and checking fee rates and the transfer amounts of a tx. The second is Tx Ancestry which is a TSC format which was created for use within DPP, this uses an array of rawtxs, merkle proofs, and Mapi responses to transport the data required for SPV. Mapi responses are essentially deprecated, so those should be discarded. The array of rawtxs makes some sense in that there are strange cases where the same rawtx has two outputs which are spent in different transactions, both within the ancestry of the tx we are validating. You don't want to have embedded a copy of the same proof twice, hence a hash map would make more sense than just including the merkle path bytes in the tx itself.
 
-We want to unify theses standards into one idea which covers edge cases and optimizes for smallest format with the least amount of data while allowing counterparties to verify the tx to the fullest
+We want to unify theses standards into one idea which covers edge cases and optimizes for smallest format with the least amount of data while allowing counterparties to verify the tx to the fullest.
+
+The idea is in effect to start by listing merkle paths for each input, and simply use the Extended Format [BRC-30](./0030.md) thereafter. The difference comes up when there are unconfirmed inputs, in which case we include a standard RawTx encoding of that input, and the whole Extended format of the parent transaction. This continues all the way back until all inputs have Merkle paths or parents included.
 
 ## Specification
 
@@ -34,14 +36,14 @@ BEEF adds a marker to the transaction format:
 | Version no       | currently 2                                                                                            | 4 bytes                                           |
 | **BEEF marker**  | **marker for Background Evaluation Extended Format**                                                   | **00000000BEEF**                                  |
 | In-counter       | positive integer VI = [[VarInt]]                                                                       | 1 - 9 bytes                                       |
-| list of inputs   | **BEEF** transaction Input Structure                                                        | <in-counter> qty with variable length per input   |
+| list of inputs   | **BEEF** transaction Input Structure                                                                   | <in-counter> qty with variable length per input   |
 | Out-counter      | positive integer VI = [[VarInt]]                                                                       | 1 - 9 bytes                                       |
 | list of outputs  | Transaction Output Structure                                                                           | <out-counter> qty with variable length per output |
 | nLocktime        | if non-zero and sequence numbers are < 0xFFFFFFFF: block height or timestamp when transaction is final | 4 bytes                                           |
 
 The BEEF marker allows a library that supports the format to recognize that it is dealing with a transaction in extended format, while a library that does not support extended format will read the transaction as having 0 inputs, 0 outputs and a future nLock time. This has been done to minimize the possible problems a legacy library will have when reading the extended format. It can in no way be recognized as a valid transaction.
 
-The input structure is the only additional thing that is changed in the Extended Format. The current input structure looks like this:
+RawTx standard uses the following input structure:
 
 | Field                     | Description                                                                                 | Size        |
 |---------------------------|---------------------------------------------------------------------------------------------|-------------|
@@ -67,50 +69,54 @@ In BEEF, we extend the input structure to include satoshi amount, the previous l
 
 The overall structure starts with the paths of all txids corresponding to their place within the blockchain. Blockhashes are not included. Instead the validator is to calculate the merkle root and lookup thier own header store by that to verify the tx appears within the valid chain of blocks.
 
-Path:
+Compound Path
 
 | Field                     | Description                                                                        |        Size          |
 |---------------------------|------------------------------------------------------------------------------------|----------------------|
-| index                     | Uint64le The index number of the txid within the block it was mined                | 8 bytes              |
+| nIndices                  | VarInt number of paths contained within                                            | 1-9 bytes            |
+||
+| index                     | VarInt index of path included                                                      | 1-9 bytes x nIndices |
+| **repeat x nIndices** |
 | nLeaves                   | VarInt number of leaves which follow in the path                                   | 1-9 bytes            |
-| leaf                      | Each leaf is a 32 byte hash                                                        | 32 bytes x nLeaves   |
+||
+| leaf                      | Each leaf is a 32 byte hash                                                        | 32 bytes             |
+| path mask                 | One byte as the exponent of a 2^N mask for path inclusion                          | 1 byte               |
+| **repeat x nLeaves** |
+
 
 
 ### Local Anchor
 
 When the VarInt following the satoshi amount of an input is "00" zero - this indicates that the input is has a local anchor. This means that the txid in the input points to a previous transactions which exists within the array of transactions in the data shared. For this reason, no further data is shared since this would be repeatition of early bytes. The process a validator would take is to at this point lookup the hashmap of validated previous transactions to determine whether to continue.
 
-Order is important - we must ensure that we end with the tx being evaluated, and its inputs are above, and their inputs are above that. There may be a complex dependency tree above so we take a stack base approach as we add inputs from inputs, and run a unique filter on the txid set to ensure no repetion, and first mention is top of the stack. This will allow us to sequentially validate a stream of transactions as they come in without depending on data which hasn't arrived yet.
-
-For the same reason, we have to start the stream with the paths of the transactions first, prior to any tx data.
+Order is important - we must ensure that we end with the tx being evaluated, and its inputs are above, and their inputs are above that. This will allow us to sequentially validate a stream of transactions as they come in without depending on data which hasn't arrived yet. For the same reason, we have to start the stream with the paths of the transactions first, prior to any tx data.
 This makes the overall structure look something like:
 
 ### Overall Structure of the Transmitted Data
 
 ```javascript
+version
+00000000BEEF
 nPaths // paths first
 index
 nLeaves
 leaves... // repeat for each path, then ancestry starting oldest first
-nTransactions
-BEEF transaction bytes...
+nTransactions // 2 in this case
+// example a tx with a merkle proof anchor
+  version
+  0000000000EF // extended format follows
+  nInputs
+  outpoint lenUnlockScript unlockingScript nSequence satoshis lenLockingScript lockingScript // txid maps to the path above based on index of a Set of unique values.
+  nOutputs
+  outputs...
+  nLocktime
 // for example a tx with local anchor
   version
-  00000000BEEF
   nInputs
-  outpoint lenUnlockScript unlockingScript nSequence 00 // last byte indicates local anchor
+  outpoint lenUnlockScript unlockingScript nSequence // no extended data hence no EF tag indicates a local parent above somewhere.
   nOutputs
   outputs...
   nLocktime
-// for another example a tx with a merkle proof anchor
-  version
-  00000000BEEF
-  nInputs
-  outpoint lenUnlockScript unlockingScript nSequence satoshis lenLockingScript lockingScript 02 // last byte indicates the index of the path from above
-  nOutputs
-  outputs...
-  nLocktime
-// repeat for each tx
 ```
 
 ## Backward compatibility
@@ -119,4 +125,81 @@ The Background Evaluation Extended Format is not backwards compatible, but has b
 
 ## Implementation
 
-SOON™
+### Transaction Order
+Step one is to ensure the transactions are in topological order. Running Khan's algorithm on the transaction DAG subset would be preferred if order is ever in doubt for complex transaction chains. Example below to demonstrate with easily identifyable txids.
+
+```javascript
+// khan's algorithm
+function khanTopologicalSort(graph) {
+    const inDegree = {}
+    const queue = []
+    const result = []
+    for (let node in graph) {
+        inDegree[node] = 0
+    }
+    for (let node in graph) {
+        for (let neighbor in graph[node]) {
+            inDegree[neighbor]++
+        }
+    }
+    for (let node in inDegree) {
+        if (inDegree[node] === 0) {
+            queue.push(node)
+        }
+    }
+    while (queue.length) {
+        let node = queue.shift()
+        result.push(node)
+        for (let neighbor in graph[node]) {
+            inDegree[neighbor]--
+            if (inDegree[neighbor] === 0) {
+                queue.push(neighbor)
+            }
+        }
+    }
+    return result.reverse()
+}
+
+const txs = [
+    {
+        txid: '2222222222222222222222222222222222222222222222222222222222222222',
+        inputs: ['1111111111111111111111111111111111111111111111111111111111111111'],
+    },
+    {
+        txid: '1111111111111111111111111111111111111111111111111111111111111111',
+        inputs: ['0000000000000000000000000000000000000000000000000000000000000000'],
+    },
+    {
+        txid: '0000000000000000000000000000000000000000000000000000000000000000',
+        inputs: [],
+    },
+    {
+        txid: '4444444444444444444444444444444444444444444444444444444444444444',
+        inputs: [
+            '3333333333333333333333333333333333333333333333333333333333333333',
+            '2222222222222222222222222222222222222222222222222222222222222222',
+        ],
+    },
+    {
+        txid: '3333333333333333333333333333333333333333333333333333333333333333',
+        inputs: [
+            '2222222222222222222222222222222222222222222222222222222222222222',
+            '1111111111111111111111111111111111111111111111111111111111111111',
+        ],
+    },
+]
+
+const graph = {}
+for (let tx of txs) {
+    graph[tx.txid] = {}
+    for (let input of tx.inputs) {
+        graph[tx.txid][input] = true
+    }
+}
+console.log({ graph })
+console.log({ correctOrder: khanTopologicalSort(graph) })
+```
+
+### Paths
+
+The next step of constructing a BEEF Tx would be to gather tha Merkle Path data for each input of the transaction we'd like to send. If we have the full set, then no additional transactions need be included.

--- a/transactions/0061.md
+++ b/transactions/0061.md
@@ -22,7 +22,11 @@ Compound Path
 | nLeaves              | VarInt number of leaves at this height                                           | 1-9 bytes            |
 | offset               | The offset from left hand side at the height of the leaf in the tree             | 1-9 bytes            |
 | leaf                 | Each leaf is a 32 byte hash                                                      | 32 bytes             |
-| | **repeat as needed for each leaf, and at each height** |
+
+> #### Formatting Syntax
+> 1. `offset` and `leaf` are repeated for `nLeaves` at each height
+> 2. `height` does not need to be repeated, the inference is that height starts as the max height of the tree and is decremented by one each time we reach the end of the current set of leaves. Once `height === -1` we stop parsing.
+> 3. `nLeaves` is repeated for each height, followed by the corresponding `offset` and `leaf` for each.
 
 
 ## Example

--- a/transactions/0061.md
+++ b/transactions/0061.md
@@ -18,25 +18,21 @@ Compound Path
 
 | Field                | Description                                                                      |        Size          |
 |----------------------|----------------------------------------------------------------------------------|----------------------|
-| nLeaves              | VarInt number of leaves which follow                                             | 1-9 bytes            |
-| height               | The height of the leaf of the tree up to a max 64                                | 1 byte               |
+| height               | The height of the tree up to a max 64                                            | 1 byte               |
+| nLeaves              | VarInt number of leaves at this height                                           | 1-9 bytes            |
 | offset               | The offset from left hand side at the height of the leaf in the tree             | 1-9 bytes            |
 | leaf                 | Each leaf is a 32 byte hash                                                      | 32 bytes             |
-| **repeat height offset and leaf for the total number of leaves** |
+| **repeat offset and leaf for the number of leaves at this height** |
+| nLeaves              | VarInt number of leaves at the next height down                                  | 1-9 bytes            |
+| **repeat the same format above until the next height would be -1** |
 
-### Example
+## Example
 
-```javascript
-height offset leaf...  // repeat for each leaf
-height offset leaf...  // repeat for each leaf
-height offset leaf...  // repeat for each leaf
-height offset leaf...  // repeat for each leaf
-height offset leaf...  // repeat for each leaf
-// ...etc.
+### Hex
 ```
-
-## Hex Example
-
+020101cd73c0c6bb645581816fa960fd2f1636062fcbf23cb57981074ab8d708a76e3b02003470d882cf556a4b943639eba15dc795dffdbebdc98b9a98e3637fda96e3811e01c58e40f22b9e9fcd05a09689a9b19e6e62dbfd3335c5253d09a7a7cd755d9a3c0201da256f78ae0ad74bbf539662cdb9122aa02ba9a9d883f1d52468d96290515adb02b4c8d919190a090e77b73ffcd52b85babaaeeb62da000473102aca7f070facef
+```
+### Breakdown
 ```javascript
 02 // height 1 byte
 01 // nLeafs at this height VarInt
@@ -128,14 +124,16 @@ const example = {
   path: []
 }
 
-let maxHeight = compoundPath.length - 1
-for (let x = maxHeight; x >= 0; x--) {
-  for (const leaf of path) {
-    if (leaf.height !== x) continue
-    indexOffset = example.index >> leaf.height ^ 1
-    if (indexOffset === leaf.offset) example.path.push(leaf.hash)
+compoundPath.map((leaves, height) => {
+  const indexOffset = example.index >> height ^ 1
+  for (const hash in leaves) {
+    if (leaves[hash] === indexOffset) {
+      example.path.push(hash)
+      return true
+    }
   }
-}
+  return Error(`We do not have a hash for this index at height: ${height}`)
+})
 ```
 
 Which yields:

--- a/transactions/0061.md
+++ b/transactions/0061.md
@@ -34,7 +34,7 @@ BEEF adds a marker to the transaction format:
 | Version no       | currently 2                                                                                            | 4 bytes                                           |
 | **BEEF marker**  | **marker for Background Evaluation Extended Format**                                                   | **00000000BEEF**                                  |
 | In-counter       | positive integer VI = [[VarInt]]                                                                       | 1 - 9 bytes                                       |
-| list of inputs   | **Extended Format** transaction Input Structure                                                        | <in-counter> qty with variable length per input   |
+| list of inputs   | **BEEF** transaction Input Structure                                                        | <in-counter> qty with variable length per input   |
 | Out-counter      | positive integer VI = [[VarInt]]                                                                       | 1 - 9 bytes                                       |
 | list of outputs  | Transaction Output Structure                                                                           | <out-counter> qty with variable length per output |
 | nLocktime        | if non-zero and sequence numbers are < 0xFFFFFFFF: block height or timestamp when transaction is final | 4 bytes                                           |
@@ -51,7 +51,7 @@ The input structure is the only additional thing that is changed in the Extended
 | Txin-script / scriptSig   | Script                                                                                      | many bytes  | 
 | Sequence_no               | Used to iterate inputs inside a payment channel. Input is final when nSequence = 0xFFFFFFFF | 4 bytes     |
 
-In the Background Evaluation Extended Format, we extend the input structure to include the previous locking script and satoshi outputs, as well as an index number which points to the particular path associated with the txid in the path array:
+In BEEF, we extend the input structure to include satoshi amount, the previous locking script, index number which points to the particular path associated with the txid in the path array:
 
 | Field                          | Description                                                                                 | Size             |
 |--------------------------------|---------------------------------------------------------------------------------------------|------------------|
@@ -82,8 +82,8 @@ When the VarInt following the satoshi amount of an input is "00" zero - this ind
 
 Order is important - we must ensure that we end with the tx being evaluated, and its inputs are above, and their inputs are above that. There may be a complex dependency tree above so we take a stack base approach as we add inputs from inputs, and run a unique filter on the txid set to ensure no repetion, and first mention is top of the stack. This will allow us to sequentially validate a stream of transactions as they come in without depending on data which hasn't arrived yet.
 
-For the same reason, we have to start the stream with the paths of the transactions first, preior to any tx data.
-This makes the overall structure looks something like:
+For the same reason, we have to start the stream with the paths of the transactions first, prior to any tx data.
+This makes the overall structure look something like:
 
 ### Overall Structure of the Transmitted Data
 

--- a/transactions/0061.md
+++ b/transactions/0061.md
@@ -1,0 +1,122 @@
+# BRC-61: Background Evaluation Extended Format (BEEF) Transaction
+
+## Abstract
+
+We propose further extension to the existing Extended Format [BRC-30](./0030.md) to allow Simple Payment Verification (SPV). Specifically we aim to validate that all inputs to a transaction come from transactions which are already in a block which exists within the longest chain of work, and if not then the chain is followed backwards through history to arrive at a place where all inputs are as such.
+
+## Copyright
+
+This BRC is licensed under the Open BSV license.
+
+## Motivation
+
+There are currently two approaches to this in the wild. First is Extended Format [BRC-30](./0030.md) which incorporates the script and satoshis of the input for script evaluation and checking fee rates and the transfer amounts of a tx. The second is Tx Ancestry which is a TSC format which was created for use within DPP, this uses an array of rawtxs, merkle proofs, and Mapi responses to transport the data required for SPV. Mapi responses are essentially deprecated, so those should be discarded. The array of rawtxs makes some sense in that there are strange cases where the same rawtx has two outputs which are spent in different transactions, both within the ancestry of the tx we are validating. You don't want to have embedded a copy of the same proof twice, hence a hash map would make more sense than just including the merkle path bytes in the tx itself.
+
+We want to unify theses standards into one idea which covers edge cases and optimizes for smallest format with the least amount of data while allowing counterparties to verify the tx to the fullest
+
+## Specification
+
+Raw Transaction format:
+
+| Field           | Description                                          | Size                                             |
+|-----------------|------------------------------------------------------|--------------------------------------------------|
+| Version no      | currently 2                                          | 4 bytes                                          |
+| In-counter      | positive integer VI = [[VarInt]]                     | 1 - 9 bytes                                      |
+| list of inputs  | Transaction Input  Structure                         | <in-counter> qty with variable length per input  |
+| Out-counter     | positive integer VI = [[VarInt]]                     | 1 - 9 bytes                                      |
+| list of outputs | Transaction Output Structure                         | <out-counter> qty with variable length per output |
+| nLocktime       | if non-zero and sequence numbers are < 0xFFFFFFFF: block height or timestamp when transaction is final | 4 bytes                                          |
+
+BEEF adds a marker to the transaction format:
+
+| Field            | Description                                                                                            | Size                                              |
+|------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------|
+| Version no       | currently 2                                                                                            | 4 bytes                                           |
+| **BEEF marker**  | **marker for Background Evaluation Extended Format**                                                   | **00000000BEEF**                                  |
+| In-counter       | positive integer VI = [[VarInt]]                                                                       | 1 - 9 bytes                                       |
+| list of inputs   | **Extended Format** transaction Input Structure                                                        | <in-counter> qty with variable length per input   |
+| Out-counter      | positive integer VI = [[VarInt]]                                                                       | 1 - 9 bytes                                       |
+| list of outputs  | Transaction Output Structure                                                                           | <out-counter> qty with variable length per output |
+| nLocktime        | if non-zero and sequence numbers are < 0xFFFFFFFF: block height or timestamp when transaction is final | 4 bytes                                           |
+
+The BEEF marker allows a library that supports the format to recognize that it is dealing with a transaction in extended format, while a library that does not support extended format will read the transaction as having 0 inputs, 0 outputs and a future nLock time. This has been done to minimize the possible problems a legacy library will have when reading the extended format. It can in no way be recognized as a valid transaction.
+
+The input structure is the only additional thing that is changed in the Extended Format. The current input structure looks like this:
+
+| Field                     | Description                                                                                 | Size        |
+|---------------------------|---------------------------------------------------------------------------------------------|-------------|
+| Previous Transaction hash | TXID of the transaction the output was created in                                           | 32 bytes    |
+| Previous Txout-index      | Index of the output (Non negative integer)                                                  | 4 bytes     |
+| Txin-script length        | Non negative integer VI = VarInt                                                            | 1 - 9 bytes |
+| Txin-script / scriptSig   | Script                                                                                      | many bytes  | 
+| Sequence_no               | Used to iterate inputs inside a payment channel. Input is final when nSequence = 0xFFFFFFFF | 4 bytes     |
+
+In the Background Evaluation Extended Format, we extend the input structure to include the previous locking script and satoshi outputs, as well as an index number which points to the particular path associated with the txid in the path array:
+
+| Field                          | Description                                                                                 | Size             |
+|--------------------------------|---------------------------------------------------------------------------------------------|------------------|
+| Previous Transaction hash      | TXID of the transaction the output was created in                                           | 32 bytes         |
+| Previous Txout-index           | Index of the output (Non negative integer)                                                  | 4 bytes          |
+| Txin-script length             | VarInt Unlocking Script Length                                                              | 1 - 9 bytes      |
+| Txin-script / scriptSig        | Unlocking Script                                                                            | many bytes       | 
+| Sequence_no                    | Used to iterate inputs inside a payment channel. Input is final when nSequence = 0xFFFFFFFF | 4 bytes          |
+| **UTXO satoshi amount**        | **Output value in satoshis of previous input - uint64le**                                   | **8 bytes**      |
+| **UTXO locking script length** | **VarInt length of locking script OR 00 which indicates there is a "local anchor"**         | **1 - 9 bytes**  |
+| **UTXO locking script**        | **Script**                                                                                  | **many bytes**   |
+| **path pointer**               | **VarInt points to a particular path from the array**                                       | **1 - 9 bytes**  |
+
+The overall structure starts with the paths of all txids corresponding to their place within the blockchain. Blockhashes are not included. Instead the validator is to calculate the merkle root and lookup thier own header store by that to verify the tx appears within the valid chain of blocks.
+
+Path:
+
+| Field                     | Description                                                                        |        Size          |
+|---------------------------|------------------------------------------------------------------------------------|----------------------|
+| index                     | Uint64le The index number of the txid within the block it was mined                | 8 bytes              |
+| nLeaves                   | VarInt number of leaves which follow in the path                                   | 1-9 bytes            |
+| leaf                      | Each leaf is a 32 byte hash                                                        | 32 bytes x nLeaves   |
+
+
+### Local Anchor
+
+When the VarInt following the satoshi amount of an input is "00" zero - this indicates that the input is has a local anchor. This means that the txid in the input points to a previous transactions which exists within the array of transactions in the data shared. For this reason, no further data is shared since this would be repeatition of early bytes. The process a validator would take is to at this point lookup the hashmap of validated previous transactions to determine whether to continue.
+
+Order is important - we must ensure that we end with the tx being evaluated, and its inputs are above, and their inputs are above that. There may be a complex dependency tree above so we take a stack base approach as we add inputs from inputs, and run a unique filter on the txid set to ensure no repetion, and first mention is top of the stack. This will allow us to sequentially validate a stream of transactions as they come in without depending on data which hasn't arrived yet.
+
+For the same reason, we have to start the stream with the paths of the transactions first, preior to any tx data.
+This makes the overall structure looks something like:
+
+### Overall Structure of the Transmitted Data
+
+```javascript
+nPaths // paths first
+index
+nLeaves
+leaves... // repeat for each path, then ancestry starting oldest first
+nTransactions
+BEEF transaction bytes...
+// for example a tx with local anchor
+  version
+  00000000BEEF
+  nInputs
+  outpoint lenUnlockScript unlockingScript nSequence 00 // last byte indicates local anchor
+  nOutputs
+  outputs...
+  nLocktime
+// for another example a tx with a merkle proof anchor
+  version
+  00000000BEEF
+  nInputs
+  outpoint lenUnlockScript unlockingScript nSequence satoshis lenLockingScript lockingScript 02 // last byte indicates the index of the path from above
+  nOutputs
+  outputs...
+  nLocktime
+// repeat for each tx
+```
+
+## Backward compatibility
+
+The Background Evaluation Extended Format is not backwards compatible, but has been designed in such a way that existing software should not read a transaction in Background Evaluation Extended Format as a valid (partial) transaction. The Background Evaluation Extended Format header (00000000BEEF) will be read as an empty transaction with a future nLock time in a library that does not support the Background Evaluation Extended Format.
+
+## Implementation
+
+SOON™

--- a/transactions/0061.md
+++ b/transactions/0061.md
@@ -22,9 +22,8 @@ Compound Path
 | nLeaves              | VarInt number of leaves at this height                                           | 1-9 bytes            |
 | offset               | The offset from left hand side at the height of the leaf in the tree             | 1-9 bytes            |
 | leaf                 | Each leaf is a 32 byte hash                                                      | 32 bytes             |
-| **repeat offset and leaf for the number of leaves at this height** |
-| nLeaves              | VarInt number of leaves at the next height down                                  | 1-9 bytes            |
-| **repeat the same format above until the next height would be -1** |
+| | **repeat as needed for each leaf, and at each height** |
+
 
 ## Example
 
@@ -32,16 +31,16 @@ Compound Path
 ```
 020101cd73c0c6bb645581816fa960fd2f1636062fcbf23cb57981074ab8d708a76e3b02003470d882cf556a4b943639eba15dc795dffdbebdc98b9a98e3637fda96e3811e01c58e40f22b9e9fcd05a09689a9b19e6e62dbfd3335c5253d09a7a7cd755d9a3c0201da256f78ae0ad74bbf539662cdb9122aa02ba9a9d883f1d52468d96290515adb02b4c8d919190a090e77b73ffcd52b85babaaeeb62da000473102aca7f070facef
 ```
-### Byte Breakdown
+### Bytewise Breakdown
 ```javascript
-02 // height 1 byte
+02 // height = 2
 01 // nLeafs at this height VarInt
 // ----------------------
 01 // offset VarInt
 cd73c0c6bb645581816fa960fd2f1636062fcbf23cb57981074ab8d708a76e3b // 32 byte hash
 // ----------------------
 // implied end of leaves at this height
-// height of next leaves is one less than the height of the above leaves
+// height of next leaves is therefore 1
 02 // nLeafs at this height VarInt
 // ----------------------
 00 // offset VarInt
@@ -51,7 +50,7 @@ cd73c0c6bb645581816fa960fd2f1636062fcbf23cb57981074ab8d708a76e3b // 32 byte hash
 c58e40f22b9e9fcd05a09689a9b19e6e62dbfd3335c5253d09a7a7cd755d9a3c // 32 byte hash
 // ----------------------
 // implied end of leaves at this height
-// height of next leaves is one less than the height of the above leaves
+// height of next leaves is therefore 0
 02 // nLeafs at this height VarInt
 // ----------------------
 01 // offset VarInt
@@ -60,7 +59,7 @@ da256f78ae0ad74bbf539662cdb9122aa02ba9a9d883f1d52468d96290515adb // 32 byte hash
 02 // offset VarInt
 b4c8d919190a090e77b73ffcd52b85babaaeeb62da000473102aca7f070facef // 32 byte hash
 // ----------------------
-// implied end of data because previous leaves were at height 0
+// implied end of data because new height would be -1
 ```
 
 ## Implementation
@@ -98,7 +97,7 @@ console.log({ compoundPath })
 
 If we JSON encode the leaves we get the following. Height is encoded as the position of the leaf object within the outermost array.
 
-```json
+```javascript
 [ // index within the outer array corresponds to the height
   { // within each height there must be one or more hashes with their corresponding offsets { [hash]: offset }
     "db5a519062d96824d5f183d8a9a92ba02a12b9cd629653bf4bd70aae786f25da": 1,
@@ -147,11 +146,14 @@ Which yields:
 }
 ```
 
+Important to understand that we only kept the paths for indices 0 and 3 for this particular example. If you attempt to run the algo above for any other indices, an error would be thrown. This allowed us to keep 5 hashes out of 14 total. Keeping each path separately we'd have to keep minimum 6 hashes, and if we added another index then the compound method would only require one more hash, whereas saving individual paths would require another 3. The total bandwidth saving would be significant if we had thousands of transactions all in the same block.
+
 ### Merkle Proof
 
 We use this to prove inclusion in a block by running a Merkle Proof algorithm on the txid, index, and path. We arrive at a Merkle root hash. This can then be used as the key in a Block Header lookup to determine whether the txid is included within a block which is part of the longest chain of work.
 
 ```javascript
+// pseudocode
 function merkleProof(txid, index, path) {
   try {
     const root = deriveRootFromPath(txid, index, path)

--- a/transactions/0061.md
+++ b/transactions/0061.md
@@ -14,13 +14,13 @@ Current format standards are JSON because it's easier to read. However, it is ex
 
 ## Specification
 
-Compound Path
+#### Data Types
 
 | Field                | Description                                                                      |        Size          |
 |----------------------|----------------------------------------------------------------------------------|----------------------|
 | height               | The height of the tree up to a max 64                                            | 1 byte               |
-| nLeaves              | VarInt number of leaves at this height                                           | 1-9 bytes            |
-| offset               | The offset from left hand side at the height of the leaf in the tree             | 1-9 bytes            |
+| nLeaves              | `VarInt` number of leaves at this height                                           | 1-9 bytes            |
+| offset               | `VarInt` offset from left hand side within tree             | 1-9 bytes            |
 | leaf                 | Each leaf is a 32 byte hash                                                      | 32 bytes             |
 
 > #### Formatting Syntax
@@ -97,7 +97,7 @@ while (height >= 0) {
 console.log({ compoundPath })
 ```
 
-### JSON Encoding of a Compound Merkle Path
+## JSON Encoding of a Compound Merkle Path
 
 If we JSON encode the leaves we get the following. Height is encoded as the position of the leaf object within the outermost array.
 
@@ -152,7 +152,7 @@ Which yields:
 
 Important to understand that we only kept the paths for indices 0 and 3 for this particular example. If you attempt to run the algo above for any other indices, an error would be thrown. This allowed us to keep 5 hashes out of 14 total. Keeping each path separately we'd have to keep minimum 6 hashes, and if we added another index then the compound method would only require one more hash, whereas saving individual paths would require another 3. The total bandwidth saving would be significant if we had thousands of transactions all in the same block.
 
-### Merkle Proof
+## Merkle Proof
 
 We use this to prove inclusion in a block by running a Merkle Proof algorithm on the txid, index, and path. We arrive at a Merkle root hash. This can then be used as the key in a Block Header lookup to determine whether the txid is included within a block which is part of the longest chain of work.
 

--- a/transactions/0061.md
+++ b/transactions/0061.md
@@ -32,40 +32,40 @@ Compound Path
 ```
 020101cd73c0c6bb645581816fa960fd2f1636062fcbf23cb57981074ab8d708a76e3b02003470d882cf556a4b943639eba15dc795dffdbebdc98b9a98e3637fda96e3811e01c58e40f22b9e9fcd05a09689a9b19e6e62dbfd3335c5253d09a7a7cd755d9a3c0201da256f78ae0ad74bbf539662cdb9122aa02ba9a9d883f1d52468d96290515adb02b4c8d919190a090e77b73ffcd52b85babaaeeb62da000473102aca7f070facef
 ```
-### Breakdown
+### Byte Breakdown
 ```javascript
 02 // height 1 byte
 01 // nLeafs at this height VarInt
 // ----------------------
 01 // offset VarInt
-cd73c0c6bb645581816fa960fd2f1636062fcbf23cb57981074ab8d708a76e3b // hash
+cd73c0c6bb645581816fa960fd2f1636062fcbf23cb57981074ab8d708a76e3b // 32 byte hash
 // ----------------------
 // implied end of leaves at this height
 // height of next leaves is one less than the height of the above leaves
 02 // nLeafs at this height VarInt
 // ----------------------
 00 // offset VarInt
-3470d882cf556a4b943639eba15dc795dffdbebdc98b9a98e3637fda96e3811e
+3470d882cf556a4b943639eba15dc795dffdbebdc98b9a98e3637fda96e3811e // 32 byte hash
 // ----------------------
 01 // offset VarInt
-c58e40f22b9e9fcd05a09689a9b19e6e62dbfd3335c5253d09a7a7cd755d9a3c
+c58e40f22b9e9fcd05a09689a9b19e6e62dbfd3335c5253d09a7a7cd755d9a3c // 32 byte hash
 // ----------------------
 // implied end of leaves at this height
 // height of next leaves is one less than the height of the above leaves
 02 // nLeafs at this height VarInt
 // ----------------------
 01 // offset VarInt
-da256f78ae0ad74bbf539662cdb9122aa02ba9a9d883f1d52468d96290515adb
+da256f78ae0ad74bbf539662cdb9122aa02ba9a9d883f1d52468d96290515adb // 32 byte hash
 // ----------------------
 02 // offset VarInt
-b4c8d919190a090e77b73ffcd52b85babaaeeb62da000473102aca7f070facef
+b4c8d919190a090e77b73ffcd52b85babaaeeb62da000473102aca7f070facef // 32 byte hash
 // ----------------------
 // implied end of data because previous leaves were at height 0
 ```
 
 ## Implementation
 
-Let's start by dumping this format as hex into a Buffer and parsing it into an object with a Buffer Reader. 
+Let's start by dumping this format as hex into a Buffer and parsing it into an object with a Buffer Reader. Then we construct an object
 
 ```javascript
 const { Br } = require('openspv')
@@ -81,18 +81,17 @@ let startOfNextHeight = nLeavesAtThisHeight
 while (height >= 0) {
   offset = reader.readVarIntNum()
   hash = reader.read(32).reverse().toString('hex')
-  console.log({ compoundPath, height, hash })
   compoundPath[height][hash] = offset
   x++
   if (x == startOfNextHeight) {
     height--
     if (height < 0) break
     nLeavesAtThisHeight = reader.readVarIntNum()
-    console.log({ nLeavesAtThisHeight })
     startOfNextHeight = nLeavesAtThisHeight + x
-    console.log({ startOfNextHeight })
   }
 }
+
+console.log({ compoundPath })
 ```
 
 ### JSON Encoding of a Compound Merkle Path

--- a/transactions/0061.md
+++ b/transactions/0061.md
@@ -6,6 +6,10 @@ Deggen (deggen@kschw.com)
 
 We propose a binary format for Compound Merkle Paths optimized for minimal data bandwidth during transmission.
 
+## Explainer Video  
+
+[![Watch Explainer](https://img.youtube.com/vi/xuc9g4_T4Ko/default.jpg)](https://youtu.be/xuc9g4_T4Ko)
+
 ## Copyright
 
 This BRC is licensed under the Open BSV license.

--- a/transactions/0062.md
+++ b/transactions/0062.md
@@ -1,0 +1,221 @@
+# BRC-62: Background Evaluation Extended Format (BEEF) Transaction
+
+## Abstract
+
+We propose a binary format for sending Transactions between peers to allow Simple Payment Verification (SPV). The format is optimized for minimal bandwidth without losing the ability to independently validate the transaction in full.
+
+Assumption: Every user has an independent source of Block Headers indexed by Merkle Root. 
+
+The simplest form is a single transaction, with extended data to allow script evaluation and satoshi amount verification, with Merkle paths for each input.
+
+In cases where one or more inputs are not yet mined, each ancestral transaction is included. We step back through the Transaction DAG until every input has a Merkle Path or corresponding parent transaction.
+
+Inputs with corresponding Merkle Paths will be extended with previous outpoint script and satoshis. Whereas inputs with parents included in stream are not extended since this data has already been sent.**
+
+## Copyright
+
+This BRC is licensed under the Open BSV license.
+
+## Motivation
+
+Simplified Payment Verification formats for transmitting transactions between peers has yet to see wide adoption. This proposal advocates for complete ecosystem adoption of the principles of SPV; acknowledges that the system is secured by economics incentives, and law; and lays out a binary format for transmitting the data between parties optimizing for minimal bandwidth.
+
+Most recently proposed was Extended Format [BRC-30](./0030.md) which incorporates the script and satoshis of the input for script evaluation and checking fee rates and the transfer amounts of a tx. 
+
+The second is Tx Ancestry which is a TSC format which was created for use within DPP, this uses an array of rawtxs, merkle proofs, and Mapi responses to transport the data required for SPV. Mapi responses are essentially deprecated, so those should be discarded. 
+
+The array of rawtxs makes some sense in that there are strange cases where the same rawtx has two outputs which are spent in different transactions, both within the ancestry of the tx we are validating. You don't want to have embedded a copy of the same proof twice, hence a hash map would make more sense than just including the merkle path bytes in the tx itself.
+
+The idea is in effect to start by listing merkle paths for each input, and simply use the Extended Format [BRC-30](./0030.md) thereafter. The difference comes up when there are unconfirmed inputs, in which case we include a standard RawTx encoding of that input, and the whole Extended format of the parent transaction. This continues all the way back until all inputs have Merkle paths or parents included.
+
+## Specification
+
+BEEF combines three formats into one binary stream, prefixed with a header for disambiguation.
+
+- Compound Path Format: [BRC-61](./0061.md)
+- Raw Transaction Format: [BRC-12](./0012.md)
+- Extended Format (EF): [BRC-30](./0012.md)
+
+
+| Field           | Description                                          | Size                                             |
+|-----------------|------------------------------------------------------|--------------------------------------------------|
+| Version no      | currently 2                                          | 4 bytes                                          |
+| In-counter      | positive integer VI = [[VarInt]]                     | 1 - 9 bytes                                      |
+| list of inputs  | Transaction Input  Structure                         | <in-counter> qty with variable length per input  |
+| Out-counter     | positive integer VI = [[VarInt]]                     | 1 - 9 bytes                                      |
+| list of outputs | Transaction Output Structure                         | <out-counter> qty with variable length per output |
+| nLocktime       | if non-zero and sequence numbers are < 0xFFFFFFFF: block height or timestamp when transaction is final | 4 bytes                                          |
+
+BEEF adds a marker to the transaction format:
+
+| Field            | Description                                                                                            | Size                                              |
+|------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------|
+| Version no       | currently 2                                                                                            | 4 bytes                                           |
+| **BEEF marker**  | **marker for Background Evaluation Extended Format**                                                   | **00000000BEEF**                                  |
+| In-counter       | positive integer VI = [[VarInt]]                                                                       | 1 - 9 bytes                                       |
+| list of inputs   | **BEEF** transaction Input Structure                                                                   | <in-counter> qty with variable length per input   |
+| Out-counter      | positive integer VI = [[VarInt]]                                                                       | 1 - 9 bytes                                       |
+| list of outputs  | Transaction Output Structure                                                                           | <out-counter> qty with variable length per output |
+| nLocktime        | if non-zero and sequence numbers are < 0xFFFFFFFF: block height or timestamp when transaction is final | 4 bytes                                           |
+
+The BEEF marker allows a library that supports the format to recognize that it is dealing with a transaction in extended format, while a library that does not support extended format will read the transaction as having 0 inputs, 0 outputs and a future nLock time. This has been done to minimize the possible problems a legacy library will have when reading the extended format. It can in no way be recognized as a valid transaction.
+
+RawTx standard uses the following input structure:
+
+| Field                     | Description                                                                                 | Size        |
+|---------------------------|---------------------------------------------------------------------------------------------|-------------|
+| Previous Transaction hash | TXID of the transaction the output was created in                                           | 32 bytes    |
+| Previous Txout-index      | Index of the output (Non negative integer)                                                  | 4 bytes     |
+| Txin-script length        | Non negative integer VI = VarInt                                                            | 1 - 9 bytes |
+| Txin-script / scriptSig   | Script                                                                                      | many bytes  | 
+| Sequence_no               | Used to iterate inputs inside a payment channel. Input is final when nSequence = 0xFFFFFFFF | 4 bytes     |
+
+In EF, we extend the input structure to include satoshi amount, the previous locking script, the outpoint's first 32 bytes points to a particular path associated with the txid in the path array:
+
+| Field                          | Description                                                                                 | Size             |
+|--------------------------------|---------------------------------------------------------------------------------------------|------------------|
+| Previous Transaction hash      | TXID of the transaction the output was created in                                           | 32 bytes         |
+| Previous Txout-index           | Index of the output (Non negative integer)                                                  | 4 bytes          |
+| Txin-script length             | VarInt Unlocking Script Length                                                              | 1 - 9 bytes      |
+| Txin-script / scriptSig        | Unlocking Script                                                                            | many bytes       | 
+| Sequence_no                    | Used to iterate inputs inside a payment channel. Input is final when nSequence = 0xFFFFFFFF | 4 bytes          |
+| **UTXO satoshi amount**        | **Output value in satoshis of previous input - uint64le**                                   | **8 bytes**      |
+| **UTXO locking script length** | **VarInt length of locking script OR 00 which indicates there is a "local anchor"**         | **1 - 9 bytes**  |
+| **UTXO locking script**        | **Script**                                                                                  | **many bytes**   |
+
+The overall structure starts with the paths of all txids corresponding to their place within the blockchain. Blockhashes are not included. Instead the validator is to calculate the merkle root and lookup thier own header store by that to verify the tx appears within the valid chain of blocks.
+
+Compound Path
+
+| Field                     | Description                                                                        |        Size          |
+|---------------------------|------------------------------------------------------------------------------------|----------------------|
+| nIndices                  | VarInt number of paths contained within                                            | 1-9 bytes            |
+||
+| index                     | VarInt index of path included                                                      | 1-9 bytes x nIndices |
+| **repeat x nIndices** |
+| nLeaves                   | VarInt number of leaves which follow in the path                                   | 1-9 bytes            |
+||
+| leaf                      | Each leaf is a 32 byte hash                                                        | 32 bytes             |
+| path mask                 | One byte as the exponent of a 2^N mask for path inclusion                          | 1 byte               |
+| **repeat x nLeaves** |
+
+
+
+### Local Anchor
+
+When the VarInt following the satoshi amount of an input is "00" zero - this indicates that the input is has a local anchor. This means that the txid in the input points to a previous transactions which exists within the array of transactions in the data shared. For this reason, no further data is shared since this would be repeatition of early bytes. The process a validator would take is to at this point lookup the hashmap of validated previous transactions to determine whether to continue.
+
+Order is important - we must ensure that we end with the tx being evaluated, and its inputs are above, and their inputs are above that. This will allow us to sequentially validate a stream of transactions as they come in without depending on data which hasn't arrived yet. For the same reason, we have to start the stream with the paths of the transactions first, prior to any tx data.
+This makes the overall structure look something like:
+
+### Overall Structure of the Transmitted Data
+
+```javascript
+version
+00000000BEEF
+nPaths // paths first
+index
+nLeaves
+leaves... // repeat for each path, then ancestry starting oldest first
+nTransactions // 2 in this case
+// example a tx with a merkle proof anchor
+  version
+  0000000000EF // extended format follows
+  nInputs
+  outpoint lenUnlockScript unlockingScript nSequence satoshis lenLockingScript lockingScript // txid maps to the path above based on index of a Set of unique values.
+  nOutputs
+  outputs...
+  nLocktime
+// for example a tx with local parent
+  version
+  nInputs
+  outpoint lenUnlockScript unlockingScript nSequence // parent has been processed above
+  nOutputs
+  outputs...
+  nLocktime
+```
+
+## Backward compatibility
+
+The Background Evaluation Extended Format is not backwards compatible, but has been designed in such a way that existing software should not read a transaction in Background Evaluation Extended Format as a valid (partial) transaction. The Background Evaluation Extended Format header (00000000BEEF) will be read as an empty transaction with a future nLock time in a library that does not support the Background Evaluation Extended Format.
+
+## Implementation
+
+### Transaction Order
+Step one is to ensure the transactions are in topological order. Running Khan's algorithm on the transaction DAG subset would be preferred if order is ever in doubt for complex transaction chains. Example below to demonstrate with easily identifyable txids.
+
+```javascript
+// khan's algorithm
+function khanTopologicalSort(graph) {
+    const inDegree = {}
+    const queue = []
+    const result = []
+    for (let node in graph) {
+        inDegree[node] = 0
+    }
+    for (let node in graph) {
+        for (let neighbor in graph[node]) {
+            inDegree[neighbor]++
+        }
+    }
+    for (let node in inDegree) {
+        if (inDegree[node] === 0) {
+            queue.push(node)
+        }
+    }
+    while (queue.length) {
+        let node = queue.shift()
+        result.push(node)
+        for (let neighbor in graph[node]) {
+            inDegree[neighbor]--
+            if (inDegree[neighbor] === 0) {
+                queue.push(neighbor)
+            }
+        }
+    }
+    return result.reverse()
+}
+
+const txs = [
+    {
+        txid: '2222222222222222222222222222222222222222222222222222222222222222',
+        inputs: ['1111111111111111111111111111111111111111111111111111111111111111'],
+    },
+    {
+        txid: '1111111111111111111111111111111111111111111111111111111111111111',
+        inputs: ['0000000000000000000000000000000000000000000000000000000000000000'],
+    },
+    {
+        txid: '0000000000000000000000000000000000000000000000000000000000000000',
+        inputs: [],
+    },
+    {
+        txid: '4444444444444444444444444444444444444444444444444444444444444444',
+        inputs: [
+            '3333333333333333333333333333333333333333333333333333333333333333',
+            '2222222222222222222222222222222222222222222222222222222222222222',
+        ],
+    },
+    {
+        txid: '3333333333333333333333333333333333333333333333333333333333333333',
+        inputs: [
+            '2222222222222222222222222222222222222222222222222222222222222222',
+            '1111111111111111111111111111111111111111111111111111111111111111',
+        ],
+    },
+]
+
+const graph = {}
+for (let tx of txs) {
+    graph[tx.txid] = {}
+    for (let input of tx.inputs) {
+        graph[tx.txid][input] = true
+    }
+}
+console.log({ graph })
+console.log({ correctOrder: khanTopologicalSort(graph) })
+```
+
+### Paths
+
+The next step of constructing a BEEF Tx would be to gather tha Merkle Path data for each input of the transaction we'd like to send. If we have the full set, then no additional transactions need be included.

--- a/transactions/0062.md
+++ b/transactions/0062.md
@@ -1,4 +1,4 @@
-# BRC-62: Background Evaluation Extended Format (BEEF) Transaction
+# BRC-62: Background Evaluation Extended Format (BEEF) Transactions
 
 ## Abstract
 

--- a/transactions/0062.md
+++ b/transactions/0062.md
@@ -225,8 +225,3 @@ ffffffff // nSequence
 The Background Evaluation Extended Format is not backwards compatible, but has been designed in such a way that existing software should not read a transaction in Background Evaluation Extended Format as a valid (partial) transaction. The Background Evaluation Extended Format header (00000000BEEF) will be read as an empty transaction with a future nLock time in a library that does not support the Background Evaluation Extended Format.
 
 ## Implementation
-
-
-### Paths
-
-The next step of constructing a BEEF Tx would be to gather tha Merkle Path data for each input of the transaction we'd like to send. If we have the full set, then no additional transactions need be included.

--- a/transactions/0062.md
+++ b/transactions/0062.md
@@ -35,7 +35,7 @@ The array of rawtxs within the Tx Ancestors spec makes some sense in that there 
 The ordering of data has streaming validation in mind - an idea raised in EF [BRC-30](./0030.md) - such that a receiver can start processing the validation immediately on receipt of the first few bytes, and any later bytes rely on previous bytes for their validation to even begin.
 
 - Merkle Paths
-- Oldest Tx Anchroed by Path
+- Oldest Tx Anchored by Path
 - Newer Txs depending on Oldest parent
 - Newest Tx
 
@@ -98,7 +98,7 @@ In CEF, we extend the input structure to include one of two things.
 
 ### Ordering
 
-Order is important - we must ensure that we end with the tx being evaluated, and its inputs are above, and their inputs are above that. Running Khan's algorithm on the transaction DAG subset would be preferred if order is ever in doubt for complex transaction chains. Example below to demonstrate with extraneous data removed for clarity.
+Order is important - we must ensure that we end with the tx being evaluated, and its inputs are above, and their inputs are above that. [Khan's algorithm](https://en.wikipedia.org/wiki/Topological_sorting) is a well known solution to the problem in Graph Theory. Running this on the transaction DAG subset is recommended for complex transaction chains where order is not clear. Example below to demonstrate with extraneous data removed for clarity.
 
 ```javascript
 // khan's algorithm
@@ -172,9 +172,9 @@ console.log({ graph })
 console.log({ correctOrder: khanTopologicalSort(graph) })
 ```
 
-## Example
+## BEEF Example
 
-The overall structure should look something like:
+The overall structure of a BEEF Transaction should look like this:
 
 ```javascript
 03000000 // version
@@ -222,6 +222,10 @@ ffffffff // nSequence
 
 ## Backward compatibility
 
-The Background Evaluation Extended Format is not backwards compatible, but has been designed in such a way that existing software should not read a transaction in Background Evaluation Extended Format as a valid (partial) transaction. The Background Evaluation Extended Format header (00000000BEEF) will be read as an empty transaction with a future nLock time in a library that does not support the Background Evaluation Extended Format.
+The Background Evaluation Extended Format is not backwards compatible, but has been designed in such a way that existing software should not read a transaction in Background Evaluation Extended Format as a valid (partial) transaction. The Background Evaluation Extended Format header (00000000BEEF) will be read as an empty transaction with a future nLock time in a library that does not support the Background Evaluation Extended Format. 
+
+This approach is a direct lift from EF [BIP-30](./0030.md).
 
 ## Implementation
+
+The format should be built into common libraries such as [bsv](https://www.npmjs.com/package/bsv) and [go-bt](https://github.com/libsv/go-bt) for easy incorporation into existing stacks.

--- a/transactions/0062.md
+++ b/transactions/0062.md
@@ -93,7 +93,7 @@ In CEF, we extend the input structure to include one of two things.
 | unlocking script               | Unlocking Script                                                                            | many bytes       | 
 | Sequence_no                    | For Payment Channels - valid when nSequence = 0xFFFFFFFF                                    | 4 bytes          | 
 | **CEF byte**                   | **Either `00` or `EF`**                                                                     | **1 byte**       |
-| **Path Index**                 | **Ppoints to the particular path above**                                                    | **1 byte**       |
+| **Path Index**                 | **Index of the particular path of the txid within the list of paths**                       | **1 byte**       |
 | **satoshis**                   | **Output value in satoshis of previous input - Uint64LE**                                   | **8 bytes**      |
 | **locking script length**      | **VarInt length of locking script**                                                         | **1 - 9 bytes**  |
 | **locking script**             | **Script**                                                                                  | **many bytes**   |

--- a/transactions/0062.md
+++ b/transactions/0062.md
@@ -48,7 +48,7 @@ As soon as the Merkle Paths are receieved we can calculate the roots and lookup 
 BEEF combines thinking from several formats into one binary stream, prefixed with a header for disambiguation.
 
 - Raw Transaction Format: [BRC-12](./0012.md)
-- Extended Format (EF): [BRC-30](./0012.md)
+- Extended Format (EF): [BRC-30](./0030.md)
 - Compound Merkle Path Format: [BRC-61](./0061.md)
 
 BEEF adds a marker to the transaction format. The BEEF marker allows a library that supports the format to recognize that it is dealing with a transaction in extended format, while a library that does not support extended format will read the transaction as having 0 inputs, 0 outputs and a future nLock time. This has been done to minimize the possible problems a legacy library will have when reading the extended format. It can in no way be recognized as a valid transaction. Lifted from [BRC-30](./0012.md).

--- a/transactions/0062.md
+++ b/transactions/0062.md
@@ -63,7 +63,7 @@ BEEF adds a marker to the transaction format. The BEEF marker allows a library t
 
 ### Conditionally Extended Format (CEF) Transaction
 
-This uses the same format detailed in EF [BRC-30](./0012.md) but only for inputs which have been mined and we have included paths for. This means that the data needs to be added to some but not all inputs. Hence we will do away with the global EF flag which is no longer needed since the transaction bytes are coming later in the stream and will not be interpreted as a standard transaction. Instead we will use a single byte to indicate inclusion or not, For sake of clarify when reading the bytes in hex we'll mark "extended format" with `EF` and "not extended" as `00`.
+This uses the same format detailed in EF [BRC-30](./0012.md) but only for inputs which have been mined and we have included paths for. This means that the data needs to be added to some but not all inputs. Hence we will do away with the global EF flag which is no longer needed since the transaction bytes are coming later in the stream and will not be interpreted as a standard transaction. Instead we will use a single byte to indicate inclusion or not, For sake of clarity when reading the bytes in hex we'll mark "extended format" with `EF` and "not extended" as `00`.
 
 #### CEF Transaction
 

--- a/transactions/0062.md
+++ b/transactions/0062.md
@@ -93,6 +93,7 @@ In CEF, we extend the input structure to include one of two things.
 | unlocking script               | Unlocking Script                                                                            | many bytes       | 
 | Sequence_no                    | For Payment Channels - valid when nSequence = 0xFFFFFFFF                                    | 4 bytes          | 
 | **CEF byte**                   | **Either `00` or `EF`**                                                                     | **1 byte**       |
+| **Path Index**                 | **Ppoints to the particular path above**                                                    | **1 byte**       |
 | **satoshis**                   | **Output value in satoshis of previous input - Uint64LE**                                   | **8 bytes**      |
 | **locking script length**      | **VarInt length of locking script**                                                         | **1 - 9 bytes**  |
 | **locking script**             | **Script**                                                                                  | **many bytes**   |

--- a/transactions/0062.md
+++ b/transactions/0062.md
@@ -1,5 +1,7 @@
 # BRC-62: Background Evaluation Extended Format (BEEF) Transactions
 
+Deggen (deggen@kschw.com)
+
 ## Abstract
 
 We propose a binary format for sending Transactions between peers to allow Simple Payment Verification (SPV). The format is optimized for minimal bandwidth while maintaining data required to independently validate the transaction in full.

--- a/transactions/0062.md
+++ b/transactions/0062.md
@@ -174,10 +174,16 @@ console.log({ correctOrder: khanTopologicalSort(graph) })
 
 ## BEEF Example
 
-The overall structure of a BEEF Transaction should look like this:
+### Hex
+```
+0100000000000000BEEF01020101cd73c0c6bb645581816fa960fd2f1636062fcbf23cb57981074ab8d708a76e3b02003470d882cf556a4b943639eba15dc795dffdbebdc98b9a98e3637fda96e3811e01c58e40f22b9e9fcd05a09689a9b19e6e62dbfd3335c5253d09a7a7cd755d9a3c0201da256f78ae0ad74bbf539662cdb9122aa02ba9a9d883f1d52468d96290515adb02b4c8d919190a090e77b73ffcd52b85babaaeeb62da000473102aca7f070facef02020000000158cb8b052fded9a6c450c4212562df8820359ec34da41286421e0d0f2b7eefee000000006a47304402206b1255cb23454c63b22833de25a3a3ecbdb8d8645ad129d3269cdddf10b2ec98022034cadf46e5bfecc38940e5497ddf5fa9aeb37ff5ec3fe8e21b19cbb64a45ec324121029a82bfce319faccc34095c8405896e1223921917501a4f736a04f126d6a01c12ffffffffef00c6c7c903000000001976a9145e506dd7afa889e8f16f5e00555d1c0ab225152f88ac0101000000000000001976a914d866ec5ebb0f4e3840351ee61887101e5407562988ac00000000020000000158cb8b052fded9a6c450c4212562df8820359ec34da41286421e0d0f2b7eefee000000006a47304402206b1255cb23454c63b22833de25a3a3ecbdb8d8645ad129d3269cdddf10b2ec98022034cadf46e5bfecc38940e5497ddf5fa9aeb37ff5ec3fe8e21b19cbb64a45ec324121029a82bfce319faccc34095c8405896e1223921917501a4f736a04f126d6a01c12ffffffff000101000000000000001976a914d866ec5ebb0f4e3840351ee61887101e5407562988ac00000000
+```
+
+
+### Bytewise Breakdown
 
 ```javascript
-03000000 // version
+01000000 // version
 00000000BEEF
 01 // VarInt nPaths = 1
 020101cd73c0c6bb645581816fa960fd2f1636062fcbf23cb57981074ab8d708a76e3b02003470d882cf556a4b943639eba15dc795dffdbebdc98b9a98e3637fda96e3811e01c58e40f22b9e9fcd05a09689a9b19e6e62dbfd3335c5253d09a7a7cd755d9a3c0201da256f78ae0ad74bbf539662cdb9122aa02ba9a9d883f1d52468d96290515adb02b4c8d919190a090e77b73ffcd52b85babaaeeb62da000473102aca7f070facef // see BRC-61 for details of compound path format
@@ -228,4 +234,4 @@ This approach is a direct lift from EF [BIP-30](./0030.md).
 
 ## Implementation
 
-The format should be built into common libraries such as [bsv](https://www.npmjs.com/package/bsv) and [go-bt](https://github.com/libsv/go-bt) for easy incorporation into existing stacks.
+The format should be built into common libraries such as [bsv](https://www.npmjs.com/package/bsv) and [go-bt](https://github.com/libsv/go-bt) for easy incorporation into existing stacks.  

--- a/transactions/0062.md
+++ b/transactions/0062.md
@@ -20,9 +20,11 @@ This BRC is licensed under the Open BSV license.
 
 Simplified Payment Verification formats for transmitting transactions between peers has yet to see wide adoption. This proposal advocates for complete ecosystem adoption of the principles of SPV; acknowledges that the system is secured by economics incentives, and law; and lays out a binary format for transmitting the data between parties optimizing for minimal bandwidth.
 
-Most recently proposed was Extended Format [BRC-30](./0030.md) which incorporates the script and satoshis of the input for script evaluation and checking fee rates and the transfer amounts of a tx. 
+Two prior formats should be mentioned:
 
-The second is Tx Ancestry which is a TSC format which was created for use within DPP, this uses an array of rawtxs, merkle proofs, and Mapi responses to transport the data required for SPV. Mapi responses are essentially deprecated, so those should be discarded. 
+Extended Format [BRC-30](./0030.md) incorporates the utxo script for script evaluation and satoshis for checking amounts. Ideal for confirmed txs but insufficient for unconfirmed.
+
+[Tx Ancestors](https://tsc.bitcoinsv.com/standards/transaction-ancestors/) which was created for use within DPP, this uses an array of rawtxs, merkle proofs, and Mapi responses to transport the data required for SPV. Mapi responses are essentially deprecated, so those should be discarded. 
 
 The array of rawtxs makes some sense in that there are strange cases where the same rawtx has two outputs which are spent in different transactions, both within the ancestry of the tx we are validating. You don't want to have embedded a copy of the same proof twice, hence a hash map would make more sense than just including the merkle path bytes in the tx itself.
 

--- a/transactions/0062.md
+++ b/transactions/0062.md
@@ -63,89 +63,42 @@ BEEF adds a marker to the transaction format. The BEEF marker allows a library t
 
 ### Conditionally Extended Format (CEF) Transaction
 
-This uses the same format detailed in EF [BRC-30](./0012.md) but only for inputs which have been mined and we have paths for. This means that the data needs to be added to some but not all inputs. Hence we will do away with the global EF flag in the data and instead use a single byte to indicate inclusion or not, For sake of clarify when reading the bytes we'll mark "extended format" with an `EF` and "not extended" as `00`.
+This uses the same format detailed in EF [BRC-30](./0012.md) but only for inputs which have been mined and we have included paths for. This means that the data needs to be added to some but not all inputs. Hence we will do away with the global EF flag which is no longer needed since the transaction bytes are coming later in the stream and will not be interpreted as a standard transaction. Instead we will use a single byte to indicate inclusion or not, For sake of clarify when reading the bytes in hex we'll mark "extended format" with `EF` and "not extended" as `00`.
 
+#### CEF Transaction
 
+| Field                     | Description                                                                                   | Size          |
+|---------------------------|-----------------------------------------------------------------------------------------------|---------------|
+| Version no       | Tx Version                                                                                             | 4 bytes       |
+| nIn              | VarInt number of inputs which follow                                                                   | 1 - 9 bytes   |
+| **inputs**       | **CEF Input - this is the only difference between RawTX and CEF**                                      | many          |
+| nOut             | positive integer VI = [[VarInt]]                                                                       | 1 - 9 bytes   |
+| outputs          | Transaction Output Structure                                                                           | many          |
+| nLocktime        | if non-zero and sequence numbers are < 0xFFFFFFFF: block height or timestamp when transaction is final | 4 bytes       |
 
+#### CEF Input
 
+In CEF, we extend the input structure to include one of two things. 
 
-
-
-| In-counter       | positive integer VI = [[VarInt]]                                                                       | 1 - 9 bytes                                       |
-| list of inputs   | **BEEF** transaction Input Structure                                                                   | <in-counter> qty with variable length per input   |
-| Out-counter      | positive integer VI = [[VarInt]]                                                                       | 1 - 9 bytes                                       |
-| list of outputs  | Transaction Output Structure                                                                           | <out-counter> qty with variable length per output |
-| nLocktime        | if non-zero and sequence numbers are < 0xFFFFFFFF: block height or timestamp when transaction is final | 4 bytes                                           |
-
-
-
-RawTx standard uses the following input structure:
-
-| Field                     | Description                                                                                 | Size        |
-|---------------------------|---------------------------------------------------------------------------------------------|-------------|
-| Previous Transaction hash | TXID of the transaction the output was created in                                           | 32 bytes    |
-| Previous Txout-index      | Index of the output (Non negative integer)                                                  | 4 bytes     |
-| Txin-script length        | Non negative integer VI = VarInt                                                            | 1 - 9 bytes |
-| Txin-script / scriptSig   | Script                                                                                      | many bytes  | 
-| Sequence_no               | Used to iterate inputs inside a payment channel. Input is final when nSequence = 0xFFFFFFFF | 4 bytes     |
-
-In EF, we extend the input structure to include satoshi amount, the previous locking script, the outpoint's first 32 bytes points to a particular path associated with the txid in the path array:
+1. `00` indicating "no extended data"
+2. `EF` indicating "extended format" which includes satoshi amount, previous locking script, and the index of the path associated with the input transaction.
 
 | Field                          | Description                                                                                 | Size             |
 |--------------------------------|---------------------------------------------------------------------------------------------|------------------|
-| Previous Transaction hash      | TXID of the transaction the output was created in                                           | 32 bytes         |
-| Previous Txout-index           | Index of the output (Non negative integer)                                                  | 4 bytes          |
-| Txin-script length             | VarInt Unlocking Script Length                                                              | 1 - 9 bytes      |
-| Txin-script / scriptSig        | Unlocking Script                                                                            | many bytes       | 
-| Sequence_no                    | Used to iterate inputs inside a payment channel. Input is final when nSequence = 0xFFFFFFFF | 4 bytes          |
-| **UTXO satoshi amount**        | **Output value in satoshis of previous input - uint64le**                                   | **8 bytes**      |
-| **UTXO locking script length** | **VarInt length of locking script OR 00 which indicates there is a "local anchor"**         | **1 - 9 bytes**  |
-| **UTXO locking script**        | **Script**                                                                                  | **many bytes**   |
+| txid                           | Hash of the transaction in which the output was created                                     | 32 bytes         |
+| vout                           | Index of the output within that transaction Uint32LE                                        | 4 bytes          |
+| unlocking script length        | VarInt Unlocking Script Length                                                              | 1 - 9 bytes      |
+| unlocking script               | Unlocking Script                                                                            | many bytes       | 
+| Sequence_no                    | For Payment Channels - valid when nSequence = 0xFFFFFFFF                                    | 4 bytes          | 
+| **CEF byte**                   | **Either `00` or `EF`**                                                                     | **1 byte**       |
+| **satoshis**                   | **Output value in satoshis of previous input - Uint64LE**                                   | **8 bytes**      |
+| **locking script length**      | **VarInt length of locking script**                                                         | **1 - 9 bytes**  |
+| **locking script**             | **Script**                                                                                  | **many bytes**   |
 
-The overall structure starts with the paths of all txids corresponding to their place within the blockchain. Blockhashes are not included. Instead the validator is to calculate the merkle root and lookup thier own header store by that to verify the tx appears within the valid chain of blocks.
 
-### Local Anchor
+### Ordering
 
-When the VarInt following the satoshi amount of an input is "00" zero - this indicates that the input is has a local anchor. This means that the txid in the input points to a previous transactions which exists within the array of transactions in the data shared. For this reason, no further data is shared since this would be repeatition of early bytes. The process a validator would take is to at this point lookup the hashmap of validated previous transactions to determine whether to continue.
-
-Order is important - we must ensure that we end with the tx being evaluated, and its inputs are above, and their inputs are above that. This will allow us to sequentially validate a stream of transactions as they come in without depending on data which hasn't arrived yet. For the same reason, we have to start the stream with the paths of the transactions first, prior to any tx data.
-This makes the overall structure look something like:
-
-### Overall Structure of the Transmitted Data
-
-```javascript
-version
-00000000BEEF
-nPaths // paths first
-index
-nLeaves
-leaves... // repeat for each path, then ancestry starting oldest first
-nTransactions // 2 in this case
-// example a tx with a merkle proof anchor
-  version
-  0000000000EF // extended format follows
-  nInputs
-  outpoint lenUnlockScript unlockingScript nSequence satoshis lenLockingScript lockingScript // txid maps to the path above based on index of a Set of unique values.
-  nOutputs
-  outputs...
-  nLocktime
-// for example a tx with local parent
-  version
-  nInputs
-  outpoint lenUnlockScript unlockingScript nSequence // parent has been processed above
-  nOutputs
-  outputs...
-  nLocktime
-```
-
-## Backward compatibility
-
-The Background Evaluation Extended Format is not backwards compatible, but has been designed in such a way that existing software should not read a transaction in Background Evaluation Extended Format as a valid (partial) transaction. The Background Evaluation Extended Format header (00000000BEEF) will be read as an empty transaction with a future nLock time in a library that does not support the Background Evaluation Extended Format.
-
-## Implementation
-
-### Transaction Order
-Step one is to ensure the transactions are in topological order. Running Khan's algorithm on the transaction DAG subset would be preferred if order is ever in doubt for complex transaction chains. Example below to demonstrate with easily identifyable txids.
+Order is important - we must ensure that we end with the tx being evaluated, and its inputs are above, and their inputs are above that. Running Khan's algorithm on the transaction DAG subset would be preferred if order is ever in doubt for complex transaction chains. Example below to demonstrate with extraneous data removed for clarity.
 
 ```javascript
 // khan's algorithm
@@ -218,6 +171,61 @@ for (let tx of txs) {
 console.log({ graph })
 console.log({ correctOrder: khanTopologicalSort(graph) })
 ```
+
+## Example
+
+The overall structure should look something like:
+
+```javascript
+03000000 // version
+00000000BEEF
+01 // VarInt nPaths = 1
+020101cd73c0c6bb645581816fa960fd2f1636062fcbf23cb57981074ab8d708a76e3b02003470d882cf556a4b943639eba15dc795dffdbebdc98b9a98e3637fda96e3811e01c58e40f22b9e9fcd05a09689a9b19e6e62dbfd3335c5253d09a7a7cd755d9a3c0201da256f78ae0ad74bbf539662cdb9122aa02ba9a9d883f1d52468d96290515adb02b4c8d919190a090e77b73ffcd52b85babaaeeb62da000473102aca7f070facef // see BRC-61 for details of compound path format
+02 // VarInt nTransactions = 2
+//------------------- example tx with a merkle path above -------------------
+02000000 // tx version
+01 // nInputs
+58cb8b052fded9a6c450c4212562df8820359ec34da41286421e0d0f2b7eefee // outpoint txid
+00000000 // outpoint vout
+6a // length of unlocking script
+47304402206b1255cb23454c63b22833de25a3a3ecbdb8d8645ad129d3269cdddf10b2ec98022034cadf46e5bfecc38940e5497ddf5fa9aeb37ff5ec3fe8e21b19cbb64a45ec324121029a82bfce319faccc34095c8405896e1223921917501a4f736a04f126d6a01c12 // unlocking script
+ffffffff // nSequence
+// CONDITIONAL EXTENDED DATA
+    ef // indicates that extended data follows
+    00 // VarInt index of associated path above
+    c6c7c90300000000 // satoshis
+    19 // lenLockingScript
+    76a9145e506dd7afa889e8f16f5e00555d1c0ab225152f88ac // lockingScript
+// END OF INPUT
+01 // nOutputs
+0100000000000000 // satoshis
+19 // locking script length
+76a914d866ec5ebb0f4e3840351ee61887101e5407562988ac // locking script
+00000000 //  nLocktime
+//------------------- example tx with parent above -------------------
+02000000 // tx version
+01 // nInputs
+58cb8b052fded9a6c450c4212562df8820359ec34da41286421e0d0f2b7eefee // outpoint txid
+00000000 // outpoint vout
+6a // length of unlocking script
+47304402206b1255cb23454c63b22833de25a3a3ecbdb8d8645ad129d3269cdddf10b2ec98022034cadf46e5bfecc38940e5497ddf5fa9aeb37ff5ec3fe8e21b19cbb64a45ec324121029a82bfce319faccc34095c8405896e1223921917501a4f736a04f126d6a01c12 // unlocking script
+ffffffff // nSequence
+// CONDITIONAL EXTENDED DATA
+    00 // indicates that no extended data follows
+// END OF INPUT
+01 // nOutputs
+0100000000000000 // satoshis
+19 // locking script length
+76a914d866ec5ebb0f4e3840351ee61887101e5407562988ac // locking script
+00000000 //  nLocktime
+```
+
+## Backward compatibility
+
+The Background Evaluation Extended Format is not backwards compatible, but has been designed in such a way that existing software should not read a transaction in Background Evaluation Extended Format as a valid (partial) transaction. The Background Evaluation Extended Format header (00000000BEEF) will be read as an empty transaction with a future nLock time in a library that does not support the Background Evaluation Extended Format.
+
+## Implementation
+
 
 ### Paths
 

--- a/transactions/0062.md
+++ b/transactions/0062.md
@@ -2,9 +2,9 @@
 
 ## Abstract
 
-We propose a binary format for sending Transactions between peers to allow Simple Payment Verification (SPV). The format is optimized for minimal bandwidth without losing the ability to independently validate the transaction in full.
+We propose a binary format for sending Transactions between peers to allow Simple Payment Verification (SPV). The format is optimized for minimal bandwidth while maintaining data required to independently validate the transaction in full.
 
-Assumption: Every user has an independent source of Block Headers indexed by Merkle Root. 
+Assumption: Every user has an independent source of Block Headers indexed by Merkle Root.
 
 The simplest form is a single transaction, with extended data to allow script evaluation and satoshi amount verification, with Merkle paths for each input.
 
@@ -20,47 +20,64 @@ This BRC is licensed under the Open BSV license.
 
 Simplified Payment Verification formats for transmitting transactions between peers has yet to see wide adoption. This proposal advocates for complete ecosystem adoption of the principles of SPV; acknowledges that the system is secured by economics incentives, and law; and lays out a binary format for transmitting the data between parties optimizing for minimal bandwidth.
 
-Two prior formats should be mentioned:
+Three prior formats should be mentioned:
 
 Extended Format [BRC-30](./0030.md) incorporates the utxo script for script evaluation and satoshis for checking amounts. Ideal for confirmed txs but insufficient for unconfirmed.
 
-[Tx Ancestors](https://tsc.bitcoinsv.com/standards/transaction-ancestors/) which was created for use within DPP, this uses an array of rawtxs, merkle proofs, and Mapi responses to transport the data required for SPV. Mapi responses are essentially deprecated, so those should be discarded. 
+[Tx Ancestors](https://tsc.bitcoinsv.com/standards/transaction-ancestors/) which was created for use within the [Lite Client Toolbox](https://docs.bitcoinsv.io), this uses an array of rawtxs, Merkle proofs, and Mapi responses to transport the data required for SPV. 
 
-The array of rawtxs makes some sense in that there are strange cases where the same rawtx has two outputs which are spent in different transactions, both within the ancestry of the tx we are validating. You don't want to have embedded a copy of the same proof twice, hence a hash map would make more sense than just including the merkle path bytes in the tx itself.
+Everett-style Transaction Envelopes [BRC-8](./0008.md) uses a recursive JSON format which is otherwise similar to the above format originally designed for use within [DPP](../payments/0027.md). One of the ideas which this proposal highlights is that the target of merkle proofs could be height rather than blockhash or root, to save on bytes. Thinking along these lines, we propose that no target be provided at all, and the root simply be calculated at the receieving end as needed. Using the root to look up headers also avoids any implementation complexity associated with competing blocks. For example, when a competing block encapsulates the transactions it may not have the same height, if all transactions are being stored with paths at a height rather than blockhash or merkle root (which are unique to specific versions of a block) then updating a set of the transactions with merkle paths from the new block will be difficult to sort out. If they're indexed by blockhash then it would be trivial to set them all as "in need of updated paths" without the need for disambiguation.
 
-The idea is in effect to start by listing merkle paths for each input, and simply use the Extended Format [BRC-30](./0030.md) thereafter. The difference comes up when there are unconfirmed inputs, in which case we include a standard RawTx encoding of that input, and the whole Extended format of the parent transaction. This continues all the way back until all inputs have Merkle paths or parents included.
+Mapi is to be deprecated in the near future, so any new recommended formats should not include Mapi Responses as part of the solution.
+
+The array of rawtxs within the Tx Ancestors spec makes some sense in that there are strange cases where the same rawtx has two outputs which are spent in different transactions, both within the ancestry of the tx we are validating. You don't want to have embedded a copy of the same proof twice, hence a hash map would make more sense than just including the merkle path bytes in the tx itself. Everett-style Transaction Envelope deals with this well even given its recursive object design. Txids are used as pointers to existing transactions when complex dependency graphs occur. This proposal uses the same thinking, but for a binary format lists are used rather than recursive objects. 
+
+The ordering of data has streaming validation in mind - an idea raised in EF [BRC-30](./0030.md) - such that a receiver can start processing the validation immediately on receipt of the first few bytes, and any later bytes rely on previous bytes for their validation to even begin.
+
+- Merkle Paths
+- Oldest Tx Anchroed by Path
+- Newer Txs depending on Oldest parent
+- Newest Tx
+
+As soon as the Merkle Paths are receieved we can calculate the roots and lookup their blockheaders. If they're not valid then validation can stop there - rejected. Then we look at the oldest ancestor - if it's valid then its children can be validated, and so on until we reach the most recent tx.
 
 ## Specification
 
-BEEF combines three formats into one binary stream, prefixed with a header for disambiguation.
+BEEF combines thinking from several formats into one binary stream, prefixed with a header for disambiguation.
 
-- Compound Path Format: [BRC-61](./0061.md)
 - Raw Transaction Format: [BRC-12](./0012.md)
 - Extended Format (EF): [BRC-30](./0012.md)
+- Compound Merkle Path Format: [BRC-61](./0061.md)
+
+BEEF adds a marker to the transaction format. The BEEF marker allows a library that supports the format to recognize that it is dealing with a transaction in extended format, while a library that does not support extended format will read the transaction as having 0 inputs, 0 outputs and a future nLock time. This has been done to minimize the possible problems a legacy library will have when reading the extended format. It can in no way be recognized as a valid transaction. Lifted from [BRC-30](./0012.md).
+
+| Field                | Description                                                                                            | Size                |
+|----------------------|--------------------------------------------------------------------------------------------------------|---------------------|
+| Version no           | Used to indicate to nodes which version of BEEF this is.                                               | 4 bytes             |
+| BEEF marker          | Marker for Background Evaluation Extended Format **00000000BEEF**                                      | 6 bytes             |
+| nPaths               | VarInt number of compound merkle paths to follow                                                       | 1-9 bytes           |
+| Compound Merkle Path | All of the paths required to prove inclusion of inputs in longest chain of blocks [BRC-61](./0061.md)  | many bytes          |
+| nTransactions        | VarInt number of transactions which follow                                                             | 1-9 bytes           |
+| CEF Transaction      | RawTx bytes with input specific extended data as defined below                                         | many bytes          |
 
 
-| Field           | Description                                          | Size                                             |
-|-----------------|------------------------------------------------------|--------------------------------------------------|
-| Version no      | currently 2                                          | 4 bytes                                          |
-| In-counter      | positive integer VI = [[VarInt]]                     | 1 - 9 bytes                                      |
-| list of inputs  | Transaction Input  Structure                         | <in-counter> qty with variable length per input  |
-| Out-counter     | positive integer VI = [[VarInt]]                     | 1 - 9 bytes                                      |
-| list of outputs | Transaction Output Structure                         | <out-counter> qty with variable length per output |
-| nLocktime       | if non-zero and sequence numbers are < 0xFFFFFFFF: block height or timestamp when transaction is final | 4 bytes                                          |
+### Conditionally Extended Format (CEF) Transaction
 
-BEEF adds a marker to the transaction format:
+This uses the same format detailed in EF [BRC-30](./0012.md) but only for inputs which have been mined and we have paths for. This means that the data needs to be added to some but not all inputs. Hence we will do away with the global EF flag in the data and instead use a single byte to indicate inclusion or not, For sake of clarify when reading the bytes we'll mark "extended format" with an `EF` and "not extended" as `00`.
 
-| Field            | Description                                                                                            | Size                                              |
-|------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------|
-| Version no       | currently 2                                                                                            | 4 bytes                                           |
-| **BEEF marker**  | **marker for Background Evaluation Extended Format**                                                   | **00000000BEEF**                                  |
+
+
+
+
+
+
 | In-counter       | positive integer VI = [[VarInt]]                                                                       | 1 - 9 bytes                                       |
 | list of inputs   | **BEEF** transaction Input Structure                                                                   | <in-counter> qty with variable length per input   |
 | Out-counter      | positive integer VI = [[VarInt]]                                                                       | 1 - 9 bytes                                       |
 | list of outputs  | Transaction Output Structure                                                                           | <out-counter> qty with variable length per output |
 | nLocktime        | if non-zero and sequence numbers are < 0xFFFFFFFF: block height or timestamp when transaction is final | 4 bytes                                           |
 
-The BEEF marker allows a library that supports the format to recognize that it is dealing with a transaction in extended format, while a library that does not support extended format will read the transaction as having 0 inputs, 0 outputs and a future nLock time. This has been done to minimize the possible problems a legacy library will have when reading the extended format. It can in no way be recognized as a valid transaction.
+
 
 RawTx standard uses the following input structure:
 
@@ -86,22 +103,6 @@ In EF, we extend the input structure to include satoshi amount, the previous loc
 | **UTXO locking script**        | **Script**                                                                                  | **many bytes**   |
 
 The overall structure starts with the paths of all txids corresponding to their place within the blockchain. Blockhashes are not included. Instead the validator is to calculate the merkle root and lookup thier own header store by that to verify the tx appears within the valid chain of blocks.
-
-Compound Path
-
-| Field                     | Description                                                                        |        Size          |
-|---------------------------|------------------------------------------------------------------------------------|----------------------|
-| nIndices                  | VarInt number of paths contained within                                            | 1-9 bytes            |
-||
-| index                     | VarInt index of path included                                                      | 1-9 bytes x nIndices |
-| **repeat x nIndices** |
-| nLeaves                   | VarInt number of leaves which follow in the path                                   | 1-9 bytes            |
-||
-| leaf                      | Each leaf is a 32 byte hash                                                        | 32 bytes             |
-| path mask                 | One byte as the exponent of a 2^N mask for path inclusion                          | 1 byte               |
-| **repeat x nLeaves** |
-
-
 
 ### Local Anchor
 

--- a/transactions/README.md
+++ b/transactions/README.md
@@ -12,3 +12,5 @@ BRC | Standard
 13   | [TXO Transaction Object Format](./0013.md)
 30   | [Transaction Extended Format (EF)](./0030.md)
 58   | [Merkle Path JSON format](./0058.md)
+60   | [Compound Merkle Path Format](./transactions/0061.md)
+60   | [Background Evaluation Extended Format (BEEF) Transactions](./transactions/0062.md)


### PR DESCRIPTION
### This pull request:

Proposes two new interrelated binary data formats for SPV

1. Compound Merkle Paths
2. BEEF Transactions

### Summary

Inviting discussion around a way to send only the minimum required data for SPV based on incremental improvement to existing standards. Combination of a few good ideas from others into a unified solution which should be compatible with multiple implementations and importantly needed for use in Merkle Service Nodes which are just starting to become a necessary component of the network thanks to Teranode.