### PR TITLE
BRC-122: Basket Identifier Namespace Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ BRC | Standard
 120  | [x402 Stateless Settlement-Gated HTTP Protocol](./payments/0120.md)
 121  | [Simple 402 Payments](./payments/0121.md)
 122  | [Auditable Real-time Inference Architecture (ARIA)](./apps/0122.md)
-123  | [Basket Identifier Namespace Framework](./wallet/0123.md)
+123  | [Basket Permission Scheme Registry and Governance](./wallet/0123.md)
 124  | [Multicast Transaction Frame Format](./transactions/0124.md)
 125  | [PeerPay URI Scheme for BRC-29 Payments](./payments/0125.md)
 

--- a/wallet/0123.md
+++ b/wallet/0123.md
@@ -1,217 +1,146 @@
-# BRC-123: Basket Identifier Namespace Framework
+# BRC-123: Basket Permission Scheme Registry and Governance
 
 Simon Bettison (simon@bettison.org)
 
 ## Abstract
 
-We define a hierarchical namespace framework for [BRC-46](./0046.md) output basket identifiers. Existing standards reserve basket prefixes in an ad-hoc manner ([BRC-44](../key-derivation/0044.md) reserves `admin`, [BRC-99](./0099.md) reserves `p `, [BRC-112](./0112.md) claims `balance ` as a virtual prefix). This specification unifies these reservations under a single grammar, establishes a mechanism for claiming new namespaces, and provides conventions that prevent collisions between protocols, applications, and wallet-internal operations.
+We define a governance framework for [BRC-99](./0099.md) basket permission schemes. [BRC-99](./0099.md) reserves basket identifiers beginning with `p ` for future permission schemes and establishes the format `p <scheme-id> <basket-name>`, but defines no process for registering scheme IDs, no taxonomy for classifying schemes, and no consolidated reference for the basket name reservations scattered across multiple wallet BRCs.
 
-We propose a backwards-compatible extension to [BRC-100](./0100.md)'s basket naming rules that introduces a **structured zone** alongside the existing **flat zone**, using the colon (`:`) character — which is not valid in any existing [BRC-100](./0100.md) basket name — as the delimiter for hierarchical namespace prefixes. This creates an opportunity for wallets to validate structured names against registered prefixes, without affecting any existing basket name or wallet behaviour.
+This specification addresses those gaps. It provides:
 
-The design draws on the hierarchical decomposition principles of RFC 3986<sup>1</sup> (URI Generic Syntax), adapted for the simpler requirements of basket identification within the [BRC-100](./0100.md) wallet interface. [BRC-87](../overlays/0087.md)<sup>2</sup> (Standardised Naming Conventions for Topic Managers and Lookup Services) provides prior art for naming conventions within the BSV ecosystem.
+1. A **registry** of registered and reserved `p <scheme>` scheme IDs
+2. A **taxonomy** that classifies schemes by purpose
+3. A **registration process** for claiming new scheme IDs via BRC specifications
+4. A **consolidated reference** of all basket name reservations across the wallet BRC family
+
+No changes to [BRC-100](./0100.md)'s basket naming rules or character validation are required. This specification operates entirely within the existing `[a-z0-9 ]` character set and builds on the `p ` reservation that [BRC-99](./0099.md) and [BRC-100](./0100.md) already enforce.
 
 ## Motivation
 
-As the BSV wallet ecosystem grows, basket names are being used for increasingly diverse purposes: token tracking, payment receipts, UTXO pool management, permission tokens, and module-defined digital asset schemes. Each new protocol that uses baskets must choose a naming convention, and without a framework, the risk of collision increases with every new standard.
+As the BSV wallet ecosystem grows, basket names are being used for increasingly diverse purposes: token tracking, payment receipts, UTXO management, permission tokens, and module-defined digital asset schemes. Each new protocol that uses baskets must choose a naming convention, and without a framework, the risk of collision increases with every new standard.
 
 The current state is fragmented:
 
