### PR TITLE
BSV Unified Merkle Path (BUMP) Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ BRC | Standard
 71   | [Merkle Path Binary Format](./transactions/0071.md)
 72   | [Protecting BRC-69 Key Linkage Information in Transit](./key-derivation/0072.md)
 73   | [Group Permissions for App Access](./wallet/0073.md)
-74   | [Unified Merkle Path Format](./transactions/0074.md)
+74   | [BSV Unified Merkle Path (BUMP) Format](./transactions/0074.md)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ BRC | Standard
 71   | [Merkle Path Binary Format](./transactions/0071.md)
 72   | [Protecting BRC-69 Key Linkage Information in Transit](./key-derivation/0072.md)
 73   | [Group Permissions for App Access](./wallet/0073.md)
+73   | [Unified Merkle Path Format](./transactions/0074.md)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ BRC | Standard
 71   | [Merkle Path Binary Format](./transactions/0071.md)
 72   | [Protecting BRC-69 Key Linkage Information in Transit](./key-derivation/0072.md)
 73   | [Group Permissions for App Access](./wallet/0073.md)
-73   | [Unified Merkle Path Format](./transactions/0074.md)
+74   | [Unified Merkle Path Format](./transactions/0074.md)
 
 ## License
 

--- a/transactions/0074.md
+++ b/transactions/0074.md
@@ -146,6 +146,35 @@ e07a2bb8bb75e5accff266022e1e5e6e7b4d6d943a04faadcf2ab4a22f796ff3 // hash at 6th 
 5e // offset VarInt (ninty four)
 01 // data follows
 5881826eb6973c54003a02118fe270f03d46d02681c8bc71cd44c613e86302f8 // hash at 5th level of tree
+01 // nLeaves VarInt at level 4
+bf // offset VarInt ()
+00 // no data follows
+01 // nLeaves VarInt at level 3
+fd7c01 // offset VarInt (three hundred and eighty)
+01 // data follows
+93b3efca9b77ddec914f8effac691ecb54e2c81d0ab81cbc4c4b93befe418e85 // hash at 3th level of tree
+01 // nLeaves VarInt at level 2
+fdfb02 // offset VarInt ()
+00 // data follows
+02 // nLeaves VarInt at level 1
+fdf405 // offset VarInt ()
+01 // data follows
+0671394f72237d08a4277f4435e5b6edf7adc272f25effef27cdfe805ce71a81 // hash at 1st level of tree
+fdf505 // offset VarInt ()
+01 // data follows
+262bccabec6c4af3ed00cc7a7414edea9c5efa92fb8623dd6160a001450a5282 // hash at 1st level of tree
+04 // nLeaves VarInt at level 0
+fde80b // offset VarInt ()
+01 // data follows
+11774f01d26412f0d16ea3f0447be0b5ebec67b0782e321a7a01cbdf7f734e30 // hash at 0 level of tree
+fde90b // offset VarInt ()
+01 // data follows
+004e53753e3fe4667073063a17987292cfdea278824e9888e52180581d7188d8 // hash at 0 level of tree
+fdea0b // offset VarInt ()
+01 // data follows
+5e441996fc53f0191d649e68a200e752fb5f39e0d5617083408fa179ddc5c998 // hash at 0 level of tree
+fdeb0b // offset VarInt ()
+00 // no data follows
 ```
 
 ## Calculating the Merkle Root from a Unified Compound Merkle Path

--- a/transactions/0074.md
+++ b/transactions/0074.md
@@ -4,6 +4,7 @@ Darren Kellenschwiler (deggen@kschw.com), Deggen
 Tone Engel (tone@kizmet.org), TonesNotes
 Ty Everett (ty@projectbabbage.com)
 Damian Orzepowski (damian.orzepowski@4chain.studio)
+Arkadiusz Osowski (arkadiusz.osowski@4chain.studio)
 
 ## Abstract
 

--- a/transactions/0074.md
+++ b/transactions/0074.md
@@ -125,7 +125,11 @@ fdeb0b // offset VarInt
 
 ## JSON Encoding
 
-In the JSON encoding - we start with a height for the whole BUMP. A path Array index corresponds to the height within the Merkle tree, so we start with level 0 which is the txids themselves. Within each array element we contain one or more leaves which are specified as an offset number as the key and a leaf as the value. { [offset]: leaf }. This is to aid in the speed of merkle root calculation. A `*` indicates an absence of a value at this position, and so a duplication of the working hash should be used in its place as this is at the right hand side of the merkle tree at that level.
+In the JSON encoding - we start with a height for the whole BUMP. A path Array index corresponds to the height within the Merkle tree, so we start with level 0 which is the txids themselves. Within each array element we contain one or more leaves which are specified as an offset number as the key and a leaf as the value.  
+
+`{ [offset]: leaf }` This is to aid in the speed of merkle root calculation, since the offset is given, and so can be used to lookup the corresponding value directly rather than having to iterate through all leaves.  
+
+A `*` indicates an absence of a value at this position, and so a duplication of the working hash should be used in its place as this is at the right hand side of the merkle tree at that level.
 
 ### JSON Example
 ```json

--- a/transactions/0074.md
+++ b/transactions/0074.md
@@ -340,7 +340,7 @@ bumpJSONtoHex(bump)
 
 ## Merging
 
-A note on compounding multiple BUMPs together. The first check should always be the height - ensure it matches. The second check is the root. Each BUMP calculates its root, and if they don't match - you cannot combine them. If they  match then the process is a simple inclusion of all leaves, dropping duplicates.
+A note on compounding multiple BUMPs together. The first check should always be the blockHeight - ensure it matches. The second check is the root. Each BUMP calculates its root, and if they don't match - you cannot combine them. If they  match then the process is a simple inclusion of all leaves, dropping duplicates.
 
 ```javascript
 function combinePaths(one, two) {

--- a/transactions/0074.md
+++ b/transactions/0074.md
@@ -58,8 +58,19 @@ Each leaf follows the format below:
 | Field                | Description                                                                            |        Size          |
 |----------------------|----------------------------------------------------------------------------------------|----------------------|
 | offset               | `VarInt` offset from left hand side within tree                                        | 1-9 bytes            |
-| data flag            | 01 indicates "a 32 byte hash follows" - 00 indicates "no data, duplicate working hash" | 1 byte               |
+| flags                | Flags can be `00`, or `01`, or `02` - detailed meaning in table below                  | 1 byte               |
 | leaf                 | Each leaf is a 32 byte hash                                                            | 0 or 32 bytes        |
+
+### Flags  
+
+The first flag is to indicate whether or not to duplicate the working hash or use the following data. The second flag indicates whether the hash is a relevant txid or just a sibling hash.
+
+| bits      | byte | meaning                                 |
+|-----------|------|-----------------------------------------|
+| 0000 0000 | 00   | data follows, not a client txid         |
+| 0000 0001 | 01   | nothing follows, duplicate working hash |
+| 0000 0010 | 02   | data follows, and is a client txid      |
+
 
 ### Hex Example
 ```
@@ -146,7 +157,7 @@ In the JSON encoding - we start with a height of a block in which transactions f
 
 `{ [offset]: leaf }` This is to aid in the speed of merkle root calculation, since the offset is given, and so can be used to lookup the corresponding value directly rather than having to iterate through all leaves.  
 
-A `*` indicates an absence of a value at this position, and so a duplication of the working hash should be used in its place as this is at the right hand side of the merkle tree at that level.
+Within the leaf itself we have a `hash` value or a `duplicate` true value. The `hash` is a hex string encoding reversed bytes of the hash at this position in the Merkle tree, the `duplicate` true is a boolean and represents a "no data" for this position, this is to encode for the right hand side of the merkle tree. The expected behavior is for a parser to duplicate the working hash in this case, therefore no further data is required. A `txid` boolean is included if true - to indicate whether the hash in question is considered a relevant txid to the receiving party, rather than just a sibling hash needed to calculate the root.
 
 ### JSON Example
 ```json

--- a/transactions/0074.md
+++ b/transactions/0074.md
@@ -130,7 +130,7 @@ af8764ce7e1cc132ab5ed2229a005c87201c9a5ee15c0f91dd53eff31ab30cd4 // leaf at 11th
 
 ## JSON Encoding
 
-In the JSON encoding - we start with a height of a block in which transactions from BUMP are mined. A path Array index corresponds to the height within the Merkle tree, so we start with level 0 which is the txids themselves. Within each array element we contain one or more leaves which are specified as an offset number as the key and a leaf as the value.  
+In the JSON encoding - we start with a height of a block in which transactions from BUMP are mined. A path Array index corresponds to the height within the Merkle tree, so we start with level 0 which includes all of the txid's of interest to a client in this block and the txid's of additional transactions required to begin the merkle root computation. Within each array element we contain one or more leaves which are specified as an offset number as the key and a leaf as the value.  
 
 `{ [offset]: leaf }` This is to aid in the speed of merkle root calculation, since the offset is given, and so can be used to lookup the corresponding value directly rather than having to iterate through all leaves.  
 

--- a/transactions/0074.md
+++ b/transactions/0074.md
@@ -43,8 +43,8 @@ Thereafter the number of leaves at the top height is specified, and the leaves f
 
 | Field                | Description                                                                            |        Size          |
 |----------------------|----------------------------------------------------------------------------------------|----------------------|
-| nLeaves              | `VarInt` number of leaves at this height                                               | nLeaves x 1-9 bytes  |
-| leaves               | Each leaf encoded in the format below.                                                 | nLeaves x 1-9 bytes  |
+| nLeaves              | `VarInt` number of leaves at this height                                               | 1-9 bytes            |
+| leaves               | Each leaf encoded in the format below.                                                 | nLeaves x 2-42 bytes |
 
 Once all leaves at this height have been specified, an implied decrement of the height in the tree occurs and we specify the number of leaves in the next level down, and so on until we have specified the leaves at level 0 at which point we stop.  
   
@@ -54,7 +54,7 @@ Each leaf follows the format below:
 |----------------------|----------------------------------------------------------------------------------------|----------------------|
 | offset               | `VarInt` offset from left hand side within tree                                        | 1-9 bytes            |
 | data flag            | 01 indicates "a 32 byte hash follows" - 00 indicates "no data, duplicate working hash" | 1 byte               |
-| leaf                 | Each leaf is a 32 byte hash                                                            | 32 bytes or skipped  |
+| leaf                 | Each leaf is a 32 byte hash                                                            | 0 or 32 bytes        |
 
 ### Hex Example
 ```

--- a/transactions/0074.md
+++ b/transactions/0074.md
@@ -81,45 +81,45 @@ af8764ce7e1cc132ab5ed2229a005c87201c9a5ee15c0f91dd53eff31ab30cd4 // hash at 11th
 01 // data follows
 502e59ac92f46543c23006bff855d96f5e648043f0fb87a7a5949e6a9bebae43 // hash at 8th level of tree
 01 // nLeaves VarInt at level 7
-16 // offset VarInt (twenty two)
+16 // offset VarInt
 01 // data follows
 8120cafa17309c0bb0e0ffce835286b3a2dcae48e4497ae2d2b7ced4f051507d // hash at 7th level of tree
 01 // nLeaves VarInt at level 6
-2e // offset VarInt (forty six)
+2e // offset VarInt
 01 // data follows
 e07a2bb8bb75e5accff266022e1e5e6e7b4d6d943a04faadcf2ab4a22f796ff3 // hash at 6th level of tree
 01 // nLeaves VarInt at level 5
-5e // offset VarInt (ninty four)
+5e // offset VarInt
 01 // data follows
 5881826eb6973c54003a02118fe270f03d46d02681c8bc71cd44c613e86302f8 // hash at 5th level of tree
 01 // nLeaves VarInt at level 4
-bf // offset VarInt ()
+bf // offset VarInt
 00 // no data follows
 01 // nLeaves VarInt at level 3
 fd7c01 // offset VarInt (three hundred and eighty)
 01 // data follows
 93b3efca9b77ddec914f8effac691ecb54e2c81d0ab81cbc4c4b93befe418e85 // hash at 3th level of tree
 01 // nLeaves VarInt at level 2
-fdfb02 // offset VarInt ()
+fdfb02 // offset VarInt
 00 // data follows
 02 // nLeaves VarInt at level 1
-fdf405 // offset VarInt ()
+fdf405 // offset VarInt
 01 // data follows
 0671394f72237d08a4277f4435e5b6edf7adc272f25effef27cdfe805ce71a81 // hash at 1st level of tree
-fdf505 // offset VarInt ()
+fdf505 // offset VarInt
 01 // data follows
 262bccabec6c4af3ed00cc7a7414edea9c5efa92fb8623dd6160a001450a5282 // hash at 1st level of tree
 04 // nLeaves VarInt at level 0
-fde80b // offset VarInt ()
+fde80b // offset VarInt
 01 // data follows
 11774f01d26412f0d16ea3f0447be0b5ebec67b0782e321a7a01cbdf7f734e30 // hash at 0 level of tree
-fde90b // offset VarInt ()
+fde90b // offset VarInt
 01 // data follows
 004e53753e3fe4667073063a17987292cfdea278824e9888e52180581d7188d8 // hash at 0 level of tree
-fdea0b // offset VarInt ()
+fdea0b // offset VarInt
 01 // data follows
 5e441996fc53f0191d649e68a200e752fb5f39e0d5617083408fa179ddc5c998 // hash at 0 level of tree
