### PR TITLE
Improvement/beef

### DIFF
--- a/transactions/0062.md
+++ b/transactions/0062.md
@@ -1,9 +1,9 @@
 # BRC-62: Background Evaluation Extended Format (BEEF) Transactions
 
-Deggen (deggen@kschw.com)
-Damian Orzepowski (damian.orzepowski@4chain.studio)
-Wojciech Regulski (wojciech.regulski@4chain.studio)
-Arkadiusz Osowski (arkadiusz.osowski@4chain.studio)
+Deggen (deggen@kschw.com)  
+Damian Orzepowski (damian.orzepowski@4chain.studio)  
+Wojciech Regulski (wojciech.regulski@4chain.studio)  
+Arkadiusz Osowski (arkadiusz.osowski@4chain.studio)  
 
 ## Abstract
 
@@ -160,13 +160,13 @@ console.log({ correctOrder: khanTopologicalSort(graph) })
 01 // VarInt nPaths
 020101cd73c0c6bb645581816fa960fd2f1636062fcbf23cb57981074ab8d708a76e3b02003470d882cf556a4b943639eba15dc795dffdbebdc98b9a98e3637fda96e3811e01c58e40f22b9e9fcd05a09689a9b19e6e62dbfd3335c5253d09a7a7cd755d9a3c04008c00bb9360e93fb822c84b2e579fa4ce75c8378ae87f67730a49552f73c56ee801da256f78ae0ad74bbf539662cdb9122aa02ba9a9d883f1d52468d96290515adb02b4c8d919190a090e77b73ffcd52b85babaaeeb62da000473102aca7f070facef03e5b331f4961d764373f3a4e2751954e75489fb17902aad583eedbb41dc165a3b // see BRC-61 for details of Compound Merkle Path format
 02 // VarInt nTransactions = 2
-//------------------- example tx with a merkle path above -------------------
-020000000158cb8b052fded9a6c450c4212562df8820359ec34da41286421e0d0f2b7eefee000000006a47304402206b1255cb23454c63b22833de25a3a3ecbdb8d8645ad129d3269cdddf10b2ec98022034cadf46e5bfecc38940e5497ddf5fa9aeb37ff5ec3fe8e21b19cbb64a45ec324121029a82bfce319faccc34095c8405896e1223921917501a4f736a04f126d6a01c12ffffffff0101000000000000001976a914d866ec5ebb0f4e3840351ee61887101e5407562988ac00000000 // rawtx parent
-01 // has merkle path above
+// rawtx parent follows
+020000000158cb8b052fded9a6c450c4212562df8820359ec34da41286421e0d0f2b7eefee000000006a47304402206b1255cb23454c63b22833de25a3a3ecbdb8d8645ad129d3269cdddf10b2ec98022034cadf46e5bfecc38940e5497ddf5fa9aeb37ff5ec3fe8e21b19cbb64a45ec324121029a82bfce319faccc34095c8405896e1223921917501a4f736a04f126d6a01c12ffffffff0101000000000000001976a914d866ec5ebb0f4e3840351ee61887101e5407562988ac00000000
+01 // above tx has merkle path
 00 // VarInt the index of the path for this tx in the above list