-| Prefix/Pattern | Reserved by | Zone | Mechanism |
-|---|---|---|---|
-| `admin` | [BRC-44](../key-derivation/0044.md) | Flat | Wallet rejects at validation |
-| `p <module> ` | [BRC-99](./0099.md) | Flat | Wallet rejects unless module installed |
-| `default` | [BRC-100](./0100.md) (implicit) | Flat | Wallet uses internally for balance |
-| `balance <basket>` | [BRC-112](./0112.md) | Flat | Virtual prefix, reinterprets `listOutputs` |
+| Reservation | Reserved by | Mechanism |
+|---|---|---|
+| `default` | [BRC-100](./0100.md) | Wallet rejects at validation |
+| `admin *` | [BRC-44](../key-derivation/0044.md) | Wallet rejects at validation |
+| `p <scheme> *` | [BRC-99](./0099.md) | Wallet rejects unless scheme supported |
+| `balance <basket>` | [BRC-112](./0112.md) | Virtual prefix, reinterprets `listOutputs` |
+| `* basket` | [BRC-100](./0100.md) | Wallet rejects (redundant suffix) |
 
-Each BRC independently grabs a prefix with no coordination, no registry, and no grammar that composes them. There is no way to answer "is this prefix taken?" or "what prefixes exist?" without reading every wallet-related BRC.
+Each BRC independently grabs a prefix with no coordination, no registry, and no way to answer "is this scheme ID taken?" without reading every wallet-related BRC.
 
-Furthermore, all reservations operate within [BRC-100](./0100.md)'s flat character set (`[a-z0-9 ]`), which provides no syntactic distinction between a reserved prefix and an ordinary name. The string `admin tokens` is rejected because the validator knows to check for `admin` — but there is no general mechanism for recognising that a name belongs to a managed namespace.
-
-RFC 3986 demonstrates that a hierarchical namespace with a simple grammar (scheme, authority, path) can scale to billions of identifiers while remaining human-readable and machine-parseable. Basket identifiers need a similar — though much simpler — structure.
+[BRC-99](./0099.md) provides the extensibility mechanism — the `p <scheme-id> <basket-name>` format — but deliberately defers the definition of actual schemes to future specifications. [BRC-116](./0116.md)<sup>1</sup> provides the implementation machinery — permission modules that route `p <scheme>` baskets to scheme-specific handlers. What is missing is the governance layer: a registry of scheme IDs, a process for claiming them, and a taxonomy that helps wallet implementers understand the landscape.
 
 ## Specification
 
-### 1. Two Zones: Flat and Structured
+### 1. Basket Name Space Overview
 
-This specification introduces the concept of two complementary zones within the basket identifier space:
+The [BRC-100](./0100.md) basket identifier space is partitioned as follows. This table is a summary of existing rules — this specification does not alter any of these partitions.
 
-**Flat zone** — the existing [BRC-100](./0100.md) character set (`[a-z0-9 ]`). All existing basket names, reservations, and validation rules operate here unchanged. Names in the flat zone are validated against the existing rules defined in [BRC-100](./0100.md) Section "Rules for Basket Names"<sup>3</sup>.
+| Zone | Pattern | Governed by | Example |
+|---|---|---|---|
+| System-reserved | `default`, `admin *` | [BRC-44](../key-derivation/0044.md), [BRC-100](./0100.md) | `admin originator keys` |
+| Virtual query prefix | `balance *` | [BRC-112](./0112.md) | `balance savings` |
+| Permission schemes | `p <scheme> *` | [BRC-99](./0099.md), **this spec** | `p token usd` |
+| Prohibited suffix | `* basket` | [BRC-100](./0100.md) | *(rejected)* |
+| Unreserved | Everything else in `[a-z0-9 ]` | [BRC-100](./0100.md) | `game inventory` |
 
-**Structured zone** — identifiers containing a colon (`:`) character. Since [BRC-100](./0100.md) restricts basket names to `[a-z0-9 ]`, no valid [BRC-100](./0100.md) basket name has ever contained a colon. The structured zone is therefore entirely new territory — its introduction cannot conflict with any existing basket, application, or wallet behaviour.
+This specification governs the **permission schemes** zone — specifically, the process by which new `p <scheme>` scheme IDs are registered and classified.
 
