### PR TITLE
Add a standard binary encoding for merkle paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ BRC | Standard
 68   | [Publishing Trust Anchor Details at an Internet Domain](./peer-to-peer/0068.md)
 69   | [Revealing Key Linkages](./key-derivation/0069.md)
 70   | [Paymail BEEF Transaction](./payments/0070.md)
+71   | [Merkle Path Binary Format](./transactions/0071.md)
 
 ## License
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -31,6 +31,7 @@
 * [Compound Merkle Path Format](./transactions/0061.md)
 * [Background Evaluation Extended Format (BEEF) Transactions](./transactions/0062.md)
 * [Simplified Payment Verification](./transactions/0067.md)
+* [Merkle Path Binary Format](./transactions/0071.md)
 
 ## Scripts
 

--- a/transactions/0071.md
+++ b/transactions/0071.md
@@ -1,0 +1,81 @@
+# BRC-71: Merkle Path Binary Format
+
+Deggen (deggen@kschw.com)
+
+## Abstract
+
+We propose a binary format for a Single Merkle Path optimized for storage in a key value database.
+
+## Copyright
+
+This BRC is licensed under the Open BSV license.
+
+## Motivation
+
+The [TSC format](https://tsc.bsvblockchain.org/standards/merkle-proof-standardised-format/) includes oddities in it for future extensions which are no longer necessary since they are covered by the compound merkle path format defined in [BRC-61](./0061.md). So now we attempt to specify the smallest possible encoding of a simple merkle path.
+
+## Specification
+
+We take the JSON version from [BRC-58](./0058.md) eg.
+
+```json
+
+{ 
+   "index": 136,
+   "path": [
+      "0c82025f47b31054e9ad52109ef25b00fd9aaae7153564619bab031d4112f56c",
+      "3b6ea708d7b84a078179b53cf2cb2f0636162ffd60a96f81815564bbc6c073cd",
+      "efac0f077fca2a10730400da62ebaebaba852bd5fc3fb7770e090a1919d9c8b4",
+      "1e81e396da7f63e3989a8bc9bdbefddf95c75da1eb3936944b6a55cf82d87034"
+	]
+}
+```
+
+Encoding in bytes we start with a VarInt for index, followed by nPath being the number of leaves to follow, followed by 32 byte leaves.
+
+
+#### Data Types
+
+| Field                | Description                                                                      |        Size          |
+|----------------------|----------------------------------------------------------------------------------|----------------------|
+| index              | `VarInt` tx index number from within a block                                      | 1-9 bytes            |
+| nLeaves              | `VarInt` number of leaves which follow                                           | 1-9 bytes            |
+| leaf                 | Each leaf of the path is a 32 byte hash                                                      | 32 bytes x nLeaves       |
+
+## Example
+
+### Hex
+```
+88040c82025f47b31054e9ad52109ef25b00fd9aaae7153564619bab031d4112f56c3b6ea708d7b84a078179b53cf2cb2f0636162ffd60a96f81815564bbc6c073cdefac0f077fca2a10730400da62ebaebaba852bd5fc3fb7770e090a1919d9c8b41e81e396da7f63e3989a8bc9bdbefddf95c75da1eb3936944b6a55cf82d87034
+```
+
+### Bytewise Breakdown
+```javascript
+88 // index VarInt
+04 // nLeaves
+0c82025f47b31054e9ad52109ef25b00fd9aaae7153564619bab031d4112f56c // leaf
+3b6ea708d7b84a078179b53cf2cb2f0636162ffd60a96f81815564bbc6c073cd // etc.
+efac0f077fca2a10730400da62ebaebaba852bd5fc3fb7770e090a1919d9c8b4
+1e81e396da7f63e3989a8bc9bdbefddf95c75da1eb3936944b6a55cf82d87034
+```
+
+## Implementation
+
+Let's start by dumping this format as hex into a Buffer and parsing it into an object with a Buffer Reader. Then we construct an object
+
+```javascript
+const { Br } = require('bsv')
+const reader = new Br()
+reader.buf = Buffer.from('88040c82025f47b31054e9ad52109ef25b00fd9aaae7153564619bab031d4112f56c3b6ea708d7b84a078179b53cf2cb2f0636162ffd60a96f81815564bbc6c073cdefac0f077fca2a10730400da62ebaebaba852bd5fc3fb7770e090a1919d9c8b41e81e396da7f63e3989a8bc9bdbefddf95c75da1eb3936944b6a55cf82d87034', 'hex')
+
+let merklePath = { path: [] }
+merklePath.index = reader.readVarIntNum()
+let nLeaves = reader.readVarIntNum()
+for (x = 0;x < nLeaves; x++) {
+  const leaf = reader.read(32).reverse().toString('hex')
+  merklePath.path.push(leaf)
+}
+
+	
+console.log({ merklePath })
+```

--- a/transactions/README.md
+++ b/transactions/README.md
@@ -15,3 +15,4 @@ BRC | Standard
 61   | [Compound Merkle Path Format](./0061.md)
 62   | [Background Evaluation Extended Format (BEEF) Transactions](./0062.md)
 67   | [Simplified Payment Verification](./0067.md)
+71   | [Merkle Path Binary Format](./0071.md)


### PR DESCRIPTION
### This pull request:

Proposes a new standard by creating a new markdown file in the appropriate directory and requests discussion and assignment of a BRC number

### Summary

Proposed binary format related to BRC-58 json format and BRC-61 BEEF merkle paths.