-fdeb0b // offset VarInt ()
+fdeb0b // offset VarInt
 00 // no data follows
 ```
 

--- a/transactions/0074.md
+++ b/transactions/0074.md
@@ -63,7 +63,7 @@ Each leaf follows the format below:
 
 ### Hex Example
 ```
-fe8a6a0c000b010001af8764ce7e1cc132ab5ed2229a005c87201c9a5ee15c0f91dd53eff31ab30cd40103000104011ccd9f8f64f4d0489b30cc815351cf425e0e78ad79a589350e4341ac165dbe45010a01502e59ac92f46543c23006bff855d96f5e648043f0fb87a7a5949e6a9bebae430116018120cafa17309c0bb0e0ffce835286b3a2dcae48e4497ae2d2b7ced4f051507d012e01e07a2bb8bb75e5accff266022e1e5e6e7b4d6d943a04faadcf2ab4a22f796ff3015e015881826eb6973c54003a02118fe270f03d46d02681c8bc71cd44c613e86302f801bf0001fd7c010193b3efca9b77ddec914f8effac691ecb54e2c81d0ab81cbc4c4b93befe418e8501fdfb020002fdf405010671394f72237d08a4277f4435e5b6edf7adc272f25effef27cdfe805ce71a81fdf50501262bccabec6c4af3ed00cc7a7414edea9c5efa92fb8623dd6160a001450a528204fde80b0111774f01d26412f0d16ea3f0447be0b5ebec67b0782e321a7a01cbdf7f734e30fde90b01004e53753e3fe4667073063a17987292cfdea278824e9888e52180581d7188d8fdea0b015e441996fc53f0191d649e68a200e752fb5f39e0d5617083408fa179ddc5c998fdeb0b00
+fe8a6a0c000c04fde80b0111774f01d26412f0d16ea3f0447be0b5ebec67b0782e321a7a01cbdf7f734e30fde90b01004e53753e3fe4667073063a17987292cfdea278824e9888e52180581d7188d8fdea0b015e441996fc53f0191d649e68a200e752fb5f39e0d5617083408fa179ddc5c998fdeb0b0002fdf405010671394f72237d08a4277f4435e5b6edf7adc272f25effef27cdfe805ce71a81fdf50501262bccabec6c4af3ed00cc7a7414edea9c5efa92fb8623dd6160a001450a528201fdfb020001fd7c010193b3efca9b77ddec914f8effac691ecb54e2c81d0ab81cbc4c4b93befe418e8501bf00015e015881826eb6973c54003a02118fe270f03d46d02681c8bc71cd44c613e86302f8012e01e07a2bb8bb75e5accff266022e1e5e6e7b4d6d943a04faadcf2ab4a22f796ff30116018120cafa17309c0bb0e0ffce835286b3a2dcae48e4497ae2d2b7ced4f051507d010a01502e59ac92f46543c23006bff855d96f5e648043f0fb87a7a5949e6a9bebae430104011ccd9f8f64f4d0489b30cc815351cf425e0e78ad79a589350e4341ac165dbe45010300010001af8764ce7e1cc132ab5ed2229a005c87201c9a5ee15c0f91dd53eff31ab30cd4
 ```
 
 ### Bytewise Breakdown
@@ -204,45 +204,39 @@ const hash = (str) => bufRevToHex(createHash('sha256').update(createHash('sha256
 function bumpHexToJSON(str) {
   const reader = new Br()
   reader.buf = Buffer.from(str, 'hex')
-  let height = reader.readVarIntNum()
+  let blockHeight = reader.readVarIntNum()
   let treeHeight = parseInt(reader.read(1).toString('hex'), 16)
-  let path = Array(treeHeight + 1).fill(0).map(() => ({}))
-  let x = 0
-  let flag, offset, hash
-  let nLeavesAtThisHeight = reader.readVarIntNum()
-  let startOfNextHeight = nLeavesAtThisHeight
-  while (treeHeight >= 0) {
-    offset = reader.readVarIntNum()
-    flag = parseInt(reader.read(1).toString('hex'), 16)
-    if (flag) {
-      hash = reader.read(32).reverse().toString('hex')
-    } else {
-      hash = '*'
-    }
-    path[treeHeight][offset] = hash
-    x++
-    if (x == startOfNextHeight) {
-      treeHeight--
-      if (treeHeight < 0) break
-      nLeavesAtThisHeight = reader.readVarIntNum()
-      startOfNextHeight = nLeavesAtThisHeight + x
+  let path = Array(treeHeight).fill(0).map(() => ({}))
+  let flag, offset, hash, nLeavesAtThisHeight
+  for (let level = 0; level < treeHeight; level++) {
+    nLeavesAtThisHeight = reader.readVarIntNum()
+    while (nLeavesAtThisHeight) {
+      offset = reader.readVarIntNum()
+      flag = parseInt(reader.read(1).toString('hex'), 16)
+      if (flag) {
+        hash = reader.read(32).reverse().toString('hex')
+      } else {
+        hash = '*'
+      }
+      path[level][offset] = hash
+      nLeavesAtThisHeight--
     }
   }
-  return { height, path }
+  return { blockHeight, path }
 }
 
-function bumpJSONtoHex({ height, path }) {
+function bumpJSONtoHex({ blockHeight, path }) {
   const bw = new Bw()
-  bw.writeVarIntNum(height)
-  let treeHeight = path.length - 1
+  bw.writeVarIntNum(blockHeight)
+  let treeHeight = path.length
   bw.writeUInt8(treeHeight)
-  for (treeHeight; treeHeight >= 0; treeHeight--) {
-    let nLeaves = Object.keys(path[treeHeight]).length
+  for (let level = 0; level < treeHeight; level++) {
+    let nLeaves = Object.keys(path[level]).length
     bw.writeVarIntNum(nLeaves)
-    for (const leaf in path[treeHeight]) {
+    for (const leaf in path[level]) {
       // offset
       bw.writeVarIntNum(Number(leaf))
-      const value = path[treeHeight][leaf]
+      const value = path[level][leaf]
       // flag
       if (value === '*') {
         bw.writeUInt8(0)
@@ -267,7 +261,7 @@ function calculateMerkleRootFromBUMP(bump, txid) {
   bump.path.map((leaves, height) => {
     const offset = index >> height ^ 1
     const leaf = leaves[offset]
-    if (!leaf) throw Error(`We do not have a hash for this index at height: ${height}`)
+    if (!leaf) throw new Error(`We do not have a hash for this index at height: ${height}`)
     if (leaf === '*') {
       workingHash = hash(workingHash + workingHash)
     } else if (offset % 2) {

--- a/transactions/0074.md
+++ b/transactions/0074.md
@@ -296,10 +296,7 @@ function combinePaths(one, two) {
   if (root1 !== root2) throw Error('You cannot combine paths which do not have the same root.')
   const combinedPath = []
   for (let h = 0; h < one.path.length; h++) {
-    const all = new Set()
-    Object.keys(one.path[h]).map(leaf => all.add({ [leaf]: one.path[h][leaf] }))
-    Object.keys(two.path[h]).map(leaf => all.add({ [leaf]: two.path[h][leaf] }))
-    combinedPath.push(Array.from(all).reduce((a, b) => ({ ...a, ...b })))
+    combinedPath.push({ ...one.path[h], ...two.path[h] })
   }
   return { height: one.height, path: combinedPath }
 }

--- a/transactions/0074.md
+++ b/transactions/0074.md
@@ -28,59 +28,7 @@ The purpose of defining this new specification is to capture the incremental imp
 - Inclusion of height makes lookup extremely fast while only adding maximum 9 bytes to the data size.
 - Multiple paths can be expressed in the same data model.
 - One format for everything, so that there is no need to convert from single to compound path.
-- Size optimization allowing us to skip encoding of far right leaves when duplication of working hash would suffice.
-
-
-## JSON Encoding
-
-
-```json
-{
-  "height": 813706,
-  "path": [ // Array index corresponds to the height within the Merkle tree, so we start with level 0 which is the txids themselves
-    { // within each height there must be one or more hashes with their corresponding offsets { [hash]: offset }
-      "3048": "304e737fdfcb017a1a322e78b067ecebb5e07b44f0a36ed1f01264d2014f7711", // txid at index 3048
-      "3049": "d888711d588021e588984e8278a2decf927298173a06737066e43f3e75534e00",
-      "3050": "98c9c5dd79a18f40837061d5e0395ffb52e700a2689e641d19f053fc9619445e", // txid at index 3050
-      "3051": "*" // indicates an absence of a value at this position, and so a dup of working hash should be used in its place.
-    },
-    {
-      "1524": "811ae75c80fecd27efff5ef272c2adf7edb6e535447f27a4087d23724f397106",
-      "1525": "82520a4501a06061dd2386fb92fa5e9ceaed14747acc00edf34a6cecabcc2b26"
-    },
-    {
-      "763": "*"
-    },
-    {
-      "380": "858e41febe934b4cbc1cb80a1dc8e254cb1e69acff8e4f91ecdd779bcaefb393"
-    },
-    {
-      "191": "*"
-    },
-    {
-      "94": "f80263e813c644cd71bcc88126d0463df070e28f11023a00543c97b66e828158"
-    },
-    {
-      "46": "f36f792fa2b42acfadfa043a946d4d7b6e5e1e2e0266f2cface575bbb82b7ae0"
-    },
-    {
-      "22": "7d5051f0d4ceb7d2e27a49e448aedca2b3865283ceffe0b00b9c3017faca2081"
-    },
-    {
-      "10": "43aeeb9b6a9e94a5a787fbf04380645e6fd955f8bf0630c24365f492ac592e50"
-    },
-    {
-      "4": "45be5d16ac41430e3589a579ad780e5e42cf515381cc309b48d0f4648f9fcd1c"
-    },
-    {
-      "3": "*"
-    },
-    {
-      "0": "d40cb31af3ef53dd910f5ce15e9a1c20875c009a22d25eab32c11c7ece6487af"
-    }
-  ]
-}
-```
+- Size optimization allowing us to skip encoding of far right leaves when duplication of working hash would suffice.  
 
 ## Binary Encoding
 
@@ -108,11 +56,9 @@ Each leaf follows the format below:
 | data flag            | 01 indicates "a 32 byte hash follows" - 00 indicates "no data, duplicate working hash" | 1 byte               |
 | leaf                 | Each leaf is a 32 byte hash                                                            | 32 bytes or skipped  |
 
-## Example
-
-### Hex
+### Hex Example
 ```
-fdea0bfe8a6a0c000c
+fe8a6a0c000b010001af8764ce7e1cc132ab5ed2229a005c87201c9a5ee15c0f91dd53eff31ab30cd40103000104011ccd9f8f64f4d0489b30cc815351cf425e0e78ad79a589350e4341ac165dbe45010a01502e59ac92f46543c23006bff855d96f5e648043f0fb87a7a5949e6a9bebae430116018120cafa17309c0bb0e0ffce835286b3a2dcae48e4497ae2d2b7ced4f051507d012e01e07a2bb8bb75e5accff266022e1e5e6e7b4d6d943a04faadcf2ab4a22f796ff3015e015881826eb6973c54003a02118fe270f03d46d02681c8bc71cd44c613e86302f801bf0001fd7c010193b3efca9b77ddec914f8effac691ecb54e2c81d0ab81cbc4c4b93befe418e8501fdfb020002fdf405010671394f72237d08a4277f4435e5b6edf7adc272f25effef27cdfe805ce71a81fdf50501262bccabec6c4af3ed00cc7a7414edea9c5efa92fb8623dd6160a001450a528204fde80b0111774f01d26412f0d16ea3f0447be0b5ebec67b0782e321a7a01cbdf7f734e30fde90b01004e53753e3fe4667073063a17987292cfdea278824e9888e52180581d7188d8fdea0b015e441996fc53f0191d649e68a200e752fb5f39e0d5617083408fa179ddc5c998fdeb0b00
 ```
 
 ### Bytewise Breakdown
@@ -177,12 +123,66 @@ fdeb0b // offset VarInt ()
 00 // no data follows
 ```
 
+## JSON Encoding
+
+In the JSON encoding - we start with a height for the whole UCMP. A path Array index corresponds to the height within the Merkle tree, so we start with level 0 which is the txids themselves. Within each array element we contain one or more leaves which are specified as an offset number as the key and a leaf as the value. { [offset]: leaf }. This is to aid in the speed of merkle root calculation. A `*` indicates an absence of a value at this position, and so a duplication of the working hash should be used in its place as this is at the right hand side of the merkle tree at that level.
+
+### JSON Example
+```json
+{
+  "height": 813706,
+  "path": [
+    {
+      "3048": "304e737fdfcb017a1a322e78b067ecebb5e07b44f0a36ed1f01264d2014f7711",
+      "3049": "d888711d588021e588984e8278a2decf927298173a06737066e43f3e75534e00",
+      "3050": "98c9c5dd79a18f40837061d5e0395ffb52e700a2689e641d19f053fc9619445e",
+      "3051": "*"
+    },
+    {
+      "1524": "811ae75c80fecd27efff5ef272c2adf7edb6e535447f27a4087d23724f397106",
+      "1525": "82520a4501a06061dd2386fb92fa5e9ceaed14747acc00edf34a6cecabcc2b26"
+    },
+    {
+      "763": "*"
+    },
+    {
+      "380": "858e41febe934b4cbc1cb80a1dc8e254cb1e69acff8e4f91ecdd779bcaefb393"
+    },
+    {
+      "191": "*"
+    },
+    {
+      "94": "f80263e813c644cd71bcc88126d0463df070e28f11023a00543c97b66e828158"
+    },
+    {
+      "46": "f36f792fa2b42acfadfa043a946d4d7b6e5e1e2e0266f2cface575bbb82b7ae0"
+    },
+    {
+      "22": "7d5051f0d4ceb7d2e27a49e448aedca2b3865283ceffe0b00b9c3017faca2081"
+    },
+    {
+      "10": "43aeeb9b6a9e94a5a787fbf04380645e6fd955f8bf0630c24365f492ac592e50"
+    },
+    {
+      "4": "45be5d16ac41430e3589a579ad780e5e42cf515381cc309b48d0f4648f9fcd1c"
+    },
+    {
+      "3": "*"
+    },
+    {
+      "0": "d40cb31af3ef53dd910f5ce15e9a1c20875c009a22d25eab32c11c7ece6487af"
+    }
+  ]
+}
+```
+
 ## Calculating the Merkle Root from a Unified Compound Merkle Path
 