-Wallets that do not implement this specification will reject structured-zone names at the [BRC-100](./0100.md) validation step (the colon fails the character check). This is the correct and safe behaviour — it means structured names are only accepted by wallets that understand them.
+### 2. Scheme Categories
 
-### 2. Proposed Extension to [BRC-100](./0100.md)
+Permission schemes registered under `p <scheme>` are classified into categories based on their purpose. The taxonomy is informational — a scheme's category does not change its validation or routing behaviour. The normative behaviour is always: the wallet encounters `p <scheme-id> <rest>`, looks up the scheme ID in its module registry ([BRC-116](./0116.md)<sup>1</sup> `permissionModules`), and routes to the module or rejects per [BRC-99](./0099.md).
 
-We propose that [BRC-100](./0100.md)'s "Rules for Basket Names" be extended as follows:
+#### Category 1: Asset Permission Schemes
 
-> Basket names conforming to the existing character set (`[a-z0-9 ]`) continue to be validated under the existing rules (minimum 5 characters, maximum 400 characters, no consecutive spaces, reserved prefix exclusions).
->
-> Additionally, basket names containing a colon (`:`) character are valid if they conform to the structured namespace grammar defined in BRC-123. The colon acts as a namespace delimiter, separating a registered or application-scoped prefix from a basket-specific identifier. Structured names are validated against their namespace's rules rather than the flat-zone character restriction.
+Schemes that define permission rules for specific types of digital assets. The scheme governs what kinds of UTXOs can be placed in the basket and what access rules apply. Permissions may be based on locking scripts, script templates, tokenisation protocols, or value constraints.
 
-This extension is purely additive:
-- No existing valid basket name is affected
-- No existing validation rule is weakened
-- The existing reserved prefixes (`admin`, `p `, `default`, `balance `) remain in the flat zone and continue to function unchanged
-- Wallets that do not implement this extension safely reject structured names
+This is the category [BRC-99](./0099.md) originally envisioned — for example, a scheme that allows access to a maximum of 10 dollars of tokenised fiat money per month within an application.
 
-### 3. Basket Name Grammar
+#### Category 2: Infrastructure Schemes
 
-A basket identifier is a UTF-8 string that, after trimming and lowercasing, conforms to one of the following forms:
+Schemes that provide wallet infrastructure capabilities. The basket requires specific wallet functionality to manage — the scheme exists not to restrict asset types but to ensure the wallet has the operational capability the basket demands.
 
-```abnf
-basket-name     = structured-name / flat-name
+For example, a scheme for managed UTXO provisioning would require the wallet to have specific output management capabilities before it can accept operations on baskets in that scheme.
 
-; --- Structured zone (new — contains ":") ---
-structured-name = protocol-name / app-name
-protocol-name   = registered-prefix ":" identifier
-app-name        = domain-prefix ":" identifier
+#### Category 3: Reserved
 
-; --- Flat zone (existing BRC-100 — no ":") ---
-flat-name       = system-name / module-name / simple-name
-system-name     = "default" / "admin" flat-identifier
-module-name     = "p" SP module-id SP flat-identifier
-simple-name     = flat-identifier
+Scheme IDs reserved for anticipated future use. A reserved scheme ID has no defining BRC and no active semantics — it serves as a placeholder to prevent the ID from being claimed for an incompatible purpose. Reserved IDs MAY be promoted to Category 1 or 2 when a defining BRC is written.
 
-; --- Components ---
-registered-prefix = 1*ALPHA                          ; claimed via BRC registration
-domain-prefix     = 1*(ALPHA / DIGIT / "." / "-")   ; FQDN or reverse-domain
-module-id         = 1*(ALPHA / DIGIT / "-")          ; BRC-99 module identifier
+### 3. Scheme Registration Process
 
-identifier        = 1*(ALPHA / DIGIT / SP / "-" / "_" / ":" / ".")
-                    ; no consecutive spaces, no leading/trailing spaces (trimmed)
+A new `p <scheme>` scheme ID is registered by defining it in a BRC specification and adding it to the registry in Section 4.
 
-flat-identifier   = 1*(ALPHA / DIGIT / SP)
-                    ; BRC-100 compatible: lowercase letters, numbers, spaces only
+#### 3.1 Scheme ID Rules
 
-SP                = %x20                              ; single space character
-```
+The scheme ID (the first space-delimited token after `p `) MUST satisfy:
 
