### PR TITLE
BRC-104 - Revise encoding general message preimage

### DIFF
--- a/peer-to-peer/0104.md
+++ b/peer-to-peer/0104.md
@@ -157,31 +157,48 @@ The **order** of included headers will be lexicographical to ensure matching pre
 - If the handshake or signature fails, the server **MUST** return `401 Unauthorized` (or another 4xx suitable code) with a JSON body describing the error.  
 - If the user sets invalid data, the server **MAY** respond with `400 Bad Request`.  
 
-### 6.7 Body Encoding Rules
+### 6.7 General Message Encoding Rules
 
 When sending a “general” message:
 
-- The **body** is included raw in the BRC-103 payload, but **only** after a length prefix.  
-- If `content-type` is `application/json`, you typically convert your JSON object to UTF-8 bytes.  
-- If it is binary data (e.g. images), you pass the binary as bytes.  
-- If no body, specify a `-1` length in the payload.
+#### 6.7.1 Path Encoding Rules
 
-The same approach is used for the server’s return body in the “general” response message.
+- If the `path` has a value, it must be serialized as UTF-8 bytes with a length prefix.  
+- If the `path` is empty, it must default to `/`, serialized as UTF-8 bytes with a length prefix.
+
+#### 6.7.2 Query Parameter Encoding Rules
+
+- If query parameters are present, the entire query string (including the leading `?`) must be serialized as UTF-8 bytes with a length prefix.  
+- If no query parameters are present, specify a length of `-1` in the payload.
+
+#### 6.7.3 Body Encoding Rules
+
+The **body** is included raw in the BRC-103 payload, but **only** after a length prefix.
+
+a. If the `content-type` is `application/json`:  
+   - The JSON object must be stringified and converted to UTF-8 bytes.  
+   - If the body is empty, an empty JSON object `{}` should be stringified and converted to UTF-8 bytes.  
+
+b. If the body consists of binary data (e.g. images):  
+   - The binary is included directly as bytes.  
+   - If the body is empty, specify a length of `-1` in the payload.
+
+The same rules apply to the server’s response body in a “general” response message.
 
 ### 6.8 Signature Preimage Calculation for HTTP Request Messages
 
-The code references BRC-103’s standard approach: concatenating these fields in a stable order:
+BRC-103 specifies that the preimage is constructed by concatenating these fields in a fixed order:
 
 1. `x-bsv-auth-request-id` (32 bytes, base64-decoded).  
-2. Request `method` length + UTF-8 bytes.  
-3. Path length + UTF-8 bytes (or `-1` if empty).  
-4. Query string length + UTF-8 bytes (or `-1` if none).  
-5. **Included headers** count, given in order of transmittal over the wire. For each header:
-   - VarInt of key length, key bytes
-   - VarInt of value length, value bytes  
-6. Body length + body bytes (or `-1` if none).
+2. Request method: length + UTF-8 bytes.  
+3. Path: length + UTF-8 bytes (use `/` if the path is empty).  
+4. Query string (including `?`): length + UTF-8 bytes (or `-1` if none).  
+5. **Included headers**: count them in the order they are transmitted. For each header:  
+   - VarInt of key length, followed by key bytes  
+   - VarInt of value length, followed by value bytes  
+6. Body: length + body bytes (or `-1` if none).
 
-Then sign with the identity key. The server reconstructs that same preimage from the request data, verifying the signature in `x-bsv-auth-signature`.
+Finally, sign the preimage using the identity key. The server reconstructs the same preimage from the request data and verifies the signature contained in `x-bsv-auth-signature`.
 
 ### 6.9 Signature Preimage Calculation for HTTP Response Messages
 


### PR DESCRIPTION
### This pull request:

Amends or corrects an existing standard, without the need for creating a new one

### Summary

Align description of general message serialization to payload with the real implementation in go and ts SDKs