-Let's start by dumping this format as hex into a Buffer and parsing it into an object with a Buffer Reader. Then we construct an object
+Let's start by dumping this format as hex into a Buffer and parsing it into an object with a Buffer Reader. Then we can calculate the merkle root from any of the included txids.
 
 ```javascript
 const { createHash } = require('crypto')
+const { Br } = require('bsv')
 
 // Displaying hashes as hex strings in reverse byte order is a matter of convention with respect to txids. 
 // The functions below handle the conversions such that when we "hash()" something, we are running sha256 - 
@@ -191,43 +191,64 @@ const hexRevToBuf = (str) => Buffer.from(str, 'hex').reverse()
 const bufRevToHex = (buf) => Buffer.from(buf.toString('hex'), 'hex').reverse().toString('hex')
 const hash = (str) => bufRevToHex(createHash('sha256').update(createHash('sha256').update(hexRevToBuf(str)).digest()).digest())
 
-function calculateMerkleRootFromUCMP(ucmp, txid) {
-    // We need to determine the index of the txid.
-    let index
-    // The first path object contains the bottom leaves of the Merkle tree.
-    for (let i in ucmp.path[0]) {
-        // Whichever points to the txid is the index we're after.
-        if (txid === ucmp.path[0][i]) index = Number(i)
+function ucmpHexToJSON(str) {
+  const reader = new Br()
+  reader.buf = Buffer.from(str, 'hex')
+  let height = reader.readVarIntNum()
+  let treeHeight = parseInt(reader.read(1).toString('hex'), 16)
+  let path = Array(treeHeight + 1).fill(0).map(() => ({}))
+  let x = 0
+  let flag, offset, hash
+  let nLeavesAtThisHeight = reader.readVarIntNum()
+  let startOfNextHeight = nLeavesAtThisHeight
+  while (treeHeight >= 0) {
+    offset = reader.readVarIntNum()
+    flag = parseInt(reader.read(1).toString('hex'), 16)
+    if (flag) {
+      hash = reader.read(32).reverse().toString('hex')
+    } else {
+      hash = '*'
     }
-    if (!index) throw Error(`The CMP does not contain the txid: ${txid}`)
-    // Calculate the root using the index as a way to determine which direction to concatenate.
-    let workingHash = txid
-    ucmp.path.map((leaves, height) => {
-        const offset = index >> height ^ 1
-        const leaf = leaves[offset]
-        if (!leaf) throw Error(`We do not have a hash for this index at height: ${height}`)
-        if (leaf === '*') {
-            // if there is no data at this index, we are at the right hand side of the tree, and so we duplicate the working hash.
-            workingHash = hash(workingHash + workingHash)
-        } else if (offset % 2) {
-            // if the offset is odd then we concatenate the leaf on the left. 
-            //     H
-            //   /  \
-            //  L   W
-            workingHash = hash(leaf + workingHash)
-        } else {
-            // if the offset is even then we concatenate the leaf on the right 
-            //     H
-            //   /  \
-            //  W   L
-            workingHash = hash(workingHash + leaf)
-        }
-    })
-    return workingHash
+    path[treeHeight][offset] = hash
+    x++
+    if (x == startOfNextHeight) {
+      treeHeight--
+      if (treeHeight < 0) break
+      nLeavesAtThisHeight = reader.readVarIntNum()
+      startOfNextHeight = nLeavesAtThisHeight + x
+    }
+  }
+  return { height, path }
 }
 
-calculateMerkleRootFromUCMP(ucmp, txid)
-// txid '98c9c5dd79a18f40837061d5e0395ffb52e700a2689e641d19f053fc9619445e'
-// Using the Unified Compound Merkle Proof json from the example in this document should yield the root: 
-// '57aab6e6fb1b697174ffb64e062c4728f2ffd33ddcfa02a43b64d8cd29b483b4'
+function calculateMerkleRootFromCMP(ucmp, txid) {
+  // Find the index of the txid at the lowest level of the Merkle tree
+  let index
+  for (let i in ucmp.path[0]) {
+    if (txid === ucmp.path[0][i]) index = Number(i)
+  }
+  if (!index) throw Error(`The CMP does not contain the txid: ${txid}`)
+  // Calculate the root using the index as a way to determine which direction to concatenate.
+  let workingHash = txid
+  ucmp.path.map((leaves, height) => {
+    const offset = index >> height ^ 1
+    const leaf = leaves[offset]
+    if (!leaf) throw Error(`We do not have a hash for this index at height: ${height}`)
+    if (leaf === '*') {
+      workingHash = hash(workingHash + workingHash)
+    } else if (offset % 2) {
+      workingHash = hash(leaf + workingHash)
+    } else {
+      workingHash = hash(workingHash + leaf)
+    }
+  })
+  return workingHash
+}
+
+
+const ucmp = ucmpHexToJSON('fe8a6a0c000b010001af8764ce7e1cc132ab5ed2229a005c87201c9a5ee15c0f91dd53eff31ab30cd40103000104011ccd9f8f64f4d0489b30cc815351cf425e0e78ad79a589350e4341ac165dbe45010a01502e59ac92f46543c23006bff855d96f5e648043f0fb87a7a5949e6a9bebae430116018120cafa17309c0bb0e0ffce835286b3a2dcae48e4497ae2d2b7ced4f051507d012e01e07a2bb8bb75e5accff266022e1e5e6e7b4d6d943a04faadcf2ab4a22f796ff3015e015881826eb6973c54003a02118fe270f03d46d02681c8bc71cd44c613e86302f801bf0001fd7c010193b3efca9b77ddec914f8effac691ecb54e2c81d0ab81cbc4c4b93befe418e8501fdfb020002fdf405010671394f72237d08a4277f4435e5b6edf7adc272f25effef27cdfe805ce71a81fdf50501262bccabec6c4af3ed00cc7a7414edea9c5efa92fb8623dd6160a001450a528204fde80b0111774f01d26412f0d16ea3f0447be0b5ebec67b0782e321a7a01cbdf7f734e30fde90b01004e53753e3fe4667073063a17987292cfdea278824e9888e52180581d7188d8fdea0b015e441996fc53f0191d649e68a200e752fb5f39e0d5617083408fa179ddc5c998fdeb0b00')
+
+calculateMerkleRootFromCMP(ucmp, '304e737fdfcb017a1a322e78b067ecebb5e07b44f0a36ed1f01264d2014f7711') // '57aab6e6fb1b697174ffb64e062c4728f2ffd33ddcfa02a43b64d8cd29b483b4'
+calculateMerkleRootFromCMP(ucmp, 'd888711d588021e588984e8278a2decf927298173a06737066e43f3e75534e00') // '57aab6e6fb1b697174ffb64e062c4728f2ffd33ddcfa02a43b64d8cd29b483b4'
+calculateMerkleRootFromCMP(ucmp, '98c9c5dd79a18f40837061d5e0395ffb52e700a2689e641d19f053fc9619445e') // '57aab6e6fb1b697174ffb64e062c4728f2ffd33ddcfa02a43b64d8cd29b483b4'
 ```

--- a/transactions/0074.md
+++ b/transactions/0074.md
@@ -30,102 +30,175 @@ The purpose of defining this new specification is to capture the incremental imp
 - One format for everything, so that there is no need to convert from single to compound path.
 - Size optimization allowing us to skip encoding of far right leaves when duplication of working hash would suffice.
 
-## Specification
+
+## JSON Encoding
+
 
 ```json
-
-{ 
-  "index": 3050,
+{
   "height": 813706,
-  "path": [
-    "*",
-    "811ae75c80fecd27efff5ef272c2adf7edb6e535447f27a4087d23724f397106",
-    "*",
-    "858e41febe934b4cbc1cb80a1dc8e254cb1e69acff8e4f91ecdd779bcaefb393",
-    "*",
-    "f80263e813c644cd71bcc88126d0463df070e28f11023a00543c97b66e828158",
-    "f36f792fa2b42acfadfa043a946d4d7b6e5e1e2e0266f2cface575bbb82b7ae0",
-    "7d5051f0d4ceb7d2e27a49e448aedca2b3865283ceffe0b00b9c3017faca2081",
-    "43aeeb9b6a9e94a5a787fbf04380645e6fd955f8bf0630c24365f492ac592e50",
-    "45be5d16ac41430e3589a579ad780e5e42cf515381cc309b48d0f4648f9fcd1c",
-    "*",
-    "d40cb31af3ef53dd910f5ce15e9a1c20875c009a22d25eab32c11c7ece6487af"
+  "path": [ // Array index corresponds to the height within the Merkle tree, so we start with level 0 which is the txids themselves
+    { // within each height there must be one or more hashes with their corresponding offsets { [hash]: offset }
+      "3048": "304e737fdfcb017a1a322e78b067ecebb5e07b44f0a36ed1f01264d2014f7711", // txid at index 3048
+      "3049": "d888711d588021e588984e8278a2decf927298173a06737066e43f3e75534e00",
+      "3050": "98c9c5dd79a18f40837061d5e0395ffb52e700a2689e641d19f053fc9619445e", // txid at index 3050
+      "3051": "*" // indicates an absence of a value at this position, and so a dup of working hash should be used in its place.
+    },
+    {
+      "1524": "811ae75c80fecd27efff5ef272c2adf7edb6e535447f27a4087d23724f397106",
+      "1525": "82520a4501a06061dd2386fb92fa5e9ceaed14747acc00edf34a6cecabcc2b26"
+    },
+    {
+      "763": "*"
+    },
+    {
+      "380": "858e41febe934b4cbc1cb80a1dc8e254cb1e69acff8e4f91ecdd779bcaefb393"
+    },
+    {
+      "191": "*"
+    },
+    {
+      "94": "f80263e813c644cd71bcc88126d0463df070e28f11023a00543c97b66e828158"
+    },
+    {
+      "46": "f36f792fa2b42acfadfa043a946d4d7b6e5e1e2e0266f2cface575bbb82b7ae0"
+    },
+    {
+      "22": "7d5051f0d4ceb7d2e27a49e448aedca2b3865283ceffe0b00b9c3017faca2081"
+    },
+    {
+      "10": "43aeeb9b6a9e94a5a787fbf04380645e6fd955f8bf0630c24365f492ac592e50"
+    },
+    {
+      "4": "45be5d16ac41430e3589a579ad780e5e42cf515381cc309b48d0f4648f9fcd1c"
+    },
+    {
+      "3": "*"
+    },
+    {
+      "0": "d40cb31af3ef53dd910f5ce15e9a1c20875c009a22d25eab32c11c7ece6487af"
+    }
   ]
 }
 ```
 
-Encoding in bytes we start with a VarInt for index, followed by nPath being the number of leaves to follow, followed by 32 byte leaves.
+## Binary Encoding
 
+The top level encoding specifies a block height and a tree height.
 
-#### Data Types
+| Field                | Description                                                                            |        Size          |
+|----------------------|----------------------------------------------------------------------------------------|----------------------|
+| block height         | `VarInt` block height in which the transactions are encapsulated                       | 1-9 bytes            |
+| tree height          | The height of the tree up to a max 64, specifies the height one below the root         | 1 byte               |
 