-Components are listed in order of decreasing precedence, following the RFC 3986 principle that "the URI syntax is organised hierarchically, with components listed in order of decreasing significance from left to right"<sup>1</sup>.
+- Matches `[a-z][a-z0-9]*` — starts with a lowercase letter, followed by zero or more lowercase letters or digits
+- Minimum 2 characters (single-letter IDs are reserved for future core use)
+- Maximum 30 characters
+- Contains no spaces (per [BRC-99](./0099.md))
+- Is unique — does not conflict with any registered or reserved scheme ID in the registry
 
-### 4. Namespace Tiers
+#### 3.2 Required Documentation
 
-#### 4.1 System-Reserved (Tier 0) — Flat Zone
+The defining BRC MUST include a section titled "Basket Namespace" (or equivalent) that specifies:
 
-Names matching `default` or the `admin` prefix are reserved for wallet-internal use. These MUST NOT be used by applications or protocols. Wallets MUST reject operations on system-reserved baskets from non-admin originators.
+1. **Scheme ID** — the claimed identifier
+2. **Category** — per Section 2
+3. **Basket name format** — the expected structure of the `<rest>` portion after `p <scheme-id> `
+4. **Wallet capability** — what functionality the wallet must provide to handle baskets in this scheme
+5. **Permission semantics** — how access is controlled, or a statement that permission enforcement is deferred to the module's implementation per [BRC-116](./0116.md)<sup>1</sup>
 
-**Existing reservations (grandfathered):**
-- `default` — wallet balance basket ([BRC-100](./0100.md))
-- `admin *` — wallet administrative baskets ([BRC-44](../key-derivation/0044.md), [BRC-116](./0116.md))
-- `balance <basket>` — virtual query prefix, not a real basket ([BRC-112](./0112.md))
+#### 3.3 Registration
 
-These reservations predate this specification and remain in the flat zone. No changes are required to their validation or behaviour.
+A scheme ID is considered registered when its defining BRC is merged into the BRC repository. This specification's registry table (Section 4) SHOULD be updated in the same pull request.
 
-#### 4.2 Module-Reserved (Tier 1) — Flat Zone
+### 4. Scheme Registry
 
-Names matching `p <module-id> ` are reserved for [BRC-99](./0099.md) wallet modules. Access requires the corresponding module to be installed in the wallet. Modules define their own permission semantics for baskets in their namespace.
+| Scheme ID | Category | Defining BRC | Purpose | Example basket |
+|---|---|---|---|---|
+| `app` | *(Reserved)* | *(Future BRC)* | Application-scoped basket isolation | *(TBD)* |
 
-**Existing reservations (grandfathered):**
-- All `p ` prefixed names ([BRC-99](./0099.md))
+The `app` scheme ID is reserved to allow a future specification to define application-scoped baskets where the originator's identity is encoded in the basket name. This supplements (rather than replaces) [BRC-116](./0116.md)<sup>1</sup> originator-based access control, which operates at the permission layer rather than the naming layer.
 
-#### 4.3 Protocol-Reserved (Tier 2) — Structured Zone
+### 5. Validation Guidance
 
-Names matching `<registered-prefix>:<identifier>` are reserved for protocols defined by BRC specifications. A protocol claims a prefix by declaring it in a "Basket Namespace" section of its BRC. The colon (`:`) delimiter is chosen because:
+Wallets implementing [BRC-99](./0099.md) permission schemes SHOULD apply the following logic when encountering a basket name beginning with `p `:
 