-//------------------- example tx with parent above -------------------
-020000000158cb8b052fded9a6c450c4212562df8820359ec34da41286421e0d0f2b7eefee000000006a47304402206b1255cb23454c63b22833de25a3a3ecbdb8d8645ad129d3269cdddf10b2ec98022034cadf46e5bfecc38940e5497ddf5fa9aeb37ff5ec3fe8e21b19cbb64a45ec324121029a82bfce319faccc34095c8405896e1223921917501a4f736a04f126d6a01c12ffffffff0101000000000000001976a914d866ec5ebb0f4e3840351ee61887101e5407562988ac00000000 //  rawtx current
-00 // doesn't have merkle path above
+// rawtx current payment follows
+020000000158cb8b052fded9a6c450c4212562df8820359ec34da41286421e0d0f2b7eefee000000006a47304402206b1255cb23454c63b22833de25a3a3ecbdb8d8645ad129d3269cdddf10b2ec98022034cadf46e5bfecc38940e5497ddf5fa9aeb37ff5ec3fe8e21b19cbb64a45ec324121029a82bfce319faccc34095c8405896e1223921917501a4f736a04f126d6a01c12ffffffff0101000000000000001976a914d866ec5ebb0f4e3840351ee61887101e5407562988ac00000000
+00 // above tx doesn't have merkle path, but instead has local parent
 ```
 
 ## Validation Process

--- a/transactions/0062.md
+++ b/transactions/0062.md
@@ -30,7 +30,7 @@ Simplified Payment Verification formats for transmitting transactions between pe
 
 Three prior formats should be mentioned:
 
-Extended Format [BRC-30](./0030.md) incorporates the utxo script for script evaluation and satoshis for checking amounts. This format would still work when sending to nodes as they have a utxo lookup which is indexed by a hash of the extended data, meaning that invalid ef data would be detected immediately.
+Extended Format [BRC-30](./0030.md) incorporates the utxo script for script evaluation and satoshis for checking amounts. This format would still work when sending to nodes as they have a utxo lookup which is indexed by a hash of the extended data, meaning that invalid EF data would be detected immediately.
 
 [Tx Ancestors](https://tsc.bitcoinsv.com/standards/transaction-ancestors/) which was created for use within the [Lite Client Toolbox](https://docs.bitcoinsv.io), this uses an array of rawtxs, Merkle proofs, and Mapi responses to transport the data required for SPV. 
 

--- a/transactions/0062.md
+++ b/transactions/0062.md
@@ -15,6 +15,11 @@ The simplest form is two transactions, one confirmed in a block which has a corr
 
 In cases where one or more inputs are not yet mined, each ancestral transaction is included. We step back through the Transaction DAG until every input has a corresponding parent transaction with a Merkle path.
 
+This format is aligned with Dr. Craig Wright's explanation of SPV from this [article](https://craigwright.net/blog/bitcoin-blockchain-tech/merkle-trees-and-spv/). He makes reference to a new paradigm, this format is an attempt to bring forth that paradigm.
+
+Users can adopt this format to transmit the data required to independently verify that a transaction is valid and is spending a real utxo from an existing block. The control mechanism to ensure no previous spend of the utxo is the economics and law. The format is intended for micropayments, so the risk is low. It is also the case that there is a cost to faking the data, since the attacker would really have to have previously owned an actual utxo. Any malfeasant would be signing incriminating evidence and sending it directly to the plaintiff if they were to defraud someone using this format. Without Merkle paths the data would be easier to fake, and there is no skin in the game required since the data could be randomly generated. Considering all these factors, the validation process is detailed in a later section.
+
+
 ## Copyright
 
 This BRC is licensed under the Open BSV license.
@@ -49,19 +54,19 @@ As soon as the Merkle Paths are receieved we can calculate the roots and lookup 
 BEEF combines thinking from several formats into one binary stream, prefixed with a very specific version number for disambiguation.
 
 - Raw Transaction Format: [BRC-12](./0012.md)
-- Compound Merkle Path Format: [BRC-61](./0061.md)
+- Compound Merkle Path Format (CMP): [BRC-61](./0061.md)
 
 The encoding version number 4022206465 is chosen such that when seen in hex encoded as 4 bytes little endian it reads: `0100BEEF`. This is to allow multiple versions to be defined in future while keeping the data minimal and leaving an obvious sequence which developers can eyeball. Often Bitcoin developers will see a sequence 0100000000... for rawtx. When they instead see 0100BEEF... they will know this data is BEEF format when debugging and so on. If there are future improvements then the next version would be `0200BEEF` for example, this marker will remain "BEEF" for tens of thousands of versions until we reach 4022271999 which is obviously much more than would ever be required. 
 
-| Field                | Description                                                                                                               | Size                |
-|----------------------|---------------------------------------------------------------------------------------------------------------------------|---------------------|
-| Version no           | Version number starts at 4022206465, encoded Uint32LE => `0100BEEF`                                                       | 4 bytes             |
-| nPaths               | VarInt number of compound merkle paths which follow                                                                       | 1-9 bytes           |
-| Compound Merkle Path | All of the paths required to prove inclusion of inputs in longest chain of blocks [BRC-61](./0061.md)                     | many bytes x nPaths |
-| nTransactions        | VarInt number of transactions which follow                                                                                | 1-9 bytes           |
-| Raw Transaction      | RawTx bytes as in standard format [BRC-12](./0012.md)                                                                     | many bytes          |
-| Has Merkle path      | Does the transaction prior have a Merkle path? `01` if so, followed by the Path index; `00` if not, followed by nothing.  | 1 byte              |
-| Path index           | VarInt index number - indicating the Compound Merkle Path to which the prior tx belongs if there is one.                  | 1-9 bytes           |
+| Field                 | Description                                                                                                               | Size                |
+|-----------------------|---------------------------------------------------------------------------------------------------------------------------|---------------------|
+| Version no            | Version number starts at 4022206465, encoded Uint32LE => `0100BEEF`                                                       | 4 bytes             |
+| nCMPs                 | VarInt number of compound merkle paths which follow                                                                       | 1-9 bytes           |
+| Compound Merkle Paths | All of the paths required to prove inclusion of inputs in longest chain of blocks [BRC-61](./0061.md)                     | many bytes x nPaths |
+| nTransactions         | VarInt number of transactions which follow                                                                                | 1-9 bytes           |
+| Raw Transaction       | RawTx bytes as in standard format [BRC-12](./0012.md)                                                                     | many bytes          |
+| Has Merkle path       | Does the transaction prior have a Merkle path? `01` if so, followed by the CMP index; `00` if not, followed by nothing.  | 1 byte              |
+| CMP index             | VarInt index number - indicating the Compound Merkle Path to which the prior tx belongs if there is one.                  | 1-9 bytes           |
 
 
 ### Ordering
@@ -164,6 +169,28 @@ console.log({ correctOrder: khanTopologicalSort(graph) })
 00 // doesn't have merkle path above
 ```
 
