### PR TITLE
BAD Privacy

### DIFF
--- a/key-derivation/0086.md
+++ b/key-derivation/0086.md
@@ -1,0 +1,27 @@
+# BRC-86: Bidirectionally Authenticated Derivation of Privacy Restricted Tyye 42 Keys
+
+Ty Everett (ty@projectbabbage.com)
+
+## Abstract
+
+Sometimes, there's a need for a third party to validate the linkage and key derivation process between two transacting parties. Type-42 derivation enables the private use of child keys between the parties based on an invoice number, but doesn't allow for third-party servers to verify the linkage of the keys. Proposals like BRC-84 describe ways to enable third-party verification while keeping the sender's key linked to the derivation process, but lack a means of sender authentication. By their nature, privacy is lacking in all of thes proposals, but more can be done to preserve it. When Bitcoin is not exchanged in a peer-to-peer manner, this specification outlines the most robust approach to Bidirectionally Authenticated Derivation with Privacy Restrictions (BAD Privacy).
+
+## Specification
+
+Senders use type-42 with the anyone key as counterparty and an invoice number in this format:
+
+`2-BAD Privacy-<key> <nonce> <sig> <keyID>`
+
+The format of the signed data is:
+
+```
+BRC-86 BAD Privacy
+<key>
+<nonce>
+<key ID>
+```
+
+Verifiers check:
+- The signature
+- The nonce
+- The child key is derivable 

--- a/key-derivation/0086.md
+++ b/key-derivation/0086.md
@@ -21,7 +21,14 @@ BRC-86 BAD Privacy
 <key ID>
 ```
 
-Verifiers check:
+Verifiers (and servers) check:
 - The signature
 - The nonce
-- The child key is derivable 
+- The child key is derivable with the invoice number and the anyone key
+
+The signature verification process for the signature embedded in the invoice number is:
+
+1. Extract the identity key of the sender from the message
+2. Invoice number is `2-BAD Signature-<nonce>`
+3. Verification counterparty is `anyone` (see BRC-3 for signature verification on public signatures)
+4. Message to verify is specified above

--- a/key-derivation/README.md
+++ b/key-derivation/README.md
@@ -11,3 +11,4 @@ BRC | Standard
 69   | [Revealing Key Linkages](./0069.md)
 72   | [Protecting BRC-69 Key Linkage Information in Transit](./0072.md)
 75   | [Mnemonic For Master Private Key](./0075.md)
+86   | [Bidirectionally Authenticated Derivation of Privacy Restricted Tyye 42 Keys](./0086.md)


### PR DESCRIPTION
### This pull request:

Proposes a new standard by creating a new markdown file in the appropriate directory and requests discussion and assignment of a BRC number

### Summary

This is an early draft, but I wanted to request early feedback about the idea.

To solve the issue of sender authentication we've discussed in BRC-84, how about we embed a signature in the invoice number? This way we don't need to change the type-42 algorithm (which may be implemented in hardware and not easy to change). Recipients and servers refuse to accept the exchange if the signature isn't valid.

To ensure that every possible measure is being taken to preserve privacy, we also add an extra nonce to the system, so that someone would need to compromise the nonce in order to link the public identity key with the public on-chain transaction data. Ahead of time, the recipient (or server) may have also had some input about what this nonce should be, and because it's signed by the sender, it could act as a way for the sender to authenticate.