-- It is not valid in any existing [BRC-100](./0100.md) basket name, ensuring zero collision
-- It is visually distinct from the space delimiter used by Tiers 0 and 1
-- It mirrors the `scheme:` pattern from RFC 3986<sup>1</sup>
-- It follows the precedent set by [BRC-87](../overlays/0087.md)<sup>2</sup> for structured identifiers in the BSV ecosystem
+1. Extract the scheme ID — the first space-delimited token after `p `
+2. Look up the scheme ID in the wallet's registered permission modules ([BRC-116](./0116.md)<sup>1</sup> `permissionModules` configuration)
+3. If a module is registered for the scheme ID, route the operation to the module
+4. If no module is registered, reject the operation — per [BRC-99](./0099.md): "wallets must reject any operation requests made under basket IDs beginning with `p `" unless they explicitly support the scheme
 
-**Registration mechanism:** A BRC specification MAY claim a protocol prefix by including a "Basket Namespace" section that declares the prefix and its intended use. The prefix MUST be a single lowercase alphabetic word (matching `1*ALPHA`). Wallets SHOULD maintain an internal registry of known protocol prefixes and MAY reject unrecognised protocol prefixes, or MAY accept them permissively — the choice is an implementation decision that balances security against extensibility.
+This is a restatement of existing [BRC-99](./0099.md) and [BRC-116](./0116.md)<sup>1</sup> behaviour, consolidated here for clarity.
 
-**Claimed prefixes:**
-- `pool:` — UTXO Pool Management (future BRC)
+### 6. Consolidated Reservation Reference
 
-**Validation:** When a wallet encounters a structured name with a recognised protocol prefix, it MAY apply protocol-specific validation rules (e.g. the UTXO Pool BRC may require `pool:` names to be at least 6 characters total). When the prefix is not recognised, the wallet MAY accept or reject at its discretion.
+The following table lists all basket name reservations across the wallet BRC family, presented as a single point of reference. Each reservation is normatively defined by its source BRC — this table is informational.
 
-#### 4.4 Application-Scoped (Tier 3) — Structured Zone
+| Pattern | Meaning | Source | Notes |
+|---|---|---|---|
+| `default` | Wallet balance basket | [BRC-100](./0100.md) | Historically used for internal operations |
+| `admin *` | Administrative baskets | [BRC-44](../key-derivation/0044.md), [BRC-116](./0116.md)<sup>1</sup> | Wallet rejects from non-admin originators |
+| `balance <basket>` | Virtual query prefix | [BRC-112](./0112.md) | Not a real basket; reinterprets `listOutputs` |
+| `p <scheme> *` | Permission scheme baskets | [BRC-99](./0099.md) | Wallet rejects unless scheme is supported |
+| `* basket` | Prohibited suffix | [BRC-100](./0100.md) | Redundant naming; always rejected |
 
-Names where the portion before the first colon contains a dot (`.`) are treated as application-scoped, using the originator's domain as a namespace:
+## Backwards Compatibility
 
-```
-example.com:my tokens
-game.x420.io:session inventory
-```
+This specification introduces no changes to [BRC-100](./0100.md)'s basket naming rules. The character set remains `[a-z0-9 ]`. No existing basket name, validation rule, or wallet behaviour is affected.
 
-This convention follows the reverse-domain pattern common in Java packages and Android namespaces. Applications MAY use this pattern to prevent cross-application collisions without requiring a BRC registration. The dot distinguishes application prefixes from protocol prefixes (which are single alphabetic words without dots).
+The `p ` reservation has been enforced by [BRC-100](./0100.md) since its introduction — wallets already reject `p `-prefixed baskets unless they support the scheme. This specification provides governance for which scheme IDs exist; it does not alter the mechanism by which they are enforced.
 