+## Validation Process
+
+1. We parse the Compound Merkle Paths (CMP) storing each in an array so that we can address them by index later.
+2. We parse each transaction.
+    a. RawTx bytes double sha256 to get the txid.
+    b. Store in hashmap from txid => parsedTx
+    c. If there is a Merkle path after the tx then we lookup the CMP using the CMP index number.
+        1. Lookup the txid within level 0 leaves of the CMP to get the index of the txid within a block.
+        2. Calculate the Merkle root with the index, txid, and CMP data.
+        3. Add the merkle root to an array which will be used in a request to our local header service once all transactions have been parsed.
+        4. Mark the tx as valid or not as soon as the header service responds.
+    d. Otherwise we run local validation on the transaction, stopping at the soonest failure.
+        1. Check the txid exists in memory, and is marked as valid.
+        2. Check that all scripts evaluate to TRUE.
+        3. Check that the sum of satoshis in > satoshis out + fee
+        4. Mark the tx as valid.
+3. We make a request to the local header service as soon as we have all merkle roots calculated.
+    a. This involves sending a list of Merkle roots to the Pulse service which will validate that the merkle roots provided are all part of headers within the longest chain.
+    b. If any of the roots are not part of the longest chain, the response is negative and the whole validation has failed.
+4. We await the final transaction being marked as valid since it depends on all other processes.
+
+
 ## Implementation
 