-| Field                | Description                                                                                                           |        Size          |
-|----------------------|-----------------------------------------------------------------------------------------------------------------------|----------------------|
-| index                | `VarInt` tx index number from within a block                                                                          | 1-9 bytes            |
-| nLeaves              | number of leaves which follow, max 64                                                                                 | 1 byte               |
-| leaf                 | Each leaf of the path is a 32 byte hash, but we prefix with a 00 to indicate a skip, or 01 to indicate a hash follows | 33 bytes x nLeaves   |
+Thereafter the number of leaves at the top height is specified, and the leaves for this height follow. 
+
+| Field                | Description                                                                            |        Size          |
+|----------------------|----------------------------------------------------------------------------------------|----------------------|
+| nLeaves              | `VarInt` number of leaves at this height                                               | nLeaves x 1-9 bytes  |
+| leaves               | Each leaf encoded in the format below.                                                 | nLeaves x 1-9 bytes  |
+
+Once all leaves at this height have been specified, an implied decrement of the height in the tree occurs and we specify the number of leaves in the next level down, and so on until we have specified the leaves at level 0 at which point we stop.  
+  
+Each leaf follows the format below:
+
+| Field                | Description                                                                            |        Size          |
+|----------------------|----------------------------------------------------------------------------------------|----------------------|
+| offset               | `VarInt` offset from left hand side within tree                                        | 1-9 bytes            |
+| data flag            | 01 indicates "a 32 byte hash follows" - 00 indicates "no data, duplicate working hash" | 1 byte               |
+| leaf                 | Each leaf is a 32 byte hash                                                            | 32 bytes or skipped  |
 
 ## Example
 
 ### Hex
 ```
-88040c82025f47b31054e9ad52109ef25b00fd9aaae7153564619bab031d4112f56c3b6ea708d7b84a078179b53cf2cb2f0636162ffd60a96f81815564bbc6c073cdefac0f077fca2a10730400da62ebaebaba852bd5fc3fb7770e090a1919d9c8b41e81e396da7f63e3989a8bc9bdbefddf95c75da1eb3936944b6a55cf82d87034
+fdea0bfe8a6a0c000c
 ```
 
 ### Bytewise Breakdown
 ```javascript
----- // index VarInt
-0c // nLeaves
-811ae75c80fecd27efff5ef272c2adf7edb6e535447f27a4087d23724f397106 // leaf
+fe8a6a0c00 // block height VarInt
+0b // 1 byte tree height (eleven)
+01 // nLeaves VarInt at level 11
+00 // offset VarInt
+01 // data follows
+af8764ce7e1cc132ab5ed2229a005c87201c9a5ee15c0f91dd53eff31ab30cd4 // hash at 11th level of tree
+01 // nLeaves VarInt at level 10
+03 // offset VarInt
+00 // no data follows
+01 // nLeaves VarInt at level 9
+04 // offset VarInt
+01 // data follows
+1ccd9f8f64f4d0489b30cc815351cf425e0e78ad79a589350e4341ac165dbe45 // hash at 9th level of tree
+01 // nLeaves VarInt at level 8
+0a // offset VarInt
+01 // data follows
+502e59ac92f46543c23006bff855d96f5e648043f0fb87a7a5949e6a9bebae43 // hash at 8th level of tree
+01 // nLeaves VarInt at level 7
+16 // offset VarInt (twenty two)
+01 // data follows
+8120cafa17309c0bb0e0ffce835286b3a2dcae48e4497ae2d2b7ced4f051507d // hash at 7th level of tree
+01 // nLeaves VarInt at level 6
+2e // offset VarInt (forty six)
+01 // data follows
+e07a2bb8bb75e5accff266022e1e5e6e7b4d6d943a04faadcf2ab4a22f796ff3 // hash at 6th level of tree
+01 // nLeaves VarInt at level 5
+5e // offset VarInt (ninty four)
+01 // data follows
+5881826eb6973c54003a02118fe270f03d46d02681c8bc71cd44c613e86302f8 // hash at 5th level of tree
 ```
 
-## Implementation
+## Calculating the Merkle Root from a Unified Compound Merkle Path
 
 Let's start by dumping this format as hex into a Buffer and parsing it into an object with a Buffer Reader. Then we construct an object
 
 ```javascript
 const { createHash } = require('crypto')
+
+// Displaying hashes as hex strings in reverse byte order is a matter of convention with respect to txids. 
+// The functions below handle the conversions such that when we "hash()" something, we are running sha256 - 
+// digesting the reverse bytes of a hex string, and returning the reverse bytes encoded as a hex string.
 const hexRevToBuf = (str) => Buffer.from(str, 'hex').reverse()
 const bufRevToHex = (buf) => Buffer.from(buf.toString('hex'), 'hex').reverse().toString('hex')
 const hash = (str) => bufRevToHex(createHash('sha256').update(createHash('sha256').update(hexRevToBuf(str)).digest()).digest())
 
-const merklePath = {
-  txid: '98c9c5dd79a18f40837061d5e0395ffb52e700a2689e641d19f053fc9619445e',
-  index: 3050,
-  height: 813706,
-  path: [
-    '*',
-    '811ae75c80fecd27efff5ef272c2adf7edb6e535447f27a4087d23724f397106',
-    '*',
-    '858e41febe934b4cbc1cb80a1dc8e254cb1e69acff8e4f91ecdd779bcaefb393',
-    '*',
-    'f80263e813c644cd71bcc88126d0463df070e28f11023a00543c97b66e828158',
-    'f36f792fa2b42acfadfa043a946d4d7b6e5e1e2e0266f2cface575bbb82b7ae0',
-    '7d5051f0d4ceb7d2e27a49e448aedca2b3865283ceffe0b00b9c3017faca2081',
-    '43aeeb9b6a9e94a5a787fbf04380645e6fd955f8bf0630c24365f492ac592e50',
-    '45be5d16ac41430e3589a579ad780e5e42cf515381cc309b48d0f4648f9fcd1c',
-    '*',
-    'd40cb31af3ef53dd910f5ce15e9a1c20875c009a22d25eab32c11c7ece6487af'
-  ]
-}
-
-function calculateMerkleRoot({ txid, index, path }) {
-  let workingHash = txid
-  let leaf
-  while (index > 0) {
-    leaf = path.shift()
-    if (leaf === '*') {
-      workingHash = hash(workingHash + workingHash)
-    } else if (index % 2) {
-      workingHash = hash(workingHash + leaf)
-    } else {
-      workingHash = hash(leaf + workingHash)
+function calculateMerkleRootFromUCMP(ucmp, txid) {
+    // We need to determine the index of the txid.
+    let index
+    // The first path object contains the bottom leaves of the Merkle tree.
+    for (let i in ucmp.path[0]) {
+        // Whichever points to the txid is the index we're after.
+        if (txid === ucmp.path[0][i]) index = Number(i)
     }
-    index = Math.floor(index / 2)
-  }
-  return workingHash
+    if (!index) throw Error(`The CMP does not contain the txid: ${txid}`)
+    // Calculate the root using the index as a way to determine which direction to concatenate.
+    let workingHash = txid
+    ucmp.path.map((leaves, height) => {
+        const offset = index >> height ^ 1
+        const leaf = leaves[offset]
+        if (!leaf) throw Error(`We do not have a hash for this index at height: ${height}`)
+        if (leaf === '*') {
+            // if there is no data at this index, we are at the right hand side of the tree, and so we duplicate the working hash.
+            workingHash = hash(workingHash + workingHash)
+        } else if (offset % 2) {
+            // if the offset is odd then we concatenate the leaf on the left. 
+            //     H
+            //   /  \
+            //  L   W
+            workingHash = hash(leaf + workingHash)
+        } else {
+            // if the offset is even then we concatenate the leaf on the right 
+            //     H
+            //   /  \
+            //  W   L
+            workingHash = hash(workingHash + leaf)
+        }
+    })
+    return workingHash
 }
 
-console.log(calculateMerkleRoot(merklePath))
+calculateMerkleRootFromUCMP(ucmp, txid)
+// txid '98c9c5dd79a18f40837061d5e0395ffb52e700a2689e641d19f053fc9619445e'
+// Using the Unified Compound Merkle Proof json from the example in this document should yield the root: 
 // '57aab6e6fb1b697174ffb64e062c4728f2ffd33ddcfa02a43b64d8cd29b483b4'
 ```