-Wallets MAY enforce that application-scoped baskets are only accessible to the matching originator, connecting to [BRC-116](./0116.md)<sup>4</sup> DBAP basket permissions. This enforcement is OPTIONAL — wallets that do not implement originator-scoping treat these as ordinary structured names.
-
-#### 4.5 Simple Names (Tier 4) — Flat Zone
-
-Any name in the flat zone that does not match the patterns in Tiers 0-1 is a simple name in the unreserved space. These names are first-come-first-served and carry no implicit ownership or access control beyond standard [BRC-116](./0116.md) basket permissions.
-
-Simple names are validated against [BRC-100](./0100.md)'s existing rules: minimum 5 characters, maximum 400 characters, lowercase letters/numbers/spaces only, no consecutive spaces, no reserved prefixes.
-
-Examples: `my tokens`, `game inventory`, `receipts`
-
-### 5. Validation Rules
-
-Wallets implementing this specification MUST apply the following validation in order:
-
-1. Reject if the value is not a string
-2. Trim leading and trailing whitespace
-3. Lowercase the entire string
-4. **Branch on zone:**
-   - If the normalised name contains `:` → **structured zone** (proceed to step 5)
-   - Otherwise → **flat zone** (proceed to step 8)
-5. Reject if byte length is less than 1 or greater than 300
-6. If the prefix before the first `:` matches a known registered protocol prefix → apply protocol-specific validation (Tier 2)
-7. If the prefix contains `.` → treat as application-scoped (Tier 3); otherwise treat as an unrecognised protocol prefix (wallet MAY accept or reject)
-8. Apply existing [BRC-100](./0100.md) flat-zone validation:
-   - Reject if character length is less than 5 or greater than 400
-   - Reject if characters outside `[a-z0-9 ]` are present
-   - Reject if consecutive spaces are present
-   - Reject if the name matches a system-reserved pattern (Tier 0)
-   - If the name matches a module pattern (`p <id> ...`), defer to [BRC-99](./0099.md) module resolution (Tier 1)
-   - Otherwise, accept as a simple name (Tier 4)
-
-### 6. Backwards Compatibility
-
-This specification is designed for full backwards compatibility:
-
-1. **No existing basket name is affected.** The structured zone uses `:` which is not valid under [BRC-100](./0100.md)'s `[a-z0-9 ]` character set. No existing basket has ever contained a colon.
-
-2. **No existing validation rule is weakened.** Flat-zone names continue to be validated under [BRC-100](./0100.md)'s original rules with the original character set, minimum length, and reserved prefix checks.
-
-3. **Non-implementing wallets are safe.** A wallet that does not implement this specification will reject any structured-zone name at [BRC-100](./0100.md)'s character validation step. This is correct behaviour — the structured zone is opt-in.
-
-4. **Existing reservations are grandfathered.** `admin`, `p `, `default`, and `balance ` continue to operate in the flat zone under their original BRC specifications. This framework does not alter or supersede those reservations — it provides a unified model that encompasses them.
-
-5. **The extension is purely additive.** The only change to [BRC-100](./0100.md) is the acceptance of colon-containing names by wallets that implement this specification. No existing behaviour is modified.
-
-### 7. Relationship to RFC 3986
-
-The basket namespace grammar draws structural inspiration from RFC 3986 but is deliberately simpler:
-
-| RFC 3986 Concept | Basket Analogue | Notes |
-|---|---|---|
-| Scheme (`http:`) | Protocol prefix (`pool:`) | Single-word, no `//` authority separator |
-| Authority (`example.com`) | Domain prefix (`example.com:`) | Application-scoped isolation |
-| Path (`/resource`) | Identifier (`doom`) | The basket-specific name after the prefix |
-| Registration (BCP 35) | BRC declaration | Federated, no central registry |
-| Query / Fragment | Not applicable | Baskets are flat identifiers, not hierarchical resources |
-
-The key simplification: baskets do not need authority, path hierarchy, query parameters, or fragment references. A single level of namespacing (prefix + name) is sufficient for the foreseeable use cases.
-
-Should the BSV ecosystem require interoperability with external systems (e.g. cross-chain wallet communication), a formal URI scheme (`bsv-basket:pool:doom`) could be proposed via RFC 3986's BCP 35 registration process. This specification does not preclude such a future extension.
-
-### 8. Relationship to [BRC-87](../overlays/0087.md)
-
-[BRC-87](../overlays/0087.md)<sup>2</sup> establishes standardised naming conventions for [BRC-22](../overlays/0022.md) Topic Managers and [BRC-24](../overlays/0024.md) Lookup Services within the overlay network. While the domain differs (overlay services vs wallet baskets), the underlying problem — preventing name collisions in a growing ecosystem — is identical. This specification follows BRC-87's precedent of proposing structured naming conventions via a BRC, and adopts a similar philosophy of human-readable identifiers with clear hierarchical separation.
-
-## Implementations
-
-This specification is implemented in the `bsv-wallet` Ruby gem's `Validators.validate_basket!` method, which applies trim, lowercase, byte-length, zone detection (colon presence), and reserved-prefix validation aligned with this grammar.
+Wallets that do not implement any permission scheme modules will continue to reject all `p ` baskets, which is the correct and safe behaviour defined by [BRC-99](./0099.md).
 
 ## References
 
