### PR TITLE
BRC-84 linked keys derivation schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ BRC | Standard
 81   | [Private Overlays with P2PKH Transactions](./overlays/0081.md)
 82   | [Defining a Scalable IPv6 Multicast Protocol for Blockchain Transaction Broadcast and Update Delivery](./peer-to-peer/0082.md)
 83   | [Scalable Transaction Processing in the BSV Network](./transactions/0083.md)
-84   | [Proven Identity Key Exchange (PIKE)](./peer-to-peer/0084.md)
+84   | [Linked Key Derivation Scheme](./key-derivation/0084.md)
+85   | [Proven Identity Key Exchange (PIKE)](./peer-to-peer/0085.md)
 
 ## License
 

--- a/key-derivation/0084.md
+++ b/key-derivation/0084.md
@@ -1,4 +1,4 @@
-# Linked Key Derivation Scheme
+# BRC-84: Linked Key Derivation Scheme
 
 Damian Orzepowski (damian.orzepowski@4chain.studio)
 

--- a/key-derivation/0084.md
+++ b/key-derivation/0084.md
@@ -1,0 +1,51 @@
+# Linked Key Derivation Scheme
+
+Damian Orzepowski (damian.orzepowski@4chain.studio)
+
+### Abstract
+The Linked Key Derivation Scheme builds on and extends the "type 42" key derivation method. This scheme allows public key derivation using only the public keys of both parties, maintaining the flexibility and unlimited key derivation of type 42. It aims to enable non-custodial wallets to derive public keys from a master public key without private key access, while only the master private key owner can derive the corresponding private key.
+
+### Motivation
+The primary goal of this scheme is to enhance privacy and scalability in key derivation processes, enabling public key derivation based solely on the public keys of involved parties. Additionally, it ensures that the derived keys are linked back to their master keys, providing a mechanism for auditing and confirming the parties involved in transactions. This supports applications such as non-custodial wallets, ensuring secure and verifiable transactions without the need for private key access during the derivation process.
+
+### Identity Keys
+The assumptions regarding identity keys remain unchanged from type 42. Each party has a master key pair, where the master public key is used to derive linked public keys. This ensures that the derived keys are linked back to the master key without requiring the master private key during the public key derivation process.
+
+### Security Considerations
+The Linked Key Derivation Scheme maintains similar security properties to type 42, with the notable exception that no shared secret is generated or utilized. The scheme ensures that only the owner of the master private key can derive the corresponding linked private key, while public key derivation remains secure and private.
+
+### Key Derivation Process
+
+#### Public Key Derivation:
+
+```mermaid
+flowchart
+    A["Master Public Key (masterPubKey)"] --> B["HMAC(message = InvoiceNumber, key = Serialized Counterparty Public Key)"]
+    B --> C[h = HMAC as big number]
+    C --> D["H = h * G (Elliptic Curve Point)"]
+    D --> E["LPK = masterPubKey + H (Derived Linked Public Key)"]
+```
+
+1. Generate HMAC from the invoice number using the serialized public key as the key.
+2. Convert the HMAC to a scalar using big-endian encoding.
+3. Multiply the generator point \( G \) by this scalar to obtain a point on the elliptic curve.
+4. Add this point to the master public key (also expressed as a point) to get a new point on the elliptic curve.
+5. This new point represents the derived linked child public key.
+
+
+#### Private Key Derivation:
+
+```mermaid
+flowchart
+    A["Master Private Key (masterPrivKey)"] --> B["HMAC(message = InvoiceNumber, key = Serialized Counterparty Public Key)"]
+    B --> C[h = HMAC as big number]
+    C --> D["lpriv = masterPrivKey + h (Derived Linked Private Key)"]
+```
+
+1. Generate HMAC from the invoice number using the serialized public key as the key.
+2. Convert the HMAC to a scalar using big-endian encoding.
+3. Add this scalar to the master private key (expressed as a number).
+4. This resulting number is the derived linked child private key.
+
+### Conclusion
+The Linked Key Derivation Scheme provides a robust method for public key derivation, suitable for applications like non-custodial wallets, ensuring privacy, auditability, and secure key management without compromising security.

--- a/peer-to-peer/0085.md
+++ b/peer-to-peer/0085.md
@@ -1,4 +1,4 @@
-# BRC-77 Proven Identity Key Exchange (PIKE)
+# Proven Identity Key Exchange (PIKE)
 
 Darren Kellenschwiler (deggen@kschw.com)  
 Damian Orzepowski (damian.orzepowski@4chain.studio)

--- a/peer-to-peer/0085.md
+++ b/peer-to-peer/0085.md
@@ -1,4 +1,4 @@
-# Proven Identity Key Exchange (PIKE)
+# BRC-85: Proven Identity Key Exchange (PIKE)
 
 Darren Kellenschwiler (deggen@kschw.com)  
 Damian Orzepowski (damian.orzepowski@4chain.studio)

--- a/peer-to-peer/README.md
+++ b/peer-to-peer/README.md
@@ -13,4 +13,4 @@ BRC | Standard
 77   | [Message Signature Creation and Verification](./0077.md)
 78   | [Serialization Format for Portable Encrypted Messages](./0078.md)
 82   | [Defining a Scalable IPv6 Multicast Protocol for Blockchain Transaction Broadcast and Update Delivery](./0082.md)
-84   | [Proven Identity Key Exchange (PIKE)](./0084.md)
+85   | [Proven Identity Key Exchange (PIKE)](./0085.md)


### PR DESCRIPTION
### This pull request:

Proposes a new standard by creating a new markdown file in the appropriate directory and requests discussion and assignment of a BRC number


### Summary

The Linked Key Derivation Scheme builds on and extends the "type 42" key derivation method. 
This scheme allows public key derivation using only the public keys of both parties. 