--- a/transactions/0074.md
+++ b/transactions/0074.md
@@ -255,7 +255,7 @@ function calculateMerkleRootFromBUMP(bump, txid) {
   for (let i in bump.path[0]) {
     if (txid === bump.path[0][i]) index = Number(i)
   }
-  if (!index) throw Error(`The CMP does not contain the txid: ${txid}`)
+  if (!index) throw Error(`The BUMP does not contain the txid: ${txid}`)
   // Calculate the root using the index as a way to determine which direction to concatenate.
   let workingHash = txid
   bump.path.map((leaves, height) => {

--- a/transactions/0074.md
+++ b/transactions/0074.md
@@ -1,0 +1,131 @@
+# BRC-74: Unified Merkle Path Format
+
+Darren Kellenschwiler (deggen@kschw.com), Deggen
+Tone Engel (tone@kizmet.org), TonesNotes
+Ty Everett (ty@projectbabbage.com)
+Damian Orzepowski (damian.orzepowski@4chain.studio)
+
+## Abstract
+
+We propose a Compound Merkle Path format in both binary and JSON encoding optimized for transmission, storage, and ease of use in a Merkle Proof validation process.
+
+## Copyright
+
+This BRC is licensed under the Open BSV license.
+
+## Motivation
+
+Several formats have made their own improvements to the original format which was returned by a Bitcoin node via json-rpc method `getmerkleproof`.
+
+Improvements include:
+- [BRC-10](./0010.md) a TSC creation which was subsequently returned by the node's json-rpc method `getmerkleproof2`
+- [BRC-11](./0011.md) removing the need for specifying targets, replacing with height to improve validation speed.
+- [BRC-58](./0058.md) removal of all extraneous data to minimize data size.
+- [BRC-61](./0061.md) introduction of a compound path encoding which allows representation of multiple paths within the same block.
+
+The purpose of defining this new specification is to capture the incremental improvements under one spec which encapsulates the pros of each, and removes the cons. This new spec should allow:
+
+- Inclusion of height makes lookup extremely fast while only adding maximum 9 bytes to the data size.
+- Multiple paths can be expressed in the same data model.
+- One format for everything, so that there is no need to convert from single to compound path.
+- Size optimization allowing us to skip encoding of far right leaves when duplication of working hash would suffice.
+
+## Specification
+
+```json
+
+{ 
+  "index": 3050,
+  "height": 813706,
+  "path": [
+    "*",
+    "811ae75c80fecd27efff5ef272c2adf7edb6e535447f27a4087d23724f397106",
+    "*",
+    "858e41febe934b4cbc1cb80a1dc8e254cb1e69acff8e4f91ecdd779bcaefb393",
+    "*",
+    "f80263e813c644cd71bcc88126d0463df070e28f11023a00543c97b66e828158",
+    "f36f792fa2b42acfadfa043a946d4d7b6e5e1e2e0266f2cface575bbb82b7ae0",
+    "7d5051f0d4ceb7d2e27a49e448aedca2b3865283ceffe0b00b9c3017faca2081",
+    "43aeeb9b6a9e94a5a787fbf04380645e6fd955f8bf0630c24365f492ac592e50",
+    "45be5d16ac41430e3589a579ad780e5e42cf515381cc309b48d0f4648f9fcd1c",
+    "*",
+    "d40cb31af3ef53dd910f5ce15e9a1c20875c009a22d25eab32c11c7ece6487af"
+  ]
+}
+```
+
+Encoding in bytes we start with a VarInt for index, followed by nPath being the number of leaves to follow, followed by 32 byte leaves.
+
+
+#### Data Types
+
+| Field                | Description                                                                                                           |        Size          |
+|----------------------|-----------------------------------------------------------------------------------------------------------------------|----------------------|
+| index                | `VarInt` tx index number from within a block                                                                          | 1-9 bytes            |
+| nLeaves              | number of leaves which follow, max 64                                                                                 | 1 byte               |
+| leaf                 | Each leaf of the path is a 32 byte hash, but we prefix with a 00 to indicate a skip, or 01 to indicate a hash follows | 33 bytes x nLeaves   |
+
+## Example
+
+### Hex
+```
+88040c82025f47b31054e9ad52109ef25b00fd9aaae7153564619bab031d4112f56c3b6ea708d7b84a078179b53cf2cb2f0636162ffd60a96f81815564bbc6c073cdefac0f077fca2a10730400da62ebaebaba852bd5fc3fb7770e090a1919d9c8b41e81e396da7f63e3989a8bc9bdbefddf95c75da1eb3936944b6a55cf82d87034
+```
+
+### Bytewise Breakdown
+```javascript
+---- // index VarInt
+0c // nLeaves
+811ae75c80fecd27efff5ef272c2adf7edb6e535447f27a4087d23724f397106 // leaf
+```
+
+## Implementation
+
+Let's start by dumping this format as hex into a Buffer and parsing it into an object with a Buffer Reader. Then we construct an object
+
+```javascript
+const { createHash } = require('crypto')
+const hexRevToBuf = (str) => Buffer.from(str, 'hex').reverse()
+const bufRevToHex = (buf) => Buffer.from(buf.toString('hex'), 'hex').reverse().toString('hex')
+const hash = (str) => bufRevToHex(createHash('sha256').update(createHash('sha256').update(hexRevToBuf(str)).digest()).digest())
+
+const merklePath = {
+  txid: '98c9c5dd79a18f40837061d5e0395ffb52e700a2689e641d19f053fc9619445e',
+  index: 3050,
+  height: 813706,
+  path: [
+    '*',
+    '811ae75c80fecd27efff5ef272c2adf7edb6e535447f27a4087d23724f397106',
+    '*',
+    '858e41febe934b4cbc1cb80a1dc8e254cb1e69acff8e4f91ecdd779bcaefb393',
+    '*',
+    'f80263e813c644cd71bcc88126d0463df070e28f11023a00543c97b66e828158',
+    'f36f792fa2b42acfadfa043a946d4d7b6e5e1e2e0266f2cface575bbb82b7ae0',
+    '7d5051f0d4ceb7d2e27a49e448aedca2b3865283ceffe0b00b9c3017faca2081',
+    '43aeeb9b6a9e94a5a787fbf04380645e6fd955f8bf0630c24365f492ac592e50',
+    '45be5d16ac41430e3589a579ad780e5e42cf515381cc309b48d0f4648f9fcd1c',
+    '*',
+    'd40cb31af3ef53dd910f5ce15e9a1c20875c009a22d25eab32c11c7ece6487af'
+  ]
+}
+
+function calculateMerkleRoot({ txid, index, path }) {
+  let workingHash = txid
+  let leaf
+  while (index > 0) {
+    leaf = path.shift()
+    if (leaf === '*') {
+      workingHash = hash(workingHash + workingHash)
+    } else if (index % 2) {
+      workingHash = hash(workingHash + leaf)
+    } else {
+      workingHash = hash(leaf + workingHash)
+    }
+    index = Math.floor(index / 2)
+  }
+  return workingHash
+}
+
+console.log(calculateMerkleRoot(merklePath))
+// '57aab6e6fb1b697174ffb64e062c4728f2ffd33ddcfa02a43b64d8cd29b483b4'
+```

--- a/transactions/0074.md
+++ b/transactions/0074.md
@@ -221,16 +221,16 @@ function bumpHexToJSON(str) {
   return { height, path }
 }
 
-function calculateMerkleRootFromBUMP(ucmp, txid) {
+function calculateMerkleRootFromBUMP(bump, txid) {
   // Find the index of the txid at the lowest level of the Merkle tree
   let index
-  for (let i in ucmp.path[0]) {
-    if (txid === ucmp.path[0][i]) index = Number(i)
+  for (let i in bump.path[0]) {
+    if (txid === bump.path[0][i]) index = Number(i)
   }
   if (!index) throw Error(`The CMP does not contain the txid: ${txid}`)
   // Calculate the root using the index as a way to determine which direction to concatenate.
   let workingHash = txid
-  ucmp.path.map((leaves, height) => {
+  bump.path.map((leaves, height) => {
     const offset = index >> height ^ 1
     const leaf = leaves[offset]
     if (!leaf) throw Error(`We do not have a hash for this index at height: ${height}`)

--- a/transactions/0074.md
+++ b/transactions/0074.md
@@ -41,7 +41,7 @@ The top level encoding specifies a block height and a tree height.
 | Field                | Description                                                                            |        Size          |
 |----------------------|----------------------------------------------------------------------------------------|----------------------|
 | block height         | `VarInt` block height in which the transactions are encapsulated                       | 1-9 bytes            |
-| tree height          | The height of the tree up to a max 64, specifies the height one below the root         | 1 byte               |
+| tree height          | The height of the Merkle Tree in this block, max 64                                    | 1 byte               |
 
 Thereafter the number of leaves at the top height is specified, and the leaves for this height follow. 
 
@@ -68,51 +68,7 @@ fe8a6a0c000b010001af8764ce7e1cc132ab5ed2229a005c87201c9a5ee15c0f91dd53eff31ab30c
 ### Bytewise Breakdown
 ```javascript
 fe8a6a0c00 // block height VarInt
-0b // 1 byte tree height (eleven)
-01 // nLeaves VarInt at level 11
-00 // offset VarInt
-01 // data follows
-af8764ce7e1cc132ab5ed2229a005c87201c9a5ee15c0f91dd53eff31ab30cd4 // leaf at 11th level of tree
-01 // nLeaves VarInt at level 10
-03 // offset VarInt
-00 // no data follows
-01 // nLeaves VarInt at level 9
-04 // offset VarInt
-01 // data follows
-1ccd9f8f64f4d0489b30cc815351cf425e0e78ad79a589350e4341ac165dbe45 // leaf at 9th level of tree
-01 // nLeaves VarInt at level 8
-0a // offset VarInt
-01 // data follows
-502e59ac92f46543c23006bff855d96f5e648043f0fb87a7a5949e6a9bebae43 // leaf at 8th level of tree
-01 // nLeaves VarInt at level 7
-16 // offset VarInt
-01 // data follows
-8120cafa17309c0bb0e0ffce835286b3a2dcae48e4497ae2d2b7ced4f051507d // leaf at 7th level of tree
-01 // nLeaves VarInt at level 6
-2e // offset VarInt
-01 // data follows
-e07a2bb8bb75e5accff266022e1e5e6e7b4d6d943a04faadcf2ab4a22f796ff3 // leaf at 6th level of tree
-01 // nLeaves VarInt at level 5
-5e // offset VarInt
-01 // data follows
-5881826eb6973c54003a02118fe270f03d46d02681c8bc71cd44c613e86302f8 // leaf at 5th level of tree
-01 // nLeaves VarInt at level 4
-bf // offset VarInt
-00 // no data follows
-01 // nLeaves VarInt at level 3
-fd7c01 // offset VarInt (three hundred and eighty)
-01 // data follows
-93b3efca9b77ddec914f8effac691ecb54e2c81d0ab81cbc4c4b93befe418e85 // leaf at 3th level of tree
-01 // nLeaves VarInt at level 2
-fdfb02 // offset VarInt
-00 // data follows
-02 // nLeaves VarInt at level 1
-fdf405 // offset VarInt
-01 // data follows
-0671394f72237d08a4277f4435e5b6edf7adc272f25effef27cdfe805ce71a81 // leaf 1 at 1st level of tree
-fdf505 // offset VarInt
-01 // data follows
-262bccabec6c4af3ed00cc7a7414edea9c5efa92fb8623dd6160a001450a5282 // leaf 2 at 1st level of tree
+0c // 1 byte tree height (twelve)
 04 // nLeaves VarInt at level 0
 fde80b // offset VarInt
 01 // data follows
@@ -125,6 +81,51 @@ fdea0b // offset VarInt
 5e441996fc53f0191d649e68a200e752fb5f39e0d5617083408fa179ddc5c998 // leaf 3 at 0 level of tree
 fdeb0b // offset VarInt
 00 // no data follows
+02 // nLeaves VarInt at level 1
+fdf405 // offset VarInt
+01 // data follows
+0671394f72237d08a4277f4435e5b6edf7adc272f25effef27cdfe805ce71a81 // leaf 1 at 1st level of tree
+fdf505 // offset VarInt
+01 // data follows
+262bccabec6c4af3ed00cc7a7414edea9c5efa92fb8623dd6160a001450a5282 // leaf 2 at 1st level of tree
+01 // nLeaves VarInt at level 2
+fdfb02 // offset VarInt
+00 // no data follows
+01 // nLeaves VarInt at level 3
+fd7c01 // offset VarInt (three hundred and eighty)
+01 // data follows
+93b3efca9b77ddec914f8effac691ecb54e2c81d0ab81cbc4c4b93befe418e85 // leaf at 3th level of tree
+01 // nLeaves VarInt at level 4
+bf // offset VarInt
+00 // no data follows
+01 // nLeaves VarInt at level 5
+5e // offset VarInt
+01 // data follows
+5881826eb6973c54003a02118fe270f03d46d02681c8bc71cd44c613e86302f8 // leaf at 5th level of tree
+01 // nLeaves VarInt at level 6
+2e // offset VarInt
+01 // data follows
+e07a2bb8bb75e5accff266022e1e5e6e7b4d6d943a04faadcf2ab4a22f796ff3 // leaf at 6th level of tree
+01 // nLeaves VarInt at level 7
+16 // offset VarInt
+01 // data follows
+8120cafa17309c0bb0e0ffce835286b3a2dcae48e4497ae2d2b7ced4f051507d // leaf at 7th level of tree
+01 // nLeaves VarInt at level 8
+0a // offset VarInt
+01 // data follows
+502e59ac92f46543c23006bff855d96f5e648043f0fb87a7a5949e6a9bebae43 // leaf at 8th level of tree
+01 // nLeaves VarInt at level 9
+04 // offset VarInt
+01 // data follows
+1ccd9f8f64f4d0489b30cc815351cf425e0e78ad79a589350e4341ac165dbe45 // leaf at 9th level of tree
+01 // nLeaves VarInt at level 10
+03 // offset VarInt
+00 // no data follows
+01 // nLeaves VarInt at level 11
+00 // offset VarInt
+01 // data follows
+af8764ce7e1cc132ab5ed2229a005c87201c9a5ee15c0f91dd53eff31ab30cd4 // leaf at 11th level of tree
+// we know this is the end of the data because the tree height is 12 and there are 11 levels of branches to encode with a Merkle Tree of height of 12
 ```
 
 ## JSON Encoding
@@ -138,7 +139,7 @@ A `*` indicates an absence of a value at this position, and so a duplication of 
 ### JSON Example
 ```json
 {
-  "height": 813706,
+  "blockHeight": 813706,
   "path": [
     {
       "3048": "304e737fdfcb017a1a322e78b067ecebb5e07b44f0a36ed1f01264d2014f7711",

--- a/transactions/0074.md
+++ b/transactions/0074.md
@@ -68,57 +68,57 @@ fe8a6a0c00 // block height VarInt
 01 // nLeaves VarInt at level 11
 00 // offset VarInt
 01 // data follows
-af8764ce7e1cc132ab5ed2229a005c87201c9a5ee15c0f91dd53eff31ab30cd4 // hash at 11th level of tree
+af8764ce7e1cc132ab5ed2229a005c87201c9a5ee15c0f91dd53eff31ab30cd4 // leaf at 11th level of tree
 01 // nLeaves VarInt at level 10
 03 // offset VarInt
 00 // no data follows
 01 // nLeaves VarInt at level 9
 04 // offset VarInt
 01 // data follows
-1ccd9f8f64f4d0489b30cc815351cf425e0e78ad79a589350e4341ac165dbe45 // hash at 9th level of tree
+1ccd9f8f64f4d0489b30cc815351cf425e0e78ad79a589350e4341ac165dbe45 // leaf at 9th level of tree
 01 // nLeaves VarInt at level 8
 0a // offset VarInt
 01 // data follows
-502e59ac92f46543c23006bff855d96f5e648043f0fb87a7a5949e6a9bebae43 // hash at 8th level of tree
+502e59ac92f46543c23006bff855d96f5e648043f0fb87a7a5949e6a9bebae43 // leaf at 8th level of tree
 01 // nLeaves VarInt at level 7
 16 // offset VarInt
 01 // data follows
-8120cafa17309c0bb0e0ffce835286b3a2dcae48e4497ae2d2b7ced4f051507d // hash at 7th level of tree
+8120cafa17309c0bb0e0ffce835286b3a2dcae48e4497ae2d2b7ced4f051507d // leaf at 7th level of tree
 01 // nLeaves VarInt at level 6
 2e // offset VarInt
 01 // data follows
-e07a2bb8bb75e5accff266022e1e5e6e7b4d6d943a04faadcf2ab4a22f796ff3 // hash at 6th level of tree
+e07a2bb8bb75e5accff266022e1e5e6e7b4d6d943a04faadcf2ab4a22f796ff3 // leaf at 6th level of tree
 01 // nLeaves VarInt at level 5
 5e // offset VarInt
 01 // data follows
-5881826eb6973c54003a02118fe270f03d46d02681c8bc71cd44c613e86302f8 // hash at 5th level of tree
+5881826eb6973c54003a02118fe270f03d46d02681c8bc71cd44c613e86302f8 // leaf at 5th level of tree
 01 // nLeaves VarInt at level 4
 bf // offset VarInt
 00 // no data follows
 01 // nLeaves VarInt at level 3
 fd7c01 // offset VarInt (three hundred and eighty)
 01 // data follows
-93b3efca9b77ddec914f8effac691ecb54e2c81d0ab81cbc4c4b93befe418e85 // hash at 3th level of tree
+93b3efca9b77ddec914f8effac691ecb54e2c81d0ab81cbc4c4b93befe418e85 // leaf at 3th level of tree
 01 // nLeaves VarInt at level 2
 fdfb02 // offset VarInt
 00 // data follows
 02 // nLeaves VarInt at level 1
 fdf405 // offset VarInt
 01 // data follows
-0671394f72237d08a4277f4435e5b6edf7adc272f25effef27cdfe805ce71a81 // hash at 1st level of tree
+0671394f72237d08a4277f4435e5b6edf7adc272f25effef27cdfe805ce71a81 // leaf 1 at 1st level of tree
 fdf505 // offset VarInt
 01 // data follows
-262bccabec6c4af3ed00cc7a7414edea9c5efa92fb8623dd6160a001450a5282 // hash at 1st level of tree
+262bccabec6c4af3ed00cc7a7414edea9c5efa92fb8623dd6160a001450a5282 // leaf 2 at 1st level of tree
 04 // nLeaves VarInt at level 0
 fde80b // offset VarInt
 01 // data follows
-11774f01d26412f0d16ea3f0447be0b5ebec67b0782e321a7a01cbdf7f734e30 // hash at 0 level of tree
+11774f01d26412f0d16ea3f0447be0b5ebec67b0782e321a7a01cbdf7f734e30 // leaf 1 at 0 level of tree
 fde90b // offset VarInt
 01 // data follows
-004e53753e3fe4667073063a17987292cfdea278824e9888e52180581d7188d8 // hash at 0 level of tree
+004e53753e3fe4667073063a17987292cfdea278824e9888e52180581d7188d8 // leaf 2 at 0 level of tree
 fdea0b // offset VarInt
 01 // data follows
-5e441996fc53f0191d649e68a200e752fb5f39e0d5617083408fa179ddc5c998 // hash at 0 level of tree
+5e441996fc53f0191d649e68a200e752fb5f39e0d5617083408fa179ddc5c998 // leaf 3 at 0 level of tree
 fdeb0b // offset VarInt
 00 // no data follows
 ```

--- a/transactions/0074.md
+++ b/transactions/0074.md
@@ -44,7 +44,7 @@ Thereafter the number of leaves at the top height is specified, and the leaves f
 | Field                | Description                                                                            |        Size          |
 |----------------------|----------------------------------------------------------------------------------------|----------------------|
 | nLeaves              | `VarInt` number of leaves at this height                                               | 1-9 bytes            |
-| leaves               | Each leaf encoded in the format below.                                                 | nLeaves x 2-42 bytes |
+| leaves               | Each leaf encoded in the format below.                                                 | sum of leaf sizes    |
 
 Once all leaves at this height have been specified, an implied decrement of the height in the tree occurs and we specify the number of leaves in the next level down, and so on until we have specified the leaves at level 0 at which point we stop.  
   

--- a/transactions/0074.md
+++ b/transactions/0074.md
@@ -130,7 +130,7 @@ af8764ce7e1cc132ab5ed2229a005c87201c9a5ee15c0f91dd53eff31ab30cd4 // leaf at 11th
 
 ## JSON Encoding
 
-In the JSON encoding - we start with a height for the whole BUMP. A path Array index corresponds to the height within the Merkle tree, so we start with level 0 which is the txids themselves. Within each array element we contain one or more leaves which are specified as an offset number as the key and a leaf as the value.  
+In the JSON encoding - we start with a height of a block in which transactions from BUMP are mined. A path Array index corresponds to the height within the Merkle tree, so we start with level 0 which is the txids themselves. Within each array element we contain one or more leaves which are specified as an offset number as the key and a leaf as the value.  
 
 `{ [offset]: leaf }` This is to aid in the speed of merkle root calculation, since the offset is given, and so can be used to lookup the corresponding value directly rather than having to iterate through all leaves.  
 

--- a/transactions/0074.md
+++ b/transactions/0074.md
@@ -1,4 +1,4 @@
-# BRC-74: Unified Merkle Path Format
+# BRC-74: BSV Unified Merkle Path (BUMP) Format
 
 Darren Kellenschwiler (deggen@kschw.com), Deggen
 Tone Engel (tone@kizmet.org), TonesNotes
@@ -7,7 +7,7 @@ Damian Orzepowski (damian.orzepowski@4chain.studio)
 
 ## Abstract
 
-We propose a Compound Merkle Path format in both binary and JSON encoding optimized for transmission, storage, and ease of use in a Merkle Proof validation process.
+We propose the BSV Unified Merkle Path format in both binary and JSON encoding optimized for transmission, storage, and ease of use in a Merkle Proof validation process.
 
 ## Copyright
 
@@ -125,7 +125,7 @@ fdeb0b // offset VarInt ()
 
 ## JSON Encoding
 
-In the JSON encoding - we start with a height for the whole UCMP. A path Array index corresponds to the height within the Merkle tree, so we start with level 0 which is the txids themselves. Within each array element we contain one or more leaves which are specified as an offset number as the key and a leaf as the value. { [offset]: leaf }. This is to aid in the speed of merkle root calculation. A `*` indicates an absence of a value at this position, and so a duplication of the working hash should be used in its place as this is at the right hand side of the merkle tree at that level.
+In the JSON encoding - we start with a height for the whole BUMP. A path Array index corresponds to the height within the Merkle tree, so we start with level 0 which is the txids themselves. Within each array element we contain one or more leaves which are specified as an offset number as the key and a leaf as the value. { [offset]: leaf }. This is to aid in the speed of merkle root calculation. A `*` indicates an absence of a value at this position, and so a duplication of the working hash should be used in its place as this is at the right hand side of the merkle tree at that level.
 
 ### JSON Example
 ```json
@@ -176,7 +176,7 @@ In the JSON encoding - we start with a height for the whole UCMP. A path Array i
 }
 ```
 
-## Calculating the Merkle Root from a Unified Compound Merkle Path
+## Calculating the Merkle Root from a BUMP
 
 Let's start by dumping this format as hex into a Buffer and parsing it into an object with a Buffer Reader. Then we can calculate the merkle root from any of the included txids.
 
@@ -191,7 +191,7 @@ const hexRevToBuf = (str) => Buffer.from(str, 'hex').reverse()
 const bufRevToHex = (buf) => Buffer.from(buf.toString('hex'), 'hex').reverse().toString('hex')
 const hash = (str) => bufRevToHex(createHash('sha256').update(createHash('sha256').update(hexRevToBuf(str)).digest()).digest())
 
-function ucmpHexToJSON(str) {
+function bumpHexToJSON(str) {
   const reader = new Br()
   reader.buf = Buffer.from(str, 'hex')
   let height = reader.readVarIntNum()
@@ -221,7 +221,7 @@ function ucmpHexToJSON(str) {
   return { height, path }
 }
 
-function calculateMerkleRootFromCMP(ucmp, txid) {
+function calculateMerkleRootFromBUMP(ucmp, txid) {
   // Find the index of the txid at the lowest level of the Merkle tree
   let index
   for (let i in ucmp.path[0]) {
@@ -246,9 +246,9 @@ function calculateMerkleRootFromCMP(ucmp, txid) {
 }
 
 
-const ucmp = ucmpHexToJSON('fe8a6a0c000b010001af8764ce7e1cc132ab5ed2229a005c87201c9a5ee15c0f91dd53eff31ab30cd40103000104011ccd9f8f64f4d0489b30cc815351cf425e0e78ad79a589350e4341ac165dbe45010a01502e59ac92f46543c23006bff855d96f5e648043f0fb87a7a5949e6a9bebae430116018120cafa17309c0bb0e0ffce835286b3a2dcae48e4497ae2d2b7ced4f051507d012e01e07a2bb8bb75e5accff266022e1e5e6e7b4d6d943a04faadcf2ab4a22f796ff3015e015881826eb6973c54003a02118fe270f03d46d02681c8bc71cd44c613e86302f801bf0001fd7c010193b3efca9b77ddec914f8effac691ecb54e2c81d0ab81cbc4c4b93befe418e8501fdfb020002fdf405010671394f72237d08a4277f4435e5b6edf7adc272f25effef27cdfe805ce71a81fdf50501262bccabec6c4af3ed00cc7a7414edea9c5efa92fb8623dd6160a001450a528204fde80b0111774f01d26412f0d16ea3f0447be0b5ebec67b0782e321a7a01cbdf7f734e30fde90b01004e53753e3fe4667073063a17987292cfdea278824e9888e52180581d7188d8fdea0b015e441996fc53f0191d649e68a200e752fb5f39e0d5617083408fa179ddc5c998fdeb0b00')
+const bump = bumpHexToJSON('fe8a6a0c000b010001af8764ce7e1cc132ab5ed2229a005c87201c9a5ee15c0f91dd53eff31ab30cd40103000104011ccd9f8f64f4d0489b30cc815351cf425e0e78ad79a589350e4341ac165dbe45010a01502e59ac92f46543c23006bff855d96f5e648043f0fb87a7a5949e6a9bebae430116018120cafa17309c0bb0e0ffce835286b3a2dcae48e4497ae2d2b7ced4f051507d012e01e07a2bb8bb75e5accff266022e1e5e6e7b4d6d943a04faadcf2ab4a22f796ff3015e015881826eb6973c54003a02118fe270f03d46d02681c8bc71cd44c613e86302f801bf0001fd7c010193b3efca9b77ddec914f8effac691ecb54e2c81d0ab81cbc4c4b93befe418e8501fdfb020002fdf405010671394f72237d08a4277f4435e5b6edf7adc272f25effef27cdfe805ce71a81fdf50501262bccabec6c4af3ed00cc7a7414edea9c5efa92fb8623dd6160a001450a528204fde80b0111774f01d26412f0d16ea3f0447be0b5ebec67b0782e321a7a01cbdf7f734e30fde90b01004e53753e3fe4667073063a17987292cfdea278824e9888e52180581d7188d8fdea0b015e441996fc53f0191d649e68a200e752fb5f39e0d5617083408fa179ddc5c998fdeb0b00')
 
-calculateMerkleRootFromCMP(ucmp, '304e737fdfcb017a1a322e78b067ecebb5e07b44f0a36ed1f01264d2014f7711') // '57aab6e6fb1b697174ffb64e062c4728f2ffd33ddcfa02a43b64d8cd29b483b4'
-calculateMerkleRootFromCMP(ucmp, 'd888711d588021e588984e8278a2decf927298173a06737066e43f3e75534e00') // '57aab6e6fb1b697174ffb64e062c4728f2ffd33ddcfa02a43b64d8cd29b483b4'
-calculateMerkleRootFromCMP(ucmp, '98c9c5dd79a18f40837061d5e0395ffb52e700a2689e641d19f053fc9619445e') // '57aab6e6fb1b697174ffb64e062c4728f2ffd33ddcfa02a43b64d8cd29b483b4'
+calculateMerkleRootFromBUMP(bump, '304e737fdfcb017a1a322e78b067ecebb5e07b44f0a36ed1f01264d2014f7711') // '57aab6e6fb1b697174ffb64e062c4728f2ffd33ddcfa02a43b64d8cd29b483b4'
+calculateMerkleRootFromBUMP(bump, 'd888711d588021e588984e8278a2decf927298173a06737066e43f3e75534e00') // '57aab6e6fb1b697174ffb64e062c4728f2ffd33ddcfa02a43b64d8cd29b483b4'
+calculateMerkleRootFromBUMP(bump, '98c9c5dd79a18f40837061d5e0395ffb52e700a2689e641d19f053fc9619445e') // '57aab6e6fb1b697174ffb64e062c4728f2ffd33ddcfa02a43b64d8cd29b483b4'
 ```

--- a/transactions/0074.md
+++ b/transactions/0074.md
@@ -288,12 +288,12 @@ A note on compounding multiple BUMPs together. The first check should always be 
 
 ```javascript
 function combinePaths(one, two) {
-  if (one.height !== two.height) throw Error('You cannot combine paths which do not have the same height.')
+  if (one.height !== two.height) throw new Error('You cannot combine paths which do not have the same height.')
   const txid1 = Object.keys(one.path[0])[0]
   const root1 = calculateMerkleRootFromBUMP(one, one.path[0][txid1])
   const txid2 = Object.keys(two.path[0])[0]
   const root2 = calculateMerkleRootFromBUMP(two, two.path[0][txid2])
-  if (root1 !== root2) throw Error('You cannot combine paths which do not have the same root.')
+  if (root1 !== root2) throw new Error('You cannot combine paths which do not have the same root.')
   const combinedPath = []
   for (let h = 0; h < one.path.length; h++) {
     combinedPath.push({ ...one.path[h], ...two.path[h] })

--- a/transactions/0074.md
+++ b/transactions/0074.md
@@ -63,70 +63,81 @@ Each leaf follows the format below:
 
 ### Hex Example
 ```
-fe8a6a0c000c04fde80b0111774f01d26412f0d16ea3f0447be0b5ebec67b0782e321a7a01cbdf7f734e30fde90b01004e53753e3fe4667073063a17987292cfdea278824e9888e52180581d7188d8fdea0b015e441996fc53f0191d649e68a200e752fb5f39e0d5617083408fa179ddc5c998fdeb0b0002fdf405010671394f72237d08a4277f4435e5b6edf7adc272f25effef27cdfe805ce71a81fdf50501262bccabec6c4af3ed00cc7a7414edea9c5efa92fb8623dd6160a001450a528201fdfb020001fd7c010193b3efca9b77ddec914f8effac691ecb54e2c81d0ab81cbc4c4b93befe418e8501bf00015e015881826eb6973c54003a02118fe270f03d46d02681c8bc71cd44c613e86302f8012e01e07a2bb8bb75e5accff266022e1e5e6e7b4d6d943a04faadcf2ab4a22f796ff30116018120cafa17309c0bb0e0ffce835286b3a2dcae48e4497ae2d2b7ced4f051507d010a01502e59ac92f46543c23006bff855d96f5e648043f0fb87a7a5949e6a9bebae430104011ccd9f8f64f4d0489b30cc815351cf425e0e78ad79a589350e4341ac165dbe45010300010001af8764ce7e1cc132ab5ed2229a005c87201c9a5ee15c0f91dd53eff31ab30cd4
+fe8a6a0c000c04fde80b0011774f01d26412f0d16ea3f0447be0b5ebec67b0782e321a7a01cbdf7f734e30fde90b02004e53753e3fe4667073063a17987292cfdea278824e9888e52180581d7188d8fdea0b025e441996fc53f0191d649e68a200e752fb5f39e0d5617083408fa179ddc5c998fdeb0b0102fdf405000671394f72237d08a4277f4435e5b6edf7adc272f25effef27cdfe805ce71a81fdf50500262bccabec6c4af3ed00cc7a7414edea9c5efa92fb8623dd6160a001450a528201fdfb020101fd7c010093b3efca9b77ddec914f8effac691ecb54e2c81d0ab81cbc4c4b93befe418e8501bf01015e005881826eb6973c54003a02118fe270f03d46d02681c8bc71cd44c613e86302f8012e00e07a2bb8bb75e5accff266022e1e5e6e7b4d6d943a04faadcf2ab4a22f796ff30116008120cafa17309c0bb0e0ffce835286b3a2dcae48e4497ae2d2b7ced4f051507d010a00502e59ac92f46543c23006bff855d96f5e648043f0fb87a7a5949e6a9bebae430104001ccd9f8f64f4d0489b30cc815351cf425e0e78ad79a589350e4341ac165dbe45010301010000af8764ce7e1cc132ab5ed2229a005c87201c9a5ee15c0f91dd53eff31ab30cd4
 ```
 
 ### Bytewise Breakdown
 ```javascript
-fe8a6a0c00 // block height VarInt
-0c // 1 byte tree height (twelve)
-04 // nLeaves VarInt at level 0
-fde80b // offset VarInt
-01 // data follows
-11774f01d26412f0d16ea3f0447be0b5ebec67b0782e321a7a01cbdf7f734e30 // leaf 1 at 0 level of tree
+fe8a6a0c00 // blockHeight (813706), VarInt
+0c // treeHeight (12), byte
+// Level 0, client TXIDs and sibling TXIDs (TXIDs required only to compute internal tree hash).
+04 // nLeaves, VarInt
+fde80b // offset, VarInt
+00 // flags
+11774f01d26412f0d16ea3f0447be0b5ebec67b0782e321a7a01cbdf7f734e30 // hash
 fde90b // offset VarInt
-01 // data follows
-004e53753e3fe4667073063a17987292cfdea278824e9888e52180581d7188d8 // leaf 2 at 0 level of tree
+02 // flags = CLIENT_TXID
+004e53753e3fe4667073063a17987292cfdea278824e9888e52180581d7188d8 // hash
 fdea0b // offset VarInt
-01 // data follows
-5e441996fc53f0191d649e68a200e752fb5f39e0d5617083408fa179ddc5c998 // leaf 3 at 0 level of tree
+02 // flags = CLIENT_TXID
+5e441996fc53f0191d649e68a200e752fb5f39e0d5617083408fa179ddc5c998 // hash
 fdeb0b // offset VarInt
-00 // no data follows
-02 // nLeaves VarInt at level 1
-fdf405 // offset VarInt
-01 // data follows
-0671394f72237d08a4277f4435e5b6edf7adc272f25effef27cdfe805ce71a81 // leaf 1 at 1st level of tree
+01 // flags = DUPLICATE_WORKING_HASH
+// Level 1, internal merkle tree hashes
+02 // nLeaves, VarInt
+fdf405 // offset, VarInt
+00 // flags
+0671394f72237d08a4277f4435e5b6edf7adc272f25effef27cdfe805ce71a81 // hash
 fdf505 // offset VarInt
-01 // data follows
-262bccabec6c4af3ed00cc7a7414edea9c5efa92fb8623dd6160a001450a5282 // leaf 2 at 1st level of tree
+00 // flags
+262bccabec6c4af3ed00cc7a7414edea9c5efa92fb8623dd6160a001450a5282 // hash
+// Level 2, internal merkle tree hashes
 01 // nLeaves VarInt at level 2
 fdfb02 // offset VarInt
-00 // no data follows
+01 // flags = DUPLICATE_WORKING_HASH
+// Level 3, internal merkle tree hashes
 01 // nLeaves VarInt at level 3
 fd7c01 // offset VarInt (three hundred and eighty)
-01 // data follows
-93b3efca9b77ddec914f8effac691ecb54e2c81d0ab81cbc4c4b93befe418e85 // leaf at 3th level of tree
+00 // flags
+93b3efca9b77ddec914f8effac691ecb54e2c81d0ab81cbc4c4b93befe418e85 // hash
+// Level 4, internal merkle tree hashes
 01 // nLeaves VarInt at level 4
 bf // offset VarInt
-00 // no data follows
+01 // flags = DUPLICATE_WORKING_HASH
+// Level 5, internal merkle tree hashes
 01 // nLeaves VarInt at level 5
 5e // offset VarInt
-01 // data follows
-5881826eb6973c54003a02118fe270f03d46d02681c8bc71cd44c613e86302f8 // leaf at 5th level of tree
+00 // flags
+5881826eb6973c54003a02118fe270f03d46d02681c8bc71cd44c613e86302f8 // hash
+// Level 6, internal merkle tree hashes
 01 // nLeaves VarInt at level 6
 2e // offset VarInt
-01 // data follows
-e07a2bb8bb75e5accff266022e1e5e6e7b4d6d943a04faadcf2ab4a22f796ff3 // leaf at 6th level of tree
+00 // flags
+e07a2bb8bb75e5accff266022e1e5e6e7b4d6d943a04faadcf2ab4a22f796ff3 // hash
+// Level 7, internal merkle tree hashes
 01 // nLeaves VarInt at level 7
 16 // offset VarInt
-01 // data follows
-8120cafa17309c0bb0e0ffce835286b3a2dcae48e4497ae2d2b7ced4f051507d // leaf at 7th level of tree
+00 // flags
+8120cafa17309c0bb0e0ffce835286b3a2dcae48e4497ae2d2b7ced4f051507d // hash
+// Level 8, internal merkle tree hashes
 01 // nLeaves VarInt at level 8
 0a // offset VarInt
-01 // data follows
-502e59ac92f46543c23006bff855d96f5e648043f0fb87a7a5949e6a9bebae43 // leaf at 8th level of tree
+00 // flags
+502e59ac92f46543c23006bff855d96f5e648043f0fb87a7a5949e6a9bebae43 // hash
+// Level 9, internal merkle tree hashes
 01 // nLeaves VarInt at level 9
 04 // offset VarInt
-01 // data follows
-1ccd9f8f64f4d0489b30cc815351cf425e0e78ad79a589350e4341ac165dbe45 // leaf at 9th level of tree
+00 // flags
+1ccd9f8f64f4d0489b30cc815351cf425e0e78ad79a589350e4341ac165dbe45 // hash
+// Level 10, internal merkle tree hashes
 01 // nLeaves VarInt at level 10
 03 // offset VarInt
-00 // no data follows
+01 // flags = DUPLICATE_WORKING_HASH
+// Level 11, internal merkle tree hashes
 01 // nLeaves VarInt at level 11
 00 // offset VarInt
-01 // data follows
-af8764ce7e1cc132ab5ed2229a005c87201c9a5ee15c0f91dd53eff31ab30cd4 // leaf at 11th level of tree
-// we know this is the end of the data because the tree height is 12 and there are 11 levels of branches to encode with a Merkle Tree of height of 12
+00 // flags
+af8764ce7e1cc132ab5ed2229a005c87201c9a5ee15c0f91dd53eff31ab30cd4 // hash
 ```
 
 ## JSON Encoding
@@ -143,44 +154,78 @@ A `*` indicates an absence of a value at this position, and so a duplication of 
   "blockHeight": 813706,
   "path": [
     {
-      "3048": "304e737fdfcb017a1a322e78b067ecebb5e07b44f0a36ed1f01264d2014f7711",
-      "3049": "d888711d588021e588984e8278a2decf927298173a06737066e43f3e75534e00",
-      "3050": "98c9c5dd79a18f40837061d5e0395ffb52e700a2689e641d19f053fc9619445e",
-      "3051": "*"
+      "3048": {
+        "hash": "304e737fdfcb017a1a322e78b067ecebb5e07b44f0a36ed1f01264d2014f7711"
+      },
+      "3049": {
+        "txid": true,
+        "hash": "d888711d588021e588984e8278a2decf927298173a06737066e43f3e75534e00"
+      },
+      "3050": {
+        "txid": true,
+        "hash": "98c9c5dd79a18f40837061d5e0395ffb52e700a2689e641d19f053fc9619445e"
+      },
+      "3051": {
+        "duplicate": true
+      }
     },
     {
-      "1524": "811ae75c80fecd27efff5ef272c2adf7edb6e535447f27a4087d23724f397106",
-      "1525": "82520a4501a06061dd2386fb92fa5e9ceaed14747acc00edf34a6cecabcc2b26"
+      "1524": {
+        "hash": "811ae75c80fecd27efff5ef272c2adf7edb6e535447f27a4087d23724f397106"
+      },
+      "1525": {
+        "hash": "82520a4501a06061dd2386fb92fa5e9ceaed14747acc00edf34a6cecabcc2b26"
+      }
     },
     {
-      "763": "*"
+      "763": {
+        "duplicate": true
+      }
     },
     {
-      "380": "858e41febe934b4cbc1cb80a1dc8e254cb1e69acff8e4f91ecdd779bcaefb393"
+      "380": {
+        "hash": "858e41febe934b4cbc1cb80a1dc8e254cb1e69acff8e4f91ecdd779bcaefb393"
+      }
     },
     {
-      "191": "*"
+      "191": {
+        "duplicate": true
+      }
     },
     {
-      "94": "f80263e813c644cd71bcc88126d0463df070e28f11023a00543c97b66e828158"
+      "94": {
+        "hash": "f80263e813c644cd71bcc88126d0463df070e28f11023a00543c97b66e828158"
+      }
     },
     {
-      "46": "f36f792fa2b42acfadfa043a946d4d7b6e5e1e2e0266f2cface575bbb82b7ae0"
+      "46": {
+        "hash": "f36f792fa2b42acfadfa043a946d4d7b6e5e1e2e0266f2cface575bbb82b7ae0"
+      }
     },
     {
-      "22": "7d5051f0d4ceb7d2e27a49e448aedca2b3865283ceffe0b00b9c3017faca2081"
+      "22": {
+        "hash": "7d5051f0d4ceb7d2e27a49e448aedca2b3865283ceffe0b00b9c3017faca2081"
+      }
     },
     {
-      "10": "43aeeb9b6a9e94a5a787fbf04380645e6fd955f8bf0630c24365f492ac592e50"
+      "10": {
+        "hash": "43aeeb9b6a9e94a5a787fbf04380645e6fd955f8bf0630c24365f492ac592e50"
+      }
     },
     {
-      "4": "45be5d16ac41430e3589a579ad780e5e42cf515381cc309b48d0f4648f9fcd1c"
+      "4": {
+        "hash": "45be5d16ac41430e3589a579ad780e5e42cf515381cc309b48d0f4648f9fcd1c"
+      }
     },
     {
-      "3": "*"
+      "3": {
+        "duplicate": true
+      }
     },
     {
-      "0": "d40cb31af3ef53dd910f5ce15e9a1c20875c009a22d25eab32c11c7ece6487af"
+      "0": {
+        "hash": "d40cb31af3ef53dd910f5ce15e9a1c20875c009a22d25eab32c11c7ece6487af"
+      }
     }
   ]
 }
@@ -207,18 +252,20 @@ function bumpHexToJSON(str) {
   let blockHeight = reader.readVarIntNum()
   let treeHeight = parseInt(reader.read(1).toString('hex'), 16)
   let path = Array(treeHeight).fill(0).map(() => ({}))
-  let flag, offset, hash, nLeavesAtThisHeight
+  let flags, offset, nLeavesAtThisHeight
   for (let level = 0; level < treeHeight; level++) {
     nLeavesAtThisHeight = reader.readVarIntNum()
     while (nLeavesAtThisHeight) {
       offset = reader.readVarIntNum()
-      flag = parseInt(reader.read(1).toString('hex'), 16)
-      if (flag) {
-        hash = reader.read(32).reverse().toString('hex')
+      flags = parseInt(reader.read(1).toString('hex'), 16)
+      const leaf = {}
+      if (flags & 1) {
+        leaf.duplicate = true
       } else {
-        hash = '*'
+        if (flags & 2) leaf.txid = true
+        leaf.hash = reader.read(32).reverse().toString('hex')
       }
-      path[level][offset] = hash
+      path[level][offset] = leaf
       nLeavesAtThisHeight--
     }
   }
@@ -233,17 +280,15 @@ function bumpJSONtoHex({ blockHeight, path }) {
   for (let level = 0; level < treeHeight; level++) {
     let nLeaves = Object.keys(path[level]).length
     bw.writeVarIntNum(nLeaves)
-    for (const leaf in path[level]) {
-      // offset
-      bw.writeVarIntNum(Number(leaf))
-      const value = path[level][leaf]
-      // flag
-      if (value === '*') {
-        bw.writeUInt8(0)
-      } else {
-        bw.writeUInt8(1)
-        bw.write(hexRevToBuf(value))
-      }
+    for (const offset in path[level]) {
+      bw.writeVarIntNum(Number(offset))
+      const leaf = path[level][offset]
+      let flags = 0
+      if (!!leaf?.duplicate) flags |= 1
+      if (!!leaf?.txid) flags |= 2
+      bw.writeUInt8(flags)
+      if ((flags & 1) === 0)
+        bw.write(hexRevToBuf(leaf["hash"]))
     }
   }
   return bw.toBuffer().toString('hex')
@@ -252,8 +297,8 @@ function bumpJSONtoHex({ blockHeight, path }) {
 function calculateMerkleRootFromBUMP(bump, txid) {
   // Find the index of the txid at the lowest level of the Merkle tree
   let index
-  for (let i in bump.path[0]) {
-    if (txid === bump.path[0][i]) index = Number(i)
+  for (const leaf in bump.path[0]) {
+    if (bump.path[0][leaf].hash === txid) index = leaf
   }
   if (!index) throw Error(`The BUMP does not contain the txid: ${txid}`)
   // Calculate the root using the index as a way to determine which direction to concatenate.
@@ -262,19 +307,19 @@ function calculateMerkleRootFromBUMP(bump, txid) {
     const offset = index >> height ^ 1
     const leaf = leaves[offset]
     if (!leaf) throw new Error(`We do not have a hash for this index at height: ${height}`)
-    if (leaf === '*') {
+    if (leaf.duplicate) {
       workingHash = hash(workingHash + workingHash)
     } else if (offset % 2) {
-      workingHash = hash(leaf + workingHash)
+      workingHash = hash(leaf['hash'] + workingHash)
     } else {
-      workingHash = hash(workingHash + leaf)
+      workingHash = hash(workingHash + leaf['hash'])
     }
   })
   return workingHash
 }
 
 
-const bump = bumpHexToJSON('fe8a6a0c000b010001af8764ce7e1cc132ab5ed2229a005c87201c9a5ee15c0f91dd53eff31ab30cd40103000104011ccd9f8f64f4d0489b30cc815351cf425e0e78ad79a589350e4341ac165dbe45010a01502e59ac92f46543c23006bff855d96f5e648043f0fb87a7a5949e6a9bebae430116018120cafa17309c0bb0e0ffce835286b3a2dcae48e4497ae2d2b7ced4f051507d012e01e07a2bb8bb75e5accff266022e1e5e6e7b4d6d943a04faadcf2ab4a22f796ff3015e015881826eb6973c54003a02118fe270f03d46d02681c8bc71cd44c613e86302f801bf0001fd7c010193b3efca9b77ddec914f8effac691ecb54e2c81d0ab81cbc4c4b93befe418e8501fdfb020002fdf405010671394f72237d08a4277f4435e5b6edf7adc272f25effef27cdfe805ce71a81fdf50501262bccabec6c4af3ed00cc7a7414edea9c5efa92fb8623dd6160a001450a528204fde80b0111774f01d26412f0d16ea3f0447be0b5ebec67b0782e321a7a01cbdf7f734e30fde90b01004e53753e3fe4667073063a17987292cfdea278824e9888e52180581d7188d8fdea0b015e441996fc53f0191d649e68a200e752fb5f39e0d5617083408fa179ddc5c998fdeb0b00')
+const bump = bumpHexToJSON('fe8a6a0c000c04fde80b0011774f01d26412f0d16ea3f0447be0b5ebec67b0782e321a7a01cbdf7f734e30fde90b02004e53753e3fe4667073063a17987292cfdea278824e9888e52180581d7188d8fdea0b025e441996fc53f0191d649e68a200e752fb5f39e0d5617083408fa179ddc5c998fdeb0b0102fdf405000671394f72237d08a4277f4435e5b6edf7adc272f25effef27cdfe805ce71a81fdf50500262bccabec6c4af3ed00cc7a7414edea9c5efa92fb8623dd6160a001450a528201fdfb020101fd7c010093b3efca9b77ddec914f8effac691ecb54e2c81d0ab81cbc4c4b93befe418e8501bf01015e005881826eb6973c54003a02118fe270f03d46d02681c8bc71cd44c613e86302f8012e00e07a2bb8bb75e5accff266022e1e5e6e7b4d6d943a04faadcf2ab4a22f796ff30116008120cafa17309c0bb0e0ffce835286b3a2dcae48e4497ae2d2b7ced4f051507d010a00502e59ac92f46543c23006bff855d96f5e648043f0fb87a7a5949e6a9bebae430104001ccd9f8f64f4d0489b30cc815351cf425e0e78ad79a589350e4341ac165dbe45010301010000af8764ce7e1cc132ab5ed2229a005c87201c9a5ee15c0f91dd53eff31ab30cd4')
 
 calculateMerkleRootFromBUMP(bump, '304e737fdfcb017a1a322e78b067ecebb5e07b44f0a36ed1f01264d2014f7711') // '57aab6e6fb1b697174ffb64e062c4728f2ffd33ddcfa02a43b64d8cd29b483b4'
 calculateMerkleRootFromBUMP(bump, 'd888711d588021e588984e8278a2decf927298173a06737066e43f3e75534e00') // '57aab6e6fb1b697174ffb64e062c4728f2ffd33ddcfa02a43b64d8cd29b483b4'
@@ -288,16 +333,20 @@ A note on compounding multiple BUMPs together. The first check should always be 
 
 ```javascript
 function combinePaths(one, two) {
-  if (one.height !== two.height) throw new Error('You cannot combine paths which do not have the same height.')
-  const txid1 = Object.keys(one.path[0])[0]
-  const root1 = calculateMerkleRootFromBUMP(one, one.path[0][txid1])
-  const txid2 = Object.keys(two.path[0])[0]
-  const root2 = calculateMerkleRootFromBUMP(two, two.path[0][txid2])
-  if (root1 !== root2) throw new Error('You cannot combine paths which do not have the same root.')
+  if (one.blockHeight !== two.blockHeight) throw Error('You cannot combine paths which do not have the same blockHeight.')
+  const txid1 = one.path[0][Object.keys(one.path[0])[0]].hash
+  const root1 = calculateMerkleRootFromBUMP(one, txid1)
+  const txid2 = two.path[0][Object.keys(two.path[0])[0]].hash
+  const root2 = calculateMerkleRootFromBUMP(two, txid2)
+  if (root1 !== root2) throw Error('You cannot combine paths which do not have the same root.')
   const combinedPath = []
   for (let h = 0; h < one.path.length; h++) {
     combinedPath.push({ ...one.path[h], ...two.path[h] })
   }
-  return { height: one.height, path: combinedPath }
+  // Ensure that any elements which appear in both are not downgraded to a non txid.
+  for (const leaf in one.path[0]) {
+      if (one.path[0][leaf].txid) combinedPath[0][leaf].txid = true
+  }
+  return { blockHeight: one.blockHeight, path: combinedPath }
 }
 ```

--- a/transactions/0074.md
+++ b/transactions/0074.md
@@ -277,3 +277,26 @@ calculateMerkleRootFromBUMP(bump, 'd888711d588021e588984e8278a2decf927298173a067
 calculateMerkleRootFromBUMP(bump, '98c9c5dd79a18f40837061d5e0395ffb52e700a2689e641d19f053fc9619445e') // '57aab6e6fb1b697174ffb64e062c4728f2ffd33ddcfa02a43b64d8cd29b483b4'
 bumpJSONtoHex(bump)
 ```
+
+## Merging
+
+A note on compounding multiple BUMPs together. The first check should always be the height - ensure it matches. The second check is the root. Each BUMP calculates its root, and if they don't match - you cannot combine them. If they  match then the process is a simple inclusion of all leaves, dropping duplicates.
+
+```javascript
+function combinePaths(one, two) {
+  if (one.height !== two.height) throw Error('You cannot combine paths which do not have the same height.')
+  const txid1 = Object.keys(one.path[0])[0]
+  const root1 = calculateMerkleRootFromBUMP(one, one.path[0][txid1])
+  const txid2 = Object.keys(two.path[0])[0]
+  const root2 = calculateMerkleRootFromBUMP(two, two.path[0][txid2])
+  if (root1 !== root2) throw Error('You cannot combine paths which do not have the same root.')
+  const combinedPath = []
+  for (let h = 0; h < one.path.length; h++) {
+    const all = new Set()
+    Object.keys(one.path[h]).map(leaf => all.add({ [leaf]: one.path[h][leaf] }))
+    Object.keys(two.path[h]).map(leaf => all.add({ [leaf]: two.path[h][leaf] }))
+    combinedPath.push(Array.from(all).reduce((a, b) => ({ ...a, ...b })))
+  }
+  return { height: one.height, path: combinedPath }
+}
+```

--- a/transactions/0074.md
+++ b/transactions/0074.md
@@ -7,7 +7,11 @@ Damian Orzepowski (damian.orzepowski@4chain.studio)
 
 ## Abstract
 
-We propose the BSV Unified Merkle Path format in both binary and JSON encoding optimized for transmission, storage, and ease of use in a Merkle Proof validation process.
+We propose the BSV Unified Merkle Path format in both binary and JSON encoding optimized for generation by transaction processors, and also happens to be convenient for proof validating clients.  
+
+At a high level the format encodes a number of txids which all exist within one particular block, along with each of their merkle paths and the blockHeight.  
+
+The blockHeight is encoded first, followed by level 0 of the Merkle tree, which includes the txids of interest, and their corresponding siblings. Thereafter we encode each level of the tree thereafter, but only include branches of the tree which are required to calculate the Merkle root the txids which are of interest to us. For example if we only have one txid of interest, we will include it and its sibling, followed by one leaf per level of the tree.  
 
 ## Copyright
 
@@ -15,7 +19,7 @@ This BRC is licensed under the Open BSV license.
 
 ## Motivation
 
-Several formats have made their own improvements to the original format which was returned by a Bitcoin node via json-rpc method `getmerkleproof`.
+Several formats have made their own improvements to the original format which was returned by a Bitcoin node via json-rpc method `getmerkleproof`.  
 
 Improvements include:
 - [BRC-10](./0010.md) a TSC creation which was subsequently returned by the node's json-rpc method `getmerkleproof2`

--- a/transactions/0074.md
+++ b/transactions/0074.md
@@ -182,7 +182,7 @@ Let's start by dumping this format as hex into a Buffer and parsing it into an o
 
 ```javascript
 const { createHash } = require('crypto')
-const { Br } = require('bsv')
+const { Br, Bw } = require('bsv')
 
 // Displaying hashes as hex strings in reverse byte order is a matter of convention with respect to txids. 
 // The functions below handle the conversions such that when we "hash()" something, we are running sha256 - 
@@ -221,6 +221,30 @@ function bumpHexToJSON(str) {
   return { height, path }
 }
 
+function bumpJSONtoHex({ height, path }) {
+  const bw = new Bw()
+  bw.writeVarIntNum(height)
+  let treeHeight = path.length - 1
+  bw.writeUInt8(treeHeight)
+  for (treeHeight; treeHeight >= 0; treeHeight--) {
+    let nLeaves = Object.keys(path[treeHeight]).length
+    bw.writeVarIntNum(nLeaves)
+    for (const leaf in path[treeHeight]) {
+      // offset
+      bw.writeVarIntNum(Number(leaf))
+      const value = path[treeHeight][leaf]
+      // flag
+      if (value === '*') {
+        bw.writeUInt8(0)
+      } else {
+        bw.writeUInt8(1)
+        bw.write(hexRevToBuf(value))
+      }
+    }
+  }
+  return bw.toBuffer().toString('hex')
+}
+
 function calculateMerkleRootFromBUMP(bump, txid) {
   // Find the index of the txid at the lowest level of the Merkle tree
   let index
@@ -251,4 +275,5 @@ const bump = bumpHexToJSON('fe8a6a0c000b010001af8764ce7e1cc132ab5ed2229a005c8720
 calculateMerkleRootFromBUMP(bump, '304e737fdfcb017a1a322e78b067ecebb5e07b44f0a36ed1f01264d2014f7711') // '57aab6e6fb1b697174ffb64e062c4728f2ffd33ddcfa02a43b64d8cd29b483b4'
 calculateMerkleRootFromBUMP(bump, 'd888711d588021e588984e8278a2decf927298173a06737066e43f3e75534e00') // '57aab6e6fb1b697174ffb64e062c4728f2ffd33ddcfa02a43b64d8cd29b483b4'
 calculateMerkleRootFromBUMP(bump, '98c9c5dd79a18f40837061d5e0395ffb52e700a2689e641d19f053fc9619445e') // '57aab6e6fb1b697174ffb64e062c4728f2ffd33ddcfa02a43b64d8cd29b483b4'
+bumpJSONtoHex(bump)
 ```

--- a/transactions/README.md
+++ b/transactions/README.md
@@ -16,4 +16,4 @@ BRC | Standard
 62   | [Background Evaluation Extended Format (BEEF) Transactions](./0062.md)
 67   | [Simplified Payment Verification](./0067.md)
 71   | [Merkle Path Binary Format](./0071.md)
-74   | [Unified Merkle Path Format](./0074.md)
+74   | [BSV Unified Merkle Path (BUMP) Format](./0074.md)

--- a/transactions/README.md
+++ b/transactions/README.md
@@ -16,4 +16,4 @@ BRC | Standard
 62   | [Background Evaluation Extended Format (BEEF) Transactions](./0062.md)
 67   | [Simplified Payment Verification](./0067.md)
 71   | [Merkle Path Binary Format](./0071.md)
-71   | [Unified Merkle Path Format](./0074.md)
+74   | [Unified Merkle Path Format](./0074.md)

--- a/transactions/README.md
+++ b/transactions/README.md
@@ -16,3 +16,4 @@ BRC | Standard
 62   | [Background Evaluation Extended Format (BEEF) Transactions](./0062.md)
 67   | [Simplified Payment Verification](./0067.md)
 71   | [Merkle Path Binary Format](./0071.md)
+71   | [Unified Merkle Path Format](./0074.md)


### PR DESCRIPTION
### This pull request:

Proposes a new standard by creating a new markdown file in the appropriate directory and requests discussion and assignment of a BRC number

### Summary

This is a proposal for a new unified compound merkle path format which supersedes all historic formats, capturing the best of each proposal and unifying them into one standard to allow compound proofs, with a binary and json encoding, with all necessary data for optimal storage and transport, without compromise. 