-- <a name="footnote-1">1</a>: [RFC 3986: Uniform Resource Identifier (URI) Generic Syntax](https://www.rfc-editor.org/rfc/rfc3986), Section 1.2.3
-- <a name="footnote-2">2</a>: [BRC-87: Standardised Naming Conventions for Topic Managers and Lookup Services](../overlays/0087.md)
-- <a name="footnote-3">3</a>: [BRC-100: Wallet Interface — Rules for Basket Names](./0100.md)
-- <a name="footnote-4">4</a>: [BRC-116: Wallet Permissions and Counterparty Trust](./0116.md)
-- <a name="footnote-5">5</a>: [BRC-44: Admin-reserved and Prohibited Key Derivation Protocols](../key-derivation/0044.md)
-- <a name="footnote-6">6</a>: [BRC-46: Wallet Transaction Output Tracking (Output Baskets)](./0046.md)
-- <a name="footnote-7">7</a>: [BRC-99: P Baskets](./0099.md)
-- <a name="footnote-8">8</a>: [BRC-112: Balance Baskets](./0112.md)
+- <a name="footnote-1">1</a>: [BRC-116: Wallet Permissions and Counterparty Trust](./0116.md)
+- <a name="footnote-2">2</a>: [BRC-99: P Baskets](./0099.md)
+- <a name="footnote-3">3</a>: [BRC-100: Wallet Interface](./0100.md)
+- <a name="footnote-4">4</a>: [BRC-44: Admin-reserved and Prohibited Key Derivation Protocols](../key-derivation/0044.md)
+- <a name="footnote-5">5</a>: [BRC-46: Wallet Transaction Output Tracking (Output Baskets)](./0046.md)
+- <a name="footnote-6">6</a>: [BRC-112: Balance Baskets](./0112.md)


### PR DESCRIPTION
## Summary

Proposes a backwards-compatible extension to BRC-100's basket naming rules that introduces a **structured zone** (colon-delimited) alongside the existing **flat zone**.

- Unifies existing ad-hoc prefix reservations (`admin`, `p `, `default`, `balance `) under a single grammar
- Introduces tiered namespaces: system-reserved, module-reserved, protocol-reserved (`pool:`, `token:`), application-scoped (`example.com:`), and simple names
- The colon character is not valid in any existing BRC-100 basket name, so the extension is purely additive — zero backwards compatibility risk
- Non-implementing wallets safely reject structured names at BRC-100's character validation step
- Draws structural inspiration from RFC 3986 (URI Generic Syntax) and follows the precedent of BRC-87 for naming conventions in the BSV ecosystem

## Motivation

Each new wallet-related BRC independently grabs a basket prefix with no coordination or registry. This proposal provides a framework so that future protocols can claim namespaces without collision, and wallets can validate structured names against registered prefixes.

## Files

- `wallet/0122.md` — BRC-122 specification
- `README.md` — index entry added

## Cross-references

Extends: BRC-100 (basket naming rules)
References: BRC-44, BRC-46, BRC-87, BRC-99, BRC-112, BRC-116, RFC 3986