-The format should be built into common libraries such as [bsv](https://www.npmjs.com/package/bsv) and [go-bt](https://github.com/libsv/go-bt) for easy incorporation into existing stacks.
+The format will be built into BUX to begin real world testing. Thereafter common libraries such as [bsv](https://www.npmjs.com/package/bsv) and [go-bt](https://github.com/libsv/go-bt) for easy incorporation into existing stacks.

--- a/transactions/0062.md
+++ b/transactions/0062.md
@@ -1,18 +1,19 @@
 # BRC-62: Background Evaluation Extended Format (BEEF) Transactions
 
 Deggen (deggen@kschw.com)
+Damian Orzepowski (damian.orzepowski@4chain.studio)
+Wojciech Regulski (wojciech.regulski@4chain.studio)
+Arkadiusz Osowski (arkadiusz.osowski@4chain.studio)
 
 ## Abstract
 
-We propose a binary format for sending Transactions between peers to allow Simple Payment Verification (SPV). The format is optimized for minimal bandwidth while maintaining data required to independently validate the transaction in full.
+We propose a binary format for sending Transactions between peers to allow [Simple Payment Verification](./0067.md) (SPV). The format is optimized for minimal bandwidth while maintaining data required to independently validate the transaction in full.
 
 Assumption: Every user has an independent source of Block Headers indexed by Merkle Root.
 
-The simplest form is a single transaction, with extended data to allow script evaluation and satoshi amount verification, with Merkle paths for each input.
+The simplest form is two transactions, one confirmed in a block which has a corresponding Merkle path and includes an output which is being spent in the second. The second is a newly signed transaction which constitutes the actual payment.
 
-In cases where one or more inputs are not yet mined, each ancestral transaction is included. We step back through the Transaction DAG until every input has a Merkle Path or corresponding parent transaction.
-
-Inputs with corresponding Merkle Paths will be extended with previous outpoint script and satoshis. Whereas inputs with parents included in stream are not extended since this data has already been sent.**
+In cases where one or more inputs are not yet mined, each ancestral transaction is included. We step back through the Transaction DAG until every input has a corresponding parent transaction with a Merkle path.
 
 ## Copyright
 
@@ -20,11 +21,11 @@ This BRC is licensed under the Open BSV license.
 
 ## Motivation
 
-Simplified Payment Verification formats for transmitting transactions between peers has yet to see wide adoption. This proposal advocates for complete ecosystem adoption of the principles of SPV; acknowledges that the system is secured by economics incentives, and law; and lays out a binary format for transmitting the data between parties optimizing for minimal bandwidth.
+Simplified Payment Verification formats for transmitting transactions between peers has yet to see wide adoption. This proposal advocates for complete ecosystem adoption of the principles of SPV; acknowledges that the system is secured by economic incentives, and law; and lays out a binary format for transmitting the data between parties optimizing for minimal bandwidth.
 
 Three prior formats should be mentioned:
 
-Extended Format [BRC-30](./0030.md) incorporates the utxo script for script evaluation and satoshis for checking amounts. Ideal for confirmed txs but insufficient for unconfirmed.
+Extended Format [BRC-30](./0030.md) incorporates the utxo script for script evaluation and satoshis for checking amounts. This format would still work when sending to nodes as they have a utxo lookup which is indexed by a hash of the extended data, meaning that invalid ef data would be detected immediately.
 
 [Tx Ancestors](https://tsc.bitcoinsv.com/standards/transaction-ancestors/) which was created for use within the [Lite Client Toolbox](https://docs.bitcoinsv.io), this uses an array of rawtxs, Merkle proofs, and Mapi responses to transport the data required for SPV. 
 
@@ -45,58 +46,22 @@ As soon as the Merkle Paths are receieved we can calculate the roots and lookup 
 
 ## Specification
 
-BEEF combines thinking from several formats into one binary stream, prefixed with a header for disambiguation.
+BEEF combines thinking from several formats into one binary stream, prefixed with a very specific version number for disambiguation.
 
 - Raw Transaction Format: [BRC-12](./0012.md)
-- Extended Format (EF): [BRC-30](./0030.md)
 - Compound Merkle Path Format: [BRC-61](./0061.md)
 
-BEEF adds a marker to the transaction format. The BEEF marker allows a library that supports the format to recognize that it is dealing with a transaction in extended format, while a library that does not support extended format will read the transaction as having 0 inputs, 0 outputs and a future nLock time. This has been done to minimize the possible problems a legacy library will have when reading the extended format. It can in no way be recognized as a valid transaction. Lifted from [BRC-30](./0012.md).
+The encoding version number 4022206465 is chosen such that when seen in hex encoded as 4 bytes little endian it reads: `0100BEEF`. This is to allow multiple versions to be defined in future while keeping the data minimal and leaving an obvious sequence which developers can eyeball. Often Bitcoin developers will see a sequence 0100000000... for rawtx. When they instead see 0100BEEF... they will know this data is BEEF format when debugging and so on. If there are future improvements then the next version would be `0200BEEF` for example, this marker will remain "BEEF" for tens of thousands of versions until we reach 4022271999 which is obviously much more than would ever be required. 
 
-| Field                | Description                                                                                            | Size                |
-|----------------------|--------------------------------------------------------------------------------------------------------|---------------------|
-| Version no           | Used to indicate to nodes which version of BEEF this is.                                               | 4 bytes             |
-| BEEF marker          | Marker for Background Evaluation Extended Format **00000000BEEF**                                      | 6 bytes             |
-| nPaths               | VarInt number of compound merkle paths to follow                                                       | 1-9 bytes           |
-| Compound Merkle Path | All of the paths required to prove inclusion of inputs in longest chain of blocks [BRC-61](./0061.md)  | many bytes          |
-| nTransactions        | VarInt number of transactions which follow                                                             | 1-9 bytes           |
-| CEF Transaction      | RawTx bytes with input specific extended data as defined below                                         | many bytes          |
-
-
-### Conditionally Extended Format (CEF) Transaction
-
-This uses the same format detailed in EF [BRC-30](./0012.md) but only for inputs which have been mined and we have included paths for. This means that the data needs to be added to some but not all inputs. Hence we will do away with the global EF flag which is no longer needed since the transaction bytes are coming later in the stream and will not be interpreted as a standard transaction. Instead we will use a single byte to indicate inclusion or not, For sake of clarity when reading the bytes in hex we'll mark "extended format" with `EF` and "not extended" as `00`.
-
-#### CEF Transaction
-
-| Field                     | Description                                                                                   | Size          |
-|---------------------------|-----------------------------------------------------------------------------------------------|---------------|
-| Version no       | Tx Version                                                                                             | 4 bytes       |
-| nIn              | VarInt number of inputs which follow                                                                   | 1 - 9 bytes   |
-| **inputs**       | **CEF Input - this is the only difference between RawTX and CEF**                                      | many          |
-| nOut             | positive integer VI = [[VarInt]]                                                                       | 1 - 9 bytes   |
-| outputs          | Transaction Output Structure                                                                           | many          |
-| nLocktime        | if non-zero and sequence numbers are < 0xFFFFFFFF: block height or timestamp when transaction is final | 4 bytes       |
-
-#### CEF Input
-
-In CEF, we extend the input structure to include one of two things. 
-
-1. `00` indicating "no extended data"
-2. `EF` indicating "extended format" which includes satoshi amount, previous locking script, and the index of the path associated with the input transaction.
-
-| Field                          | Description                                                                                 | Size             |
-|--------------------------------|---------------------------------------------------------------------------------------------|------------------|
-| txid                           | Hash of the transaction in which the output was created                                     | 32 bytes         |
-| vout                           | Index of the output within that transaction Uint32LE                                        | 4 bytes          |
-| unlocking script length        | VarInt Unlocking Script Length                                                              | 1 - 9 bytes      |
-| unlocking script               | Unlocking Script                                                                            | many bytes       | 
-| Sequence_no                    | For Payment Channels - valid when nSequence = 0xFFFFFFFF                                    | 4 bytes          | 
-| **CEF byte**                   | **Either `00` or `EF`**                                                                     | **1 byte**       |
-| **Path Index**                 | **VarInt Index of the particular path of the txid within the list of paths**                | **1 - 9 bytes**  |
-| **satoshis**                   | **Output value in satoshis of previous input - Uint64LE**                                   | **8 bytes**      |
-| **locking script length**      | **VarInt length of locking script**                                                         | **1 - 9 bytes**  |
-| **locking script**             | **Script**                                                                                  | **many bytes**   |
+| Field                | Description                                                                                                               | Size                |
+|----------------------|---------------------------------------------------------------------------------------------------------------------------|---------------------|
+| Version no           | Version number starts at 4022206465, encoded Uint32LE => `0100BEEF`                                                       | 4 bytes             |
+| nPaths               | VarInt number of compound merkle paths which follow                                                                       | 1-9 bytes           |
+| Compound Merkle Path | All of the paths required to prove inclusion of inputs in longest chain of blocks [BRC-61](./0061.md)                     | many bytes x nPaths |
+| nTransactions        | VarInt number of transactions which follow                                                                                | 1-9 bytes           |
+| Raw Transaction      | RawTx bytes as in standard format [BRC-12](./0012.md)                                                                     | many bytes          |
+| Has Merkle path      | Does the transaction prior have a Merkle path? `01` if so, followed by the Path index; `00` if not, followed by nothing.  | 1 byte              |
+| Path index           | VarInt index number - indicating the Compound Merkle Path to which the prior tx belongs if there is one.                  | 1-9 bytes           |
 
 
 ### Ordering
@@ -179,62 +144,26 @@ console.log({ correctOrder: khanTopologicalSort(graph) })
 
 ### Hex
 ```
-0100000000000000BEEF01020101cd73c0c6bb645581816fa960fd2f1636062fcbf23cb57981074ab8d708a76e3b02003470d882cf556a4b943639eba15dc795dffdbebdc98b9a98e3637fda96e3811e01c58e40f22b9e9fcd05a09689a9b19e6e62dbfd3335c5253d09a7a7cd755d9a3c0201da256f78ae0ad74bbf539662cdb9122aa02ba9a9d883f1d52468d96290515adb02b4c8d919190a090e77b73ffcd52b85babaaeeb62da000473102aca7f070facef02020000000158cb8b052fded9a6c450c4212562df8820359ec34da41286421e0d0f2b7eefee000000006a47304402206b1255cb23454c63b22833de25a3a3ecbdb8d8645ad129d3269cdddf10b2ec98022034cadf46e5bfecc38940e5497ddf5fa9aeb37ff5ec3fe8e21b19cbb64a45ec324121029a82bfce319faccc34095c8405896e1223921917501a4f736a04f126d6a01c12ffffffffef00c6c7c903000000001976a9145e506dd7afa889e8f16f5e00555d1c0ab225152f88ac0101000000000000001976a914d866ec5ebb0f4e3840351ee61887101e5407562988ac00000000020000000158cb8b052fded9a6c450c4212562df8820359ec34da41286421e0d0f2b7eefee000000006a47304402206b1255cb23454c63b22833de25a3a3ecbdb8d8645ad129d3269cdddf10b2ec98022034cadf46e5bfecc38940e5497ddf5fa9aeb37ff5ec3fe8e21b19cbb64a45ec324121029a82bfce319faccc34095c8405896e1223921917501a4f736a04f126d6a01c12ffffffff000101000000000000001976a914d866ec5ebb0f4e3840351ee61887101e5407562988ac00000000
+0100beef01020101cd73c0c6bb645581816fa960fd2f1636062fcbf23cb57981074ab8d708a76e3b02003470d882cf556a4b943639eba15dc795dffdbebdc98b9a98e3637fda96e3811e01c58e40f22b9e9fcd05a09689a9b19e6e62dbfd3335c5253d09a7a7cd755d9a3c04008c00bb9360e93fb822c84b2e579fa4ce75c8378ae87f67730a49552f73c56ee801da256f78ae0ad74bbf539662cdb9122aa02ba9a9d883f1d52468d96290515adb02b4c8d919190a090e77b73ffcd52b85babaaeeb62da000473102aca7f070facef03e5b331f4961d764373f3a4e2751954e75489fb17902aad583eedbb41dc165a3b02020000000158cb8b052fded9a6c450c4212562df8820359ec34da41286421e0d0f2b7eefee000000006a47304402206b1255cb23454c63b22833de25a3a3ecbdb8d8645ad129d3269cdddf10b2ec98022034cadf46e5bfecc38940e5497ddf5fa9aeb37ff5ec3fe8e21b19cbb64a45ec324121029a82bfce319faccc34095c8405896e1223921917501a4f736a04f126d6a01c12ffffffff0101000000000000001976a914d866ec5ebb0f4e3840351ee61887101e5407562988ac000000000100020000000158cb8b052fded9a6c450c4212562df8820359ec34da41286421e0d0f2b7eefee000000006a47304402206b1255cb23454c63b22833de25a3a3ecbdb8d8645ad129d3269cdddf10b2ec98022034cadf46e5bfecc38940e5497ddf5fa9aeb37ff5ec3fe8e21b19cbb64a45ec324121029a82bfce319faccc34095c8405896e1223921917501a4f736a04f126d6a01c12ffffffff0101000000000000001976a914d866ec5ebb0f4e3840351ee61887101e5407562988ac0000000000
 ```
 
 
 ### Bytewise Breakdown
 
 ```javascript
-01000000 // version
-00000000BEEF
-01 // VarInt nPaths = 1
-020101cd73c0c6bb645581816fa960fd2f1636062fcbf23cb57981074ab8d708a76e3b02003470d882cf556a4b943639eba15dc795dffdbebdc98b9a98e3637fda96e3811e01c58e40f22b9e9fcd05a09689a9b19e6e62dbfd3335c5253d09a7a7cd755d9a3c0201da256f78ae0ad74bbf539662cdb9122aa02ba9a9d883f1d52468d96290515adb02b4c8d919190a090e77b73ffcd52b85babaaeeb62da000473102aca7f070facef // see BRC-61 for details of compound path format
+0100beef // version
+01 // VarInt nPaths
+020101cd73c0c6bb645581816fa960fd2f1636062fcbf23cb57981074ab8d708a76e3b02003470d882cf556a4b943639eba15dc795dffdbebdc98b9a98e3637fda96e3811e01c58e40f22b9e9fcd05a09689a9b19e6e62dbfd3335c5253d09a7a7cd755d9a3c04008c00bb9360e93fb822c84b2e579fa4ce75c8378ae87f67730a49552f73c56ee801da256f78ae0ad74bbf539662cdb9122aa02ba9a9d883f1d52468d96290515adb02b4c8d919190a090e77b73ffcd52b85babaaeeb62da000473102aca7f070facef03e5b331f4961d764373f3a4e2751954e75489fb17902aad583eedbb41dc165a3b // see BRC-61 for details of Compound Merkle Path format
 02 // VarInt nTransactions = 2
 //------------------- example tx with a merkle path above -------------------
-02000000 // tx version
-01 // nInputs
-58cb8b052fded9a6c450c4212562df8820359ec34da41286421e0d0f2b7eefee // outpoint txid
-00000000 // outpoint vout
-6a // length of unlocking script
-47304402206b1255cb23454c63b22833de25a3a3ecbdb8d8645ad129d3269cdddf10b2ec98022034cadf46e5bfecc38940e5497ddf5fa9aeb37ff5ec3fe8e21b19cbb64a45ec324121029a82bfce319faccc34095c8405896e1223921917501a4f736a04f126d6a01c12 // unlocking script
-ffffffff // nSequence
-// CONDITIONAL EXTENDED DATA
-    ef // indicates that extended data follows
-    00 // VarInt index of associated path above
-    c6c7c90300000000 // satoshis
-    19 // lenLockingScript
-    76a9145e506dd7afa889e8f16f5e00555d1c0ab225152f88ac // lockingScript
-// END OF INPUT
-01 // nOutputs
-0100000000000000 // satoshis
-19 // locking script length
-76a914d866ec5ebb0f4e3840351ee61887101e5407562988ac // locking script
-00000000 //  nLocktime
+020000000158cb8b052fded9a6c450c4212562df8820359ec34da41286421e0d0f2b7eefee000000006a47304402206b1255cb23454c63b22833de25a3a3ecbdb8d8645ad129d3269cdddf10b2ec98022034cadf46e5bfecc38940e5497ddf5fa9aeb37ff5ec3fe8e21b19cbb64a45ec324121029a82bfce319faccc34095c8405896e1223921917501a4f736a04f126d6a01c12ffffffff0101000000000000001976a914d866ec5ebb0f4e3840351ee61887101e5407562988ac00000000 // rawtx parent
+01 // has merkle path above
+00 // VarInt the index of the path for this tx in the above list
 //------------------- example tx with parent above -------------------
-02000000 // tx version
-01 // nInputs
-58cb8b052fded9a6c450c4212562df8820359ec34da41286421e0d0f2b7eefee // outpoint txid
-00000000 // outpoint vout
-6a // length of unlocking script
-47304402206b1255cb23454c63b22833de25a3a3ecbdb8d8645ad129d3269cdddf10b2ec98022034cadf46e5bfecc38940e5497ddf5fa9aeb37ff5ec3fe8e21b19cbb64a45ec324121029a82bfce319faccc34095c8405896e1223921917501a4f736a04f126d6a01c12 // unlocking script
-ffffffff // nSequence
-// CONDITIONAL EXTENDED DATA
-    00 // indicates that no extended data follows
-// END OF INPUT
-01 // nOutputs
-0100000000000000 // satoshis
-19 // locking script length
-76a914d866ec5ebb0f4e3840351ee61887101e5407562988ac // locking script
-00000000 //  nLocktime
+020000000158cb8b052fded9a6c450c4212562df8820359ec34da41286421e0d0f2b7eefee000000006a47304402206b1255cb23454c63b22833de25a3a3ecbdb8d8645ad129d3269cdddf10b2ec98022034cadf46e5bfecc38940e5497ddf5fa9aeb37ff5ec3fe8e21b19cbb64a45ec324121029a82bfce319faccc34095c8405896e1223921917501a4f736a04f126d6a01c12ffffffff0101000000000000001976a914d866ec5ebb0f4e3840351ee61887101e5407562988ac00000000 //  rawtx current
+00 // doesn't have merkle path above
 ```
-
-## Backward compatibility
-
-The Background Evaluation Extended Format is not backwards compatible, but has been designed in such a way that existing software should not read a transaction in Background Evaluation Extended Format as a valid (partial) transaction. The Background Evaluation Extended Format header (00000000BEEF) will be read as an empty transaction with a future nLock time in a library that does not support the Background Evaluation Extended Format. 
-
-This approach is a direct lift from EF [BIP-30](./0030.md).
 
 ## Implementation
 
-The format should be built into common libraries such as [bsv](https://www.npmjs.com/package/bsv) and [go-bt](https://github.com/libsv/go-bt) for easy incorporation into existing stacks.  
+The format should be built into common libraries such as [bsv](https://www.npmjs.com/package/bsv) and [go-bt](https://github.com/libsv/go-bt) for easy incorporation into existing stacks.

--- a/transactions/0062.md
+++ b/transactions/0062.md
@@ -65,7 +65,7 @@ The encoding version number 4022206465 is chosen such that when seen in hex enco
 | CMP data              | All of the CMPs required to prove inclusion of inputs in longest chain of blocks [BRC-61](./0061.md)                      | many bytes x nCMPs  |
 | nTransactions         | VarInt number of transactions which follow                                                                                | 1-9 bytes           |
 | Raw Transaction       | RawTx bytes as in standard format [BRC-12](./0012.md)                                                                     | many bytes          |
-| Has Merkle path       | `01` if so, followed by the CMP index; `00` if not, followed by nothing.                                                  | 1 byte              |
+| Has CMP               | `01` if so, followed by the CMP index; `00` if not, followed by nothing.                                                  | 1 byte              |
 | CMP index             | VarInt index number - indicating the Compound Merkle Path to which the prior tx belongs if there is one.                  | 1-9 bytes           |
 
 

--- a/transactions/0062.md
+++ b/transactions/0062.md
@@ -62,10 +62,10 @@ The encoding version number 4022206465 is chosen such that when seen in hex enco
 |-----------------------|---------------------------------------------------------------------------------------------------------------------------|---------------------|
 | Version no            | Version number starts at 4022206465, encoded Uint32LE => `0100BEEF`                                                       | 4 bytes             |
 | nCMPs                 | VarInt number of compound merkle paths which follow                                                                       | 1-9 bytes           |
-| Compound Merkle Paths | All of the paths required to prove inclusion of inputs in longest chain of blocks [BRC-61](./0061.md)                     | many bytes x nPaths |
+| CMP data              | All of the CMPs required to prove inclusion of inputs in longest chain of blocks [BRC-61](./0061.md)                      | many bytes x nCMPs  |
 | nTransactions         | VarInt number of transactions which follow                                                                                | 1-9 bytes           |
 | Raw Transaction       | RawTx bytes as in standard format [BRC-12](./0012.md)                                                                     | many bytes          |
-| Has Merkle path       | Does the transaction prior have a Merkle path? `01` if so, followed by the CMP index; `00` if not, followed by nothing.  | 1 byte              |
+| Has Merkle path       | `01` if so, followed by the CMP index; `00` if not, followed by nothing.                                                  | 1 byte              |
 | CMP index             | VarInt index number - indicating the Compound Merkle Path to which the prior tx belongs if there is one.                  | 1-9 bytes           |
 
 


### PR DESCRIPTION
### This pull request:

Amends or corrects an existing standard, without the need for creating a new one

### Summary

Since BEEF standard is as yet unimplemented, this substantial change is incorporated into the original proposal rather than made anew. The proposal is now that all transactions must be included in full, not with extended data only, since this prevents the receiver from determining whether the extended values are truly within the txid provided.

The intention is to allow use of this format without relying on a h(outpoint, script, sats) keyed lookup - which we expect to see in both overlay nodes and teranode, but not lite clients.
