### PR TITLE
Refresh BRC specs and documentation across wallets, payments, and transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ BRC | Standard
 34   | [PeerServ Host Interconnect Protocol](./peer-to-peer/0034.md)
 35   | [Layered Key-Value Store for Wallets and Overlay Services](./overlays/0035.md)
 36   | [Format for Bitcoin Outpoints](./outpoints/0036.md)
-37   | [Spending Instructions Extension for UTXO Storage Format](./outpoints/0037.md)
-38   | Placeholder only, no spec published here
-39   | Placeholder only, no spec published here
-40   | Placeholder only, no spec published here
+37   | [Basket and Custom Instructions Extension for Bitcoin Outpoints](./outpoints/0037.md)
+38   | [User Wallet Data Format](./outpoints/0038.md)
+39   | [User Wallet Data Format Encryption Extension](./outpoints/0039.md)
+40   | [User Wallet Data Synchronization](./outpoints/0040.md)
 41   | [PacketPay HTTP Payment Mechanism](./payments/0041.md)
 42   | [BSV Key Derivation Scheme (BKDS)](./key-derivation/0042.md)
 43   | [Security Levels, Protocol IDs, Key IDs and Counterparties](./key-derivation/0043.md)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A repository for submitting, discussing, sharing, and indexing technical proposa
 
 ## Contributing
 
-Contributions from all builders are welcome and encouraged. To propose a new BRC, fork the repo and create a new markdown file using the [~EXAMPLE.md](./~EXAMPLE.md) as the template. The common structure is outlined below, which is a guideline to aid you rather than a strict requirement. Once your proposal is ready to share, submit a pull request so that others can review and discuss it.
+Contributions from all builders are welcome and encouraged. To propose a new BRC, fork the repo and create a new markdown file using [EXAMPLE.md](./EXAMPLE.md) as the template. The common structure is outlined below, which is a guideline to aid you rather than a strict requirement. Once your proposal is ready to share, submit a pull request so that others can review and discuss it.
 
 To participate in discussions about existing proposals, simply open an issue and link back to the BRC file in question.
 
@@ -40,7 +40,13 @@ Each proposal should be written as a markdown file and should loosely adhere to 
 
 Things that help depict and understand the document, such as media, may also be added in a media subdirectory where appropriate.
 
-Refer to the [Banana-Powered Bitcoin Wallet Control Protocol](./~EXAMPLE.md) for a fun example template you can copy when proposing your own standards.
+Refer to the [Banana-Powered Bitcoin Wallet Control Protocol](./EXAMPLE.md) for a fun example template you can copy when proposing your own standards.
+
+## Interpreting the Repository
+
+This repository contains both active interoperability specifications and historical design context.
+
+Use the directory README files and in-spec status notes to determine which documents currently define interoperable behavior in a given area. Where a newer BRC narrows, extends, or authoritatively re-specifies behavior, implementers should follow the newer normative document rather than inferring precedence from chronology alone.
 
 ## Standards
 
@@ -84,9 +90,9 @@ BRC | Standard
 35   | [Layered Key-Value Store for Wallets and Overlay Services](./overlays/0035.md)
 36   | [Format for Bitcoin Outpoints](./outpoints/0036.md)
 37   | [Spending Instructions Extension for UTXO Storage Format](./outpoints/0037.md)
-38   | User Wallet Data Format
-39   | User Wallet Data Format Encryption Extension
-40   | User Wallet Data Synchronization
+38   | Placeholder only, no spec published here
+39   | Placeholder only, no spec published here
+40   | Placeholder only, no spec published here
 41   | [PacketPay HTTP Payment Mechanism](./payments/0041.md)
 42   | [BSV Key Derivation Scheme (BKDS)](./key-derivation/0042.md)
 43   | [Security Levels, Protocol IDs, Key IDs and Counterparties](./key-derivation/0043.md)

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ BRC | Standard
 32   | [BIP32 Key Derivation Scheme](./key-derivation/0032.md)
 33   | [PeerServ Message Relay Interface](./peer-to-peer/0033.md)
 34   | [PeerServ Host Interconnect Protocol](./peer-to-peer/0034.md)
-35   | (unused, will assign next BRC to this number)
+35   | [Layered Key-Value Store for Wallets and Overlay Services](./overlays/0035.md)
 36   | [Format for Bitcoin Outpoints](./outpoints/0036.md)
 37   | [Spending Instructions Extension for UTXO Storage Format](./outpoints/0037.md)
 38   | User Wallet Data Format

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -91,6 +91,7 @@
 * [Overlay Network Lookup Services](./overlays/0024.md)
 * [Confederacy Lookup Availability Protocol (CLAP)](./overlays/0025.md)
 * [Universal Hash Resolution Protocol](./overlays/0026.md)
+* [Layered Key-Value Store for Wallets and Overlay Services](./overlays/0035.md)
 * [Overlay Network Transaction History Tracking](./overlays/0064.md)
 * [Private Overlays with P2PKH Transactions](./overlays/0081.md)
 * [Standardized Naming Conventions for BRC-22 Topic Managers and BRC-24 Lookup Services](./overlays/0087.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -144,7 +144,10 @@
 ## Outpoints
 
 * [Format for Bitcoin Outpoints](./outpoints/0036.md)
-* [Spending Instructions Extension for UTXO Storage Format](./outpoints/0037.md)
+* [Basket and Custom Instructions Extension for Bitcoin Outpoints](./outpoints/0037.md)
+* [User Wallet Data Format](./outpoints/0038.md)
+* [User Wallet Data Format Encryption Extension](./outpoints/0039.md)
+* [User Wallet Data Synchronization](./outpoints/0040.md)
 
 ## Opinions
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,6 +1,6 @@
 # Apps
 
-These specifications describe schemas, templates, and conventions related toe BSV app development.
+These specifications describe schemas, templates, and conventions related to BSV app development.
 
 BRC   | Standard
 ------|------------------

--- a/outpoints/0036.md
+++ b/outpoints/0036.md
@@ -4,60 +4,116 @@ Ty Everett (ty@projectbabbage.com)
 
 ## Abstract
 
-This document specifies the standard format for representing spendable Unspent Transaction Outputs (UTXOs) and the associated information required for spending or sharing them with other parties. The goal is to provide a baseline UTXO storage format that encapsulates the minimal set of requirements, promotes compatibility and interoperability between different implementations, and reduces fragmentation within the Bitcoin ecosystem. This standard allows for extensions or deviations to be defined as part of other standards.
+This document specifies the canonical portable format for representing a Bitcoin outpoint together with the minimum data required for interoperable validation and use. The format is intentionally narrow: it standardizes the identity of the output, its value, its optional locking script, and the transaction-validity payload required to verify the creating transaction. This specification aligns with the output model used by [BRC-100](../wallet/0100.md) and current Wallet Toolbox implementations.
 
 ## Motivation
 
-The development of the BRC-36 standard is motivated by the need for a unified and standardized format for storing UTXOs, which are fundamental to Bitcoin and facilitate tokenization, as well as define the mechanism by which value is represented and conveyed within the system. With many different storage formats in use by various applications and implementations around the ecosystem, the lack of a standard format has led to compatibility issues and fragmentation. By providing a clear, standardized format for UTXO storage, we aim to enhance compatibility, facilitate sharing and spending of UTXOs among different parties, and simplify the implementation of Bitcoin-related services and applications.
+Outputs are the fundamental bearer objects of Bitcoin. They are also the units tracked, discovered, moved, and reinterpreted by modern wallet software. Historically, some implementations represented outputs together with [BRC-8](../transactions/0008.md) transaction envelopes and optional mAPI responses. That representation is no longer normative for interoperable wallet behavior.
+
+Current interoperable wallet systems use the [BRC-62](../transactions/0062.md) / [BRC-95](../transactions/0095.md) BEEF family for transaction-validity data, and use compact output objects centered on the outpoint itself. This document updates BRC-36 to reflect that reality while preserving its original purpose: defining a portable and implementation-neutral baseline format for Bitcoin outputs.
 
 ## Specification
 
-The JSON representation of the UTXO storage format is specified as an object with the following fields:
+### Canonical JSON Object
 
-Field | Description
-------|----------------
-`txid` | The transaction ID, represented as a hex string, of the transaction that contains the UTXO.
-`vout` | The output index in the transaction (where 0 is the first output) where the UTXO is found.
-`outputScript` | A [BRC-14](../scripts/0014.md) hex string representation of the Bitcoin output script associated with the UTXO.
-`satoshis` | The number of satoshis contained in the UTXO.
-`rawTx` | The raw transaction ([BRC-12](../transactions/0012.md) hex format) that encompasses the UTXO.
-`inputs`, `mapiResponses`, and/or `proof` | The other envelope fields, as defined by [BRC-8](../transactions/0008.md).
+A BRC-36 outpoint object is a JSON object with the following fields:
 
-## Implementation
+Field | Required | Description
+------|----------|------------
+`outpoint` | yes | The canonical identifier for the output, encoded as an outpoint string in the form `<txid>.<vout>`.
+`satoshis` | yes | The number of satoshis contained in the output.
+`lockingScript` | no | The hex-encoded Bitcoin locking script for the output.
+`tx` | yes | The transaction-validity payload for the creating transaction, encoded in [BRC-95](../transactions/0095.md) Atomic BEEF format.
 
-In order to implement a compatible UTXO storage system, developers should adhere to the following guidelines:
+### Semantics
 
-- Ensure that the UTXO storage object includes all the required fields, as specified.
-- Store the [BRC-8](../transactions/0008.md) transaction envelope associated with the encompassing transaction alongside the UTXO, providing information about either the merkle proof on such a transaction or its associated input transactions and their SPV information.
-- Implement the ability to serialize and deserialize UTXOs using the JSON format specified in this standard, allowing for easy sharing and spending of UTXOs between parties.
-- When extending or deviating from the BRC-36 standard, make sure to define these changes as part of other standards or specifications to maintain compatibility and avoid further fragmentation.
+- The `outpoint` field is the canonical identifier of the output. Implementations MAY derive `txid` and `vout` from this field for internal use, but they are not part of the canonical BRC-36 object.
+- The `lockingScript` field is optional because some contexts only require identification and proof of the output, while others additionally require the locking script bytes.
+- The `tx` field is required. A BRC-36 object is intended to be self-contained with respect to transaction validation data.
+- The `tx` field MUST encode an [Atomic BEEF](../transactions/0095.md) whose subject transaction is the transaction identified by the `txid` component of the `outpoint`.
+- The Atomic BEEF payload MUST contain sufficient data to validate the subject transaction according to the rules of the BEEF family of specifications.
+
+### Explicit Replacement of Historical Assumptions
+
+The following historical representations are not normative for BRC-36:
+
+- [BRC-8](../transactions/0008.md) transaction envelopes
+- `rawTx`, `inputs`, `proof`, and `mapiResponses` as BRC-36 fields
+- mAPI-era output-sharing formats
+
+Implementations MAY continue to support such formats for historical compatibility, but interoperable BRC-36 exchange is defined only by the object specified in this document.
+
+### Scope Boundaries
+
+BRC-36 standardizes portable output facts only. It does not standardize wallet-internal state such as:
+
+- spendability flags
+- change classification
+- wallet-specific purpose or type labels
+- storage-layer IDs or offsets
+- basket assignment
+- tags or labels
+- custom spending metadata
+
+These concerns are either internal to a wallet or defined by other standards such as [BRC-37](./0037.md), [BRC-46](../wallet/0046.md), and [BRC-100](../wallet/0100.md).
+
+## Binary Profile
+
+In addition to the canonical JSON object, BRC-36 defines a canonical standalone binary representation for a single outpoint object. This binary profile is designed to be independently usable while remaining aligned with the serialization conventions employed by [BRC-100](../wallet/0100.md).
+
+### Binary Field Order
+
+The binary representation of a BRC-36 object consists of the following fields in order:
+
+Field | Type | Description
+------|------|------------
+`outpoint` | Byte Array | The outpoint, encoded as 32 bytes of TXID followed by the output index.
+`satoshis` | VarInt | The number of satoshis in the output.
+`lockingScript` | VarInt Length + Byte Array | The locking script, if present. If absent, encode `-1`.
+`tx` | VarInt Length + Byte Array | The required Atomic BEEF payload.
+
+### Binary Encoding Rules
+
+- The `outpoint` field MUST use the same byte-level representation employed by [BRC-100](../wallet/0100.md) for output objects.
+- The `satoshis` field MUST be encoded as a VarInt.
+- If `lockingScript` is absent, its length field MUST be encoded as `-1`.
+- The `tx` field MUST be present and MUST contain a valid [BRC-95](../transactions/0095.md) Atomic BEEF byte sequence.
+- The binary profile carries exactly the same semantics as the canonical JSON form and MUST NOT introduce transport-only framing fields.
+
+## Mapping to BRC-100
+
+This specification is intentionally aligned with the output model used by [BRC-100](../wallet/0100.md):
+
+- `outpoint` aligns directly with the BRC-100 output identifier.
+- `satoshis` aligns directly with the BRC-100 output amount.
+- `lockingScript`, when included, aligns directly with the optional script-return behavior in BRC-100 `listOutputs`.
+- `tx` corresponds to the transaction-validity payload returned in BRC-100 contexts that include full transaction data, except that BRC-36 standardizes a single-output portable object and requires the payload to be an Atomic BEEF associated with that output's creating transaction.
 
 ## Example
 
-Here are some examples of UTXO storage objects in JSON format:
+### JSON Example
 
 ```json
 {
-  "txid": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-  "vout": 0,
-  "outputScript": "76a9140123456789abcdef0123456789abcdef0123456789abcdef88ac",
-  "satoshis": 310033,
-  "rawTx": "0100000001...",
-  "inputs": {...},
-  "mapiResponses": [...],
-  "proof": {...}
+  "outpoint": "7001295a287fee8e7ad5de58ed30bd61923977ddc9b7a44830ebb9a68b12dc39.0",
+  "satoshis": 500,
+  "lockingScript": "76a9148055582669432149141abcf887fced6881f7404288ac",
+  "tx": "01010101..."
 }
 ```
 
-```json
-{
-  "txid":"7001295a287fee8e7ad5de58ed30bd61923977ddc9b7a44830ebb9a68b12dc39",
-  "vout":0,"outputScript":"4104ca0a8ce950bf2bc85115bd68818455ae2f187efc96c7527dfad98b69531ae65d13cff3e6f07263dcc64c8ccfd03884983a896b0c5887f2ec5bfd7ad739b76119ac213155485250596e4d4850755135546762334146384a5871774b6b6d5a56793568472231485438347a7272467645594658567a6b5343436f6968706d33437754586a74726b200c613f338ad70e228eaee180f65c34d72a63bdf4c9e167dd5bf70a61539e80a8096164766572746973654468747470733a2f2f73746167696e672d6e616e6f73746f72652e626162626167652e73797374656d732f63646e2f54436f5a366269715743634b574b4d6e5065695854620a31383338383430313032043834303046304402205da55600d8f260d760b37491bc3286b9faacd0d408c187e69119ddc1d98bf3fe02207996fda8d6aba1b7494d7fe8a9b7e5111ea492348f11162bc898b3f7ab2ebf486d6d6d6d",
-  "topic":"UHRP",
-  "satoshis":500,
-  "rawTx":"0100000001e09afc3f6ed8842e3f231aac29d325c0f90137a5441bf861c7a9ee7499fafc9a020000006b483045022100cfef7385daedeb6f54a68c1188bf7d9061774f88eb391e132daea49cfcb883c60220010ba950bbb2952a1d4ace35c6721a254774c6370be75e804334be13544e4f3c412102dc35718aeb818a6075a926e8f68bd6656e5fa007a083d8f5b6193b7b1c34e3f7ffffffff03f401000000000000fd53014104ca0a8ce950bf2bc85115bd68818455ae2f187efc96c7527dfad98b69531ae65d13cff3e6f07263dcc64c8ccfd03884983a896b0c5887f2ec5bfd7ad739b76119ac213155485250596e4d4850755135546762334146384a5871774b6b6d5a56793568472231485438347a7272467645594658567a6b5343436f6968706d33437754586a74726b200c613f338ad70e228eaee180f65c34d72a63bdf4c9e167dd5bf70a61539e80a8096164766572746973654468747470733a2f2f73746167696e672d6e616e6f73746f72652e626162626167652e73797374656d732f63646e2f54436f5a366269715743634b574b4d6e5065695854620a31383338383430313032043834303046304402205da55600d8f260d760b37491bc3286b9faacd0d408c187e69119ddc1d98bf3fe02207996fda8d6aba1b7494d7fe8a9b7e5111ea492348f11162bc898b3f7ab2ebf486d6d6d6dc8000000000000001976a9148055582669432149141abcf887fced6881f7404288ac207c1202000000001976a9146a1a5f00deb78b2ef39e9a80d3e3ea2c97d0710c88ac00000000",
-  "proof":null,
-  "inputs":"{\"9afcfa9974eea9c761f81b44a53701f9c025d329ac1a233f2e84d86e3ffc9ae0\":{\"proof\":{\"flags\":2,\"index\":3,\"txOrId\":\"9afcfa9974eea9c761f81b44a53701f9c025d329ac1a233f2e84d86e3ffc9ae0\",\"target\":\"c99dfb20991b131142a915b086eb6413d78fb472477c31ef06495c7d712dc4e4\",\"nodes\":[\"5206842a42c144617bee40869bd73b0f65ecf6d19c75e73c7106ee2f5b271308\",\"624c68a9e2c8e83df9e55c0bc4b3a560924d6cb027285e6d6499f6445149e4ac\",\"4c02bfcd6098e40ecebab74783e1bd14d8495bccb02e4b5447057de31ed485d6\"],\"targetType\":\"merkleRoot\"},\"rawTx\":\"010000000166dee27f6d4ca528dbd664c1b6a686f9a3b18336ca396bcead7f2065ec0f07ac020000006b483045022100effd3358e1a602898e2a80b0d45b3a01bb36dfc9148b0766bc6e8185f4cf3c0c02203c3d6c6ff180d395b1300b89f96056d9ec915d6cfbf02c7cff2d6f4bb9611d1941210228ec497f7097a26ea1049ef732931d5abc40335e7693cac56d4534f15ff60aefffffffff03204e0000000000001976a9145b296c72cbec349171445808df953c2edaa3a1d388acc8000000000000001976a914d013936b4177bcbb0d934c6348b0d9ec3cc05dac88ac1e7f1202000000001976a914b281d7f257d79aebb910a5ba2c8e787f7ea635ab88ac00000000\"}}",
-  "mapiResponses":"[{\"payload\":\"{\\\"apiVersion\\\":\\\"1.5.0\\\",\\\"timestamp\\\":\\\"2023-04-10T20:55:03.2794204Z\\\",\\\"txid\\\":\\\"7001295a287fee8e7ad5de58ed30bd61923977ddc9b7a44830ebb9a68b12dc39\\\",\\\"returnResult\\\":\\\"success\\\",\\\"resultDescription\\\":\\\"\\\",\\\"minerId\\\":\\\"030d1fe5c1b560efe196ba40540ce9017c20daa9504c4c4cec6184fc702d9f274e\\\",\\\"currentHighestBlockHash\\\":\\\"00000000000004863e21305bc8cee6dd66b80a443416f14ccc5c74895fdefcac\\\",\\\"currentHighestBlockHeight\\\":1546251,\\\"txSecondMempoolExpiry\\\":0,\\\"warnings\\\":[],\\\"failureRetryable\\\":false}\",\"publicKey\":\"030d1fe5c1b560efe196ba40540ce9017c20daa9504c4c4cec6184fc702d9f274e\",\"signature\":\"304402205cd7c1b8f64de17c5824fec87549ecf46d69f122ed96971878562795d432a00702202097e309da4db38876bcaecafdd9f6234fcee999113a5fd54c909383d223a24f\"}]"
-}
+### Binary Layout Example
+
+```text
+[outpoint bytes][satoshis varint][lockingScript length + bytes][atomicBEEF length + bytes]
 ```
+
+## Implementation
+
+Implementations of BRC-36 should adhere to the following guidelines:
+
+- Treat `outpoint` as the canonical identifier at the interoperability boundary.
+- Include `lockingScript` whenever the recipient is expected to inspect or evaluate the script.
+- Ensure the `tx` payload is a valid Atomic BEEF for the transaction that created the output.
+- When other standards extend this object, preserve the semantics of the four base fields defined here.
+

--- a/outpoints/0036.md
+++ b/outpoints/0036.md
@@ -1,16 +1,34 @@
 # BRC-36: Format for Bitcoin Outpoints
 
-Ty Everett (ty@projectbabbage.com)
+Ty Everett (`ty@projectbabbage.com`)
 
 ## Abstract
 
-This document specifies the canonical portable format for representing a Bitcoin outpoint together with the minimum data required for interoperable validation and use. The format is intentionally narrow: it standardizes the identity of the output, its value, its optional locking script, and the transaction-validity payload required to verify the creating transaction. This specification aligns with the output model used by [BRC-100](../wallet/0100.md) and current Wallet Toolbox implementations.
+This document specifies the canonical portable format for representing
+a Bitcoin outpoint together with the minimum data required for
+interoperable validation and use. The format is intentionally narrow:
+it standardizes the identity of the output, its value, its optional
+locking script, and the transaction-validity payload required to
+verify the creating transaction. This specification aligns with the
+output model used by [BRC-100](../wallet/0100.md) and current Wallet
+Toolbox implementations.
 
 ## Motivation
 
-Outputs are the fundamental bearer objects of Bitcoin. They are also the units tracked, discovered, moved, and reinterpreted by modern wallet software. Historically, some implementations represented outputs together with [BRC-8](../transactions/0008.md) transaction envelopes and optional mAPI responses. That representation is no longer normative for interoperable wallet behavior.
+Outputs are the fundamental bearer objects of Bitcoin. They are also
+the units tracked, discovered, moved, and reinterpreted by modern
+wallet software. Historically, some implementations represented
+outputs together with [BRC-8](../transactions/0008.md) transaction
+envelopes and optional mAPI responses. That representation is no
+longer normative for interoperable wallet behavior.
 
-Current interoperable wallet systems use the [BRC-62](../transactions/0062.md) / [BRC-95](../transactions/0095.md) BEEF family for transaction-validity data, and use compact output objects centered on the outpoint itself. This document updates BRC-36 to reflect that reality while preserving its original purpose: defining a portable and implementation-neutral baseline format for Bitcoin outputs.
+Current interoperable wallet systems use the
+[BRC-62](../transactions/0062.md) /
+[BRC-95](../transactions/0095.md) BEEF family for transaction-validity
+data, and use compact output objects centered on the outpoint itself.
+This document updates BRC-36 to reflect that reality while preserving
+its original purpose: defining a portable and implementation-neutral
+baseline format for Bitcoin outputs.
 
 ## Specification
 
@@ -18,20 +36,32 @@ Current interoperable wallet systems use the [BRC-62](../transactions/0062.md) /
 
 A BRC-36 outpoint object is a JSON object with the following fields:
 
-Field | Required | Description
-------|----------|------------
-`outpoint` | yes | The canonical identifier for the output, encoded as an outpoint string in the form `<txid>.<vout>`.
-`satoshis` | yes | The number of satoshis contained in the output.
-`lockingScript` | no | The hex-encoded Bitcoin locking script for the output.
-`tx` | yes | The transaction-validity payload for the creating transaction, encoded in [BRC-95](../transactions/0095.md) Atomic BEEF format.
+- `outpoint` (required): The canonical identifier for the output,
+  encoded as an outpoint string in the form `<txid>.<vout>`.
+- `satoshis` (required): The number of satoshis contained in the
+  output.
+- `lockingScript` (optional): The hex-encoded Bitcoin locking script
+  for the output.
+- `tx` (required): The transaction-validity payload for the creating
+  transaction, encoded in [BRC-95](../transactions/0095.md) Atomic BEEF
+  format.
 
 ### Semantics
 
-- The `outpoint` field is the canonical identifier of the output. Implementations MAY derive `txid` and `vout` from this field for internal use, but they are not part of the canonical BRC-36 object.
-- The `lockingScript` field is optional because some contexts only require identification and proof of the output, while others additionally require the locking script bytes.
-- The `tx` field is required. A BRC-36 object is intended to be self-contained with respect to transaction validation data.
-- The `tx` field MUST encode an [Atomic BEEF](../transactions/0095.md) whose subject transaction is the transaction identified by the `txid` component of the `outpoint`.
-- The Atomic BEEF payload MUST contain sufficient data to validate the subject transaction according to the rules of the BEEF family of specifications.
+- The `outpoint` field is the canonical identifier of the output.
+  Implementations MAY derive `txid` and `vout` from this field for
+  internal use, but they are not part of the canonical BRC-36 object.
+- The `lockingScript` field is optional because some contexts only
+  require identification and proof of the output, while others
+  additionally require the locking script bytes.
+- The `tx` field is required. A BRC-36 object is intended to be
+  self-contained with respect to transaction validation data.
+- The `tx` field MUST encode an
+  [Atomic BEEF](../transactions/0095.md) whose subject transaction is
+  the transaction identified by the `txid` component of the `outpoint`.
+- The Atomic BEEF payload MUST contain sufficient data to validate the
+  subject transaction according to the rules of the BEEF family of
+  specifications.
 
 ### Explicit Replacement of Historical Assumptions
 
@@ -41,11 +71,14 @@ The following historical representations are not normative for BRC-36:
 - `rawTx`, `inputs`, `proof`, and `mapiResponses` as BRC-36 fields
 - mAPI-era output-sharing formats
 
-Implementations MAY continue to support such formats for historical compatibility, but interoperable BRC-36 exchange is defined only by the object specified in this document.
+Implementations MAY continue to support such formats for historical
+compatibility, but interoperable BRC-36 exchange is defined only by the
+object specified in this document.
 
 ### Scope Boundaries
 
-BRC-36 standardizes portable output facts only. It does not standardize wallet-internal state such as:
+BRC-36 standardizes portable output facts only. It does not
+standardize wallet-internal state such as:
 
 - spendability flags
 - change classification
@@ -55,39 +88,57 @@ BRC-36 standardizes portable output facts only. It does not standardize wallet-i
 - tags or labels
 - custom spending metadata
 
-These concerns are either internal to a wallet or defined by other standards such as [BRC-37](./0037.md), [BRC-46](../wallet/0046.md), and [BRC-100](../wallet/0100.md).
+These concerns are either internal to a wallet or defined by other
+standards such as [BRC-37](./0037.md),
+[BRC-46](../wallet/0046.md), and [BRC-100](../wallet/0100.md).
 
 ## Binary Profile
 
-In addition to the canonical JSON object, BRC-36 defines a canonical standalone binary representation for a single outpoint object. This binary profile is designed to be independently usable while remaining aligned with the serialization conventions employed by [BRC-100](../wallet/0100.md).
+In addition to the canonical JSON object, BRC-36 defines a canonical
+standalone binary representation for a single outpoint object. This
+binary profile is designed to be independently usable while remaining
+aligned with the serialization conventions employed by
+[BRC-100](../wallet/0100.md).
 
 ### Binary Field Order
 
-The binary representation of a BRC-36 object consists of the following fields in order:
+The binary representation of a BRC-36 object consists of the following
+fields in order:
 
-Field | Type | Description
-------|------|------------
-`outpoint` | Byte Array | The outpoint, encoded as 32 bytes of TXID followed by the output index.
-`satoshis` | VarInt | The number of satoshis in the output.
-`lockingScript` | VarInt Length + Byte Array | The locking script, if present. If absent, encode `-1`.
-`tx` | VarInt Length + Byte Array | The required Atomic BEEF payload.
+- `outpoint` (`Byte Array`): The outpoint, encoded as 32 bytes of TXID
+  followed by the output index.
+- `satoshis` (`VarInt`): The number of satoshis in the output.
+- `lockingScript` (`VarInt Length + Byte Array`): The locking script,
+  if present. If absent, encode `-1`.
+- `tx` (`VarInt Length + Byte Array`): The required Atomic BEEF
+  payload.
 
 ### Binary Encoding Rules
 
-- The `outpoint` field MUST use the same byte-level representation employed by [BRC-100](../wallet/0100.md) for output objects.
+- The `outpoint` field MUST use the same byte-level representation
+  employed by [BRC-100](../wallet/0100.md) for output objects.
 - The `satoshis` field MUST be encoded as a VarInt.
 - If `lockingScript` is absent, its length field MUST be encoded as `-1`.
-- The `tx` field MUST be present and MUST contain a valid [BRC-95](../transactions/0095.md) Atomic BEEF byte sequence.
-- The binary profile carries exactly the same semantics as the canonical JSON form and MUST NOT introduce transport-only framing fields.
+- The `tx` field MUST be present and MUST contain a valid
+  [BRC-95](../transactions/0095.md) Atomic BEEF byte sequence.
+- The binary profile carries exactly the same semantics as the
+  canonical JSON form and MUST NOT introduce transport-only framing
+  fields.
 
 ## Mapping to BRC-100
 
-This specification is intentionally aligned with the output model used by [BRC-100](../wallet/0100.md):
+This specification is intentionally aligned with the output model used
+by [BRC-100](../wallet/0100.md):
 
 - `outpoint` aligns directly with the BRC-100 output identifier.
 - `satoshis` aligns directly with the BRC-100 output amount.
-- `lockingScript`, when included, aligns directly with the optional script-return behavior in BRC-100 `listOutputs`.
-- `tx` corresponds to the transaction-validity payload returned in BRC-100 contexts that include full transaction data, except that BRC-36 standardizes a single-output portable object and requires the payload to be an Atomic BEEF associated with that output's creating transaction.
+- `lockingScript`, when included, aligns directly with the optional
+  script-return behavior in BRC-100 `listOutputs`.
+- `tx` corresponds to the transaction-validity payload returned in
+  BRC-100 contexts that include full transaction data, except that
+  BRC-36 standardizes a single-output portable object and requires the
+  payload to be an Atomic BEEF associated with that output's creating
+  transaction.
 
 ## Example
 
@@ -105,7 +156,8 @@ This specification is intentionally aligned with the output model used by [BRC-1
 ### Binary Layout Example
 
 ```text
-[outpoint bytes][satoshis varint][lockingScript length + bytes][atomicBEEF length + bytes]
+[outpoint bytes][satoshis varint][lockingScript length + bytes]
+[atomicBEEF length + bytes]
 ```
 
 ## Implementation
@@ -113,7 +165,9 @@ This specification is intentionally aligned with the output model used by [BRC-1
 Implementations of BRC-36 should adhere to the following guidelines:
 
 - Treat `outpoint` as the canonical identifier at the interoperability boundary.
-- Include `lockingScript` whenever the recipient is expected to inspect or evaluate the script.
-- Ensure the `tx` payload is a valid Atomic BEEF for the transaction that created the output.
-- When other standards extend this object, preserve the semantics of the four base fields defined here.
-
+- Include `lockingScript` whenever the recipient is expected to inspect
+  or evaluate the script.
+- Ensure the `tx` payload is a valid Atomic BEEF for the transaction
+  that created the output.
+- When other standards extend this object, preserve the semantics of
+  the four base fields defined here.

--- a/outpoints/0037.md
+++ b/outpoints/0037.md
@@ -1,35 +1,57 @@
 # BRC-37: Basket and Custom Instructions Extension for Bitcoin Outpoints
 
-Ty Everett (ty@projectbabbage.com)
+Ty Everett (`ty@projectbabbage.com`)
 
 ## Abstract
 
-This document defines a minimal extension to [BRC-36](./0036.md) for associating a Bitcoin outpoint with a wallet basket and, optionally, with custom instructions whose meaning is defined by that basket. The purpose of this extension is to support interoperable wallet-managed output organization without standardizing wallet-internal classification systems or forcing a universal instruction schema.
+This document defines a minimal extension to [BRC-36](./0036.md)
+for associating a Bitcoin outpoint with a wallet basket and,
+optionally, with custom instructions whose meaning is defined by that
+basket. The purpose of this extension is to support interoperable
+wallet-managed output organization without standardizing wallet-internal
+classification systems or forcing a universal instruction schema.
 
 ## Motivation
 
-Modern wallets do more than merely store outputs. They organize outputs into permissioned collections, often called baskets, and attach application-relevant metadata needed to later interpret or spend those outputs. This pattern is reflected in [BRC-46](../wallet/0046.md), [BRC-100](../wallet/0100.md), and current Wallet Toolbox implementations.
+Modern wallets do more than merely store outputs. They organize outputs
+into permissioned collections, often called baskets, and attach
+application-relevant metadata needed to later interpret or spend those
+outputs. This pattern is reflected in [BRC-46](../wallet/0046.md),
+[BRC-100](../wallet/0100.md), and current Wallet Toolbox
+implementations.
 
-The original version of BRC-37 used a broad `spendingInstructions` concept whose structure was left entirely to wallet software. That approach was too vague to provide meaningful interoperability. This revision keeps the extension intentionally small and precise: it standardizes basket association and optional custom instructions, while leaving basket-specific semantics to the basket itself and the higher-layer protocols that use it.
+The original version of BRC-37 used a broad `spendingInstructions`
+concept whose structure was left entirely to wallet software. That
+approach was too vague to provide meaningful interoperability. This
+revision keeps the extension intentionally small and precise: it
+standardizes basket association and optional custom instructions, while
+leaving basket-specific semantics to the basket itself and the
+higher-layer protocols that use it.
 
 ## Specification
 
 ### Extended Object
 
-A BRC-37 object is a [BRC-36](./0036.md) object extended with the following fields:
+A BRC-37 object is a [BRC-36](./0036.md) object extended with the
+following fields:
 
-Field | Required | Description
-------|----------|------------
-`basket` | yes | The basket with which the outpoint is associated.
-`customInstructions` | no | Basket-defined custom instructions associated with the outpoint.
+- `basket` (required): The basket with which the outpoint is
+  associated.
+- `customInstructions` (optional): Basket-defined custom instructions
+  associated with the outpoint.
 
 ### Semantics
 
-- The `basket` field identifies the basket context in which the output is to be interpreted.
-- The meaning of `customInstructions`, when present, is determined by the basket named in `basket`.
+- The `basket` field identifies the basket context in which the output
+  is to be interpreted.
+- The meaning of `customInstructions`, when present, is determined by
+  the basket named in `basket`.
 - BRC-37 does not define a universal schema for `customInstructions`.
 - BRC-37 does not require every basket to use `customInstructions`.
-- Software that understands a basket's semantics may interpret the corresponding `customInstructions` value. Software that does not understand that basket may still transport or store the value unchanged.
+- Software that understands a basket's semantics may interpret the
+  corresponding `customInstructions` value. Software that does not
+  understand that basket may still transport or store the value
+  unchanged.
 
 ### Scope Boundaries
 
@@ -40,7 +62,8 @@ BRC-37 does not standardize:
 - storage relations such as spending links, sequence bookkeeping, or script offsets
 - a general schema for all possible spending metadata
 
-Those concerns remain outside the scope of this specification unless separately standardized by another BRC.
+Those concerns remain outside the scope of this specification unless
+separately standardized by another BRC.
 
 ## Example Guidance
 
@@ -48,19 +71,31 @@ The following examples are non-normative and illustrative only.
 
 ### Basket-Defined Meaning
 
-A wallet may define a basket whose outputs all use the same `customInstructions` convention. Software that requests outputs from that basket can then interpret `customInstructions` according to the basket's documented semantics.
+A wallet may define a basket whose outputs all use the same
+`customInstructions` convention. Software that requests outputs from
+that basket can then interpret `customInstructions` according to the
+basket's documented semantics.
 
 ### BRC-29 Example
 
-In one possible implementation, outputs placed in the `default` basket may represent [BRC-29](../payments/0029.md) payments. In that context, `customInstructions` could contain a JSON-serialized object carrying payment-related context such as a sender identity key, derivation prefix, derivation suffix, or other information useful to the receiving wallet or application.
+In one possible implementation, outputs placed in the `default` basket
+may represent [BRC-29](../payments/0029.md) payments. In that context,
+`customInstructions` could contain a JSON-serialized object carrying
+payment-related context such as a sender identity key, derivation
+prefix, derivation suffix, or other information useful to the
+receiving wallet or application.
 
-This example is illustrative only. BRC-37 does not require the `default` basket to behave this way, nor does it impose a universal JSON schema for such instructions.
+This example is illustrative only. BRC-37 does not require the
+`default` basket to behave this way, nor does it impose a universal
+JSON schema for such instructions.
 
 ## Relationship to Other Standards
 
 - [BRC-36](./0036.md) defines the portable base output object.
 - [BRC-46](../wallet/0046.md) defines basket-oriented wallet behavior.
-- [BRC-100](../wallet/0100.md) defines the current interoperable wallet interface through which basket-associated outputs are commonly exchanged.
+- [BRC-100](../wallet/0100.md) defines the current interoperable wallet
+  interface through which basket-associated outputs are commonly
+  exchanged.
 
 ## Example
 
@@ -79,6 +114,8 @@ This example is illustrative only. BRC-37 does not require the `default` basket 
 
 Implementations of BRC-37 should adhere to the following guidelines:
 
-- Preserve unknown `customInstructions` values unchanged when transporting or storing BRC-37 objects.
-- Define basket-specific semantics in the protocol or implementation documentation for that basket.
+- Preserve unknown `customInstructions` values unchanged when
+  transporting or storing BRC-37 objects.
+- Define basket-specific semantics in the protocol or implementation
+  documentation for that basket.
 - Avoid treating BRC-37 as a general container for arbitrary wallet-internal state.

--- a/outpoints/0037.md
+++ b/outpoints/0037.md
@@ -1,11 +1,84 @@
-# BRC-37: Spending Instructions Extension for UTXO Storage Format
+# BRC-37: Basket and Custom Instructions Extension for Bitcoin Outpoints
 
 Ty Everett (ty@projectbabbage.com)
 
-**Abstract:** This document defines a simple extension to the [BRC-36](./0036.md) UTXO storage format, adding a `spendingInstructions` field to the UTXO Storage Object. This field allows for the storage of necessary information, such as key derivation details and overlay network operator contact information, that may be required to unlock and spend a particular UTXO, or to notify relevant parties of its spending.
+## Abstract
 
-**Specification:** The [BRC-36](./0036.md) UTXO Storage Object is extended to include an optional `spendingInstructions` field. This field can store any relevant data that may be necessary for spending the UTXO, as determined by the wallet software that stored the UTXO. The structure and interpretation of the `spendingInstructions` field is left to the wallet software, allowing for flexibility in handling different mechanisms, such as "output baskets", tokenization protocol separation, or any other method.
+This document defines a minimal extension to [BRC-36](./0036.md) for associating a Bitcoin outpoint with a wallet basket and, optionally, with custom instructions whose meaning is defined by that basket. The purpose of this extension is to support interoperable wallet-managed output organization without standardizing wallet-internal classification systems or forcing a universal instruction schema.
 
-> For example, a wallet could separate UTXOs of different types into output baskets. All the tokens in a given basket have spending instructions in the same format, and any software could request access to the outputs in a given basket. After the wallet obtains permission from the user, the software is given access to the tokens alongside their spending instructions. Programs that work with various types of UTXOs only need to know how to use specific spending instruction formats, and they can be confident that all UTXOs in a particular basket will conform to the format they know how to use because protocols can define expectations for tokens in particular baskets.
+## Motivation
 
-By incorporating the `spendingInstructions` field into the [BRC-36](./0036.md) UTXO storage format, this extension enhances the utility and flexibility of the storage standard, enabling wallet software to store and convey crucial spending information alongside the UTXO data.
+Modern wallets do more than merely store outputs. They organize outputs into permissioned collections, often called baskets, and attach application-relevant metadata needed to later interpret or spend those outputs. This pattern is reflected in [BRC-46](../wallet/0046.md), [BRC-100](../wallet/0100.md), and current Wallet Toolbox implementations.
+
+The original version of BRC-37 used a broad `spendingInstructions` concept whose structure was left entirely to wallet software. That approach was too vague to provide meaningful interoperability. This revision keeps the extension intentionally small and precise: it standardizes basket association and optional custom instructions, while leaving basket-specific semantics to the basket itself and the higher-layer protocols that use it.
+
+## Specification
+
+### Extended Object
+
+A BRC-37 object is a [BRC-36](./0036.md) object extended with the following fields:
+
+Field | Required | Description
+------|----------|------------
+`basket` | yes | The basket with which the outpoint is associated.
+`customInstructions` | no | Basket-defined custom instructions associated with the outpoint.
+
+### Semantics
+
+- The `basket` field identifies the basket context in which the output is to be interpreted.
+- The meaning of `customInstructions`, when present, is determined by the basket named in `basket`.
+- BRC-37 does not define a universal schema for `customInstructions`.
+- BRC-37 does not require every basket to use `customInstructions`.
+- Software that understands a basket's semantics may interpret the corresponding `customInstructions` value. Software that does not understand that basket may still transport or store the value unchanged.
+
+### Scope Boundaries
+
+BRC-37 does not standardize:
+
+- wallet-internal state such as `spendable` or `change`
+- wallet-specific classification fields such as `purpose` or `type`
+- storage relations such as spending links, sequence bookkeeping, or script offsets
+- a general schema for all possible spending metadata
+
+Those concerns remain outside the scope of this specification unless separately standardized by another BRC.
+
+## Example Guidance
+
+The following examples are non-normative and illustrative only.
+
+### Basket-Defined Meaning
+
+A wallet may define a basket whose outputs all use the same `customInstructions` convention. Software that requests outputs from that basket can then interpret `customInstructions` according to the basket's documented semantics.
+
+### BRC-29 Example
+
+In one possible implementation, outputs placed in the `default` basket may represent [BRC-29](../payments/0029.md) payments. In that context, `customInstructions` could contain a JSON-serialized object carrying payment-related context such as a sender identity key, derivation prefix, derivation suffix, or other information useful to the receiving wallet or application.
+
+This example is illustrative only. BRC-37 does not require the `default` basket to behave this way, nor does it impose a universal JSON schema for such instructions.
+
+## Relationship to Other Standards
+
+- [BRC-36](./0036.md) defines the portable base output object.
+- [BRC-46](../wallet/0046.md) defines basket-oriented wallet behavior.
+- [BRC-100](../wallet/0100.md) defines the current interoperable wallet interface through which basket-associated outputs are commonly exchanged.
+
+## Example
+
+```json
+{
+  "outpoint": "7001295a287fee8e7ad5de58ed30bd61923977ddc9b7a44830ebb9a68b12dc39.0",
+  "satoshis": 500,
+  "lockingScript": "76a9148055582669432149141abcf887fced6881f7404288ac",
+  "tx": "01010101...",
+  "basket": "default",
+  "customInstructions": "{\"senderIdentityKey\":\"03...\",\"derivationPrefix\":\"...\",\"derivationSuffix\":\"...\"}"
+}
+```
+
+## Implementation
+
+Implementations of BRC-37 should adhere to the following guidelines:
+
+- Preserve unknown `customInstructions` values unchanged when transporting or storing BRC-37 objects.
+- Define basket-specific semantics in the protocol or implementation documentation for that basket.
+- Avoid treating BRC-37 as a general container for arbitrary wallet-internal state.

--- a/outpoints/0038.md
+++ b/outpoints/0038.md
@@ -4,7 +4,7 @@ Ty Everett (ty@projectbabbage.com)
 
 ## Abstract
 
-This specification defines a canonical, complete, portable file format for exporting all current Wallet Toolbox data for a single user as one blob.
+This specification defines a canonical, complete, portable file format for exporting Wallet Toolbox data for a single user as one blob.
 
 The format is intended to support:
 
@@ -14,7 +14,7 @@ The format is intended to support:
 - storage-provider migration
 - backup, archival, and forensic recovery
 
-This specification is based on the current Wallet Toolbox storage implementation. It defines a canonical plaintext payload format for a single-user export. Encryption and protected transport are out of scope for this document and belong in a separate extension.
+This specification is based on the Wallet Toolbox storage implementation. It defines a canonical plaintext payload format for a single-user export. Encryption and protected transport are out of scope for this document and belong in a separate extension.
 
 ## Motivation
 
@@ -42,7 +42,7 @@ It does not define:
 - transport protocols for moving the blob
 - multi-user export containers
 - chain-wide or storage-global operational logs unrelated to one user
-- root-key, profile, or encrypted snapshot material that is not part of the current Wallet Toolbox storage schema
+- root-key, profile, or encrypted snapshot material that is not part of the Wallet Toolbox storage schema
 
 ### 2. Conformance
 
@@ -141,7 +141,7 @@ The following fields are binary:
 
 #### 5.3 Structured JSON-in-String Fields
 
-The current Wallet Toolbox schema stores some structured values as JSON strings. In BRC-38 these MUST be exported as decoded JSON values, not as embedded JSON strings.
+The Wallet Toolbox schema stores some structured values as JSON strings. In BRC-38 these MUST be exported as decoded JSON values, not as embedded JSON strings.
 
 The affected fields are:
 
@@ -165,7 +165,7 @@ If a field is absent or undefined in the source dataset, it MUST be omitted from
 
 ### 6. Export Closure
 
-The exported dataset for a user is the following closure over the current Wallet Toolbox schema.
+The exported dataset for a user is the following closure over the Wallet Toolbox schema.
 
 #### 6.1 Required Singletons
 
@@ -213,7 +213,7 @@ The export MUST include:
 
 The export MUST NOT include storage-global tables that are not scoped to a single user.
 
-In the current Wallet Toolbox implementation this means:
+In the Wallet Toolbox implementation this means:
 
 - `monitor_events` MUST NOT be included
 
@@ -586,7 +586,7 @@ Implementations MUST treat BRC-38 blobs as highly sensitive user data.
 
 ### 12. Implementation Notes
 
-This specification is based on the current Wallet Toolbox schema:
+This specification is based on the Wallet Toolbox schema:
 
 - `users`
 - `proven_txs`

--- a/outpoints/0038.md
+++ b/outpoints/0038.md
@@ -1,0 +1,614 @@
+# BRC-38: User Wallet Data Format
+
+Ty Everett (ty@projectbabbage.com)
+
+## Abstract
+
+This specification defines a canonical, complete, portable file format for exporting all current Wallet Toolbox data for a single user as one blob.
+
+The format is intended to support:
+
+- strong user data portability
+- GDPR and similar access/export requirements
+- wallet import and export
+- storage-provider migration
+- backup, archival, and forensic recovery
+
+This specification is based on the current Wallet Toolbox storage implementation. It defines a canonical plaintext payload format for a single-user export. Encryption and protected transport are out of scope for this document and belong in a separate extension.
+
+## Motivation
+
+Wallet data portability is only meaningful if the exported artifact is complete, stable, and implementation-neutral.
+
+Exporting only high-level balances or transaction lists is insufficient. A serious wallet export must preserve:
+
+- all user-owned records
+- all user-linked proof and broadcast state
+- deleted/tombstoned rows
+- wallet-local metadata needed to reconstruct labels, baskets, certificates, sync state, and action history
+
+Wallet Toolbox already has a rich schema that captures this information, but it does not yet define a canonical single-file export format. This specification fills that gap.
+
+## Specification
+
+### 1. Scope
+
+This specification defines the canonical plaintext payload for exporting all Wallet Toolbox data for one user.
+
+It does not define:
+
+- encryption of the export blob
+- compression of the export blob
+- transport protocols for moving the blob
+- multi-user export containers
+- chain-wide or storage-global operational logs unrelated to one user
+- root-key, profile, or encrypted snapshot material that is not part of the current Wallet Toolbox storage schema
+
+### 2. Conformance
+
+An implementation conforms to BRC-38 if it can:
+
+1. export a single user's Wallet Toolbox data into the canonical format defined here
+2. parse a BRC-38 blob and reconstruct the exported dataset semantics
+3. preserve all included row values, relationships, tombstones, and binary payloads without loss
+
+### 3. Canonical File Form
+
+The canonical BRC-38 artifact is a UTF-8 JSON document serialized according to RFC 8785 JSON Canonicalization Scheme (JCS).
+
+The canonical unencrypted file extension SHOULD be:
+
+- `.brc38.json`
+
+If a deployment wraps, compresses, or encrypts the document, the canonical BRC-38 payload remains the inner JSON document defined here.
+
+### 4. Top-Level Document
+
+The canonical top-level object MUST have the following shape:
+
+```json
+{
+  "brc": 38,
+  "title": "User Wallet Data Format",
+  "formatVersion": 1,
+  "exportedAt": "2026-04-23T20:00:00.000Z",
+  "sourceStorage": {
+    "created_at": "2026-04-01T00:00:00.000Z",
+    "updated_at": "2026-04-23T20:00:00.000Z",
+    "storageIdentityKey": "<hex>",
+    "storageName": "Primary Wallet Storage",
+    "chain": "main",
+    "dbtype": "SQLite",
+    "maxOutputScript": 1024
+  },
+  "user": {
+    "...": "..."
+  },
+  "tables": {
+    "provenTxs": [],
+    "provenTxReqs": [],
+    "outputBaskets": [],
+    "transactions": [],
+    "commissions": [],
+    "outputs": [],
+    "outputTags": [],
+    "outputTagMaps": [],
+    "txLabels": [],
+    "txLabelMaps": [],
+    "certificates": [],
+    "certificateFields": [],
+    "syncStates": []
+  }
+}
+```
+
+Top-level requirements:
+
+- `brc` MUST equal `38`.
+- `title` MUST equal `User Wallet Data Format`.
+- `formatVersion` MUST equal `1` for this version of the format.
+- `exportedAt` MUST be the UTC timestamp at which the export payload was finalized.
+- `sourceStorage` MUST contain the exported storage's current `settings` row in portable form.
+- `user` MUST contain exactly one exported user row in portable form.
+- `tables` MUST contain every array listed above, even if empty.
+
+### 5. Canonical Value Encoding
+
+#### 5.1 Timestamps
+
+All timestamp values MUST be exported as strings in UTC using the exact form:
+
+- `YYYY-MM-DDTHH:MM:SS.sssZ`
+
+Offsets other than `Z` MUST NOT be used.
+
+#### 5.2 Binary Data
+
+Fields stored in Wallet Toolbox as `number[]` byte arrays MUST be exported as standard RFC 4648 base64 strings with padding.
+
+No whitespace is permitted in base64 values.
+
+The following fields are binary:
+
+- `TableCommission.lockingScript`
+- `TableOutput.lockingScript`
+- `TableProvenTx.merklePath`
+- `TableProvenTx.rawTx`
+- `TableProvenTxReq.rawTx`
+- `TableProvenTxReq.inputBEEF`
+- `TableTransaction.inputBEEF`
+- `TableTransaction.rawTx`
+
+#### 5.3 Structured JSON-in-String Fields
+
+The current Wallet Toolbox schema stores some structured values as JSON strings. In BRC-38 these MUST be exported as decoded JSON values, not as embedded JSON strings.
+
+The affected fields are:
+
+- `TableProvenTxReq.history`
+- `TableProvenTxReq.notify`
+- `TableSyncState.syncMap`
+- `TableSyncState.errorLocal`
+- `TableSyncState.errorOther`
+
+Their portable BRC-38 forms are:
+
+- `history`: object
+- `notify`: object
+- `syncMap`: object
+- `errorLocal`: object or omitted
+- `errorOther`: object or omitted
+
+#### 5.4 Optional Fields
+
+If a field is absent or undefined in the source dataset, it MUST be omitted from the exported JSON rather than emitted as `null`.
+
+### 6. Export Closure
+
+The exported dataset for a user is the following closure over the current Wallet Toolbox schema.
+
+#### 6.1 Required Singletons
+
+The export MUST include:
+
+- exactly one `user` row for the requested user identity
+- exactly one `sourceStorage` object derived from the exporting storage's settings row
+
+#### 6.2 User-Owned Tables
+
+The export MUST include every row from the following tables where `userId` equals the exported user's `userId`:
+
+- `output_baskets`
+- `transactions`
+- `commissions`
+- `outputs`
+- `output_tags`
+- `tx_labels`
+- `certificates`
+- `certificate_fields`
+- `sync_states`
+
+#### 6.3 User-Linked Map Tables
+
+The export MUST include:
+
+- every `tx_labels_map` row whose `txLabelId` references an exported `tx_labels` row
+- every `output_tags_map` row whose `outputTagId` references an exported `output_tags` row
+
+An exporter SHOULD additionally verify that:
+
+- every exported `tx_labels_map.transactionId` references an exported transaction
+- every exported `output_tags_map.outputId` references an exported output
+
+#### 6.4 User-Linked Proof Tables
+
+The export MUST include:
+
+- every `proven_tx_reqs` row whose `txid` matches the `txid` of an exported transaction
+- every `proven_txs` row whose `provenTxId` is referenced by:
+  - an exported transaction, or
+  - an exported `proven_tx_reqs` row
+
+#### 6.5 Excluded Storage-Global Tables
+
+The export MUST NOT include storage-global tables that are not scoped to a single user.
+
+In the current Wallet Toolbox implementation this means:
+
+- `monitor_events` MUST NOT be included
+
+### 7. Portable Row Forms
+
+The BRC-38 portable row forms are defined below.
+
+#### 7.1 User
+
+```json
+{
+  "created_at": "2026-04-01T00:00:00.000Z",
+  "updated_at": "2026-04-23T20:00:00.000Z",
+  "userId": 1,
+  "identityKey": "<hex>",
+  "activeStorage": "<storageIdentityKey>"
+}
+```
+
+#### 7.2 Proven Transaction
+
+```json
+{
+  "created_at": "2026-04-01T00:00:00.000Z",
+  "updated_at": "2026-04-23T20:00:00.000Z",
+  "provenTxId": 7,
+  "txid": "<hex>",
+  "height": 900000,
+  "index": 12,
+  "merklePath": "<base64>",
+  "rawTx": "<base64>",
+  "blockHash": "<hex>",
+  "merkleRoot": "<hex>"
+}
+```
+
+#### 7.3 Proven Transaction Request
+
+```json
+{
+  "created_at": "2026-04-01T00:00:00.000Z",
+  "updated_at": "2026-04-23T20:00:00.000Z",
+  "provenTxReqId": 8,
+  "provenTxId": 7,
+  "status": "completed",
+  "attempts": 2,
+  "notified": true,
+  "txid": "<hex>",
+  "batch": "abc123",
+  "history": {
+    "notes": []
+  },
+  "notify": {
+    "transactionIds": [42]
+  },
+  "rawTx": "<base64>",
+  "inputBEEF": "<base64>"
+}
+```
+
+`history` MUST conform to:
+
+```json
+{
+  "notes": [
+    {
+      "when": "2026-04-23T20:00:00.000Z",
+      "what": "sent"
+    }
+  ]
+}
+```
+
+`notify` MUST conform to:
+
+```json
+{
+  "transactionIds": [1, 2, 3]
+}
+```
+
+#### 7.4 Output Basket
+
+```json
+{
+  "created_at": "2026-04-01T00:00:00.000Z",
+  "updated_at": "2026-04-23T20:00:00.000Z",
+  "basketId": 2,
+  "userId": 1,
+  "name": "default",
+  "numberOfDesiredUTXOs": 32,
+  "minimumDesiredUTXOValue": 1000,
+  "isDeleted": false
+}
+```
+
+#### 7.5 Transaction
+
+```json
+{
+  "created_at": "2026-04-01T00:00:00.000Z",
+  "updated_at": "2026-04-23T20:00:00.000Z",
+  "transactionId": 42,
+  "userId": 1,
+  "provenTxId": 7,
+  "status": "completed",
+  "reference": "<base64>",
+  "isOutgoing": true,
+  "satoshis": 1234,
+  "description": "Payment",
+  "version": 1,
+  "lockTime": 0,
+  "txid": "<hex>",
+  "inputBEEF": "<base64>",
+  "rawTx": "<base64>"
+}
+```
+
+#### 7.6 Commission
+
+```json
+{
+  "created_at": "2026-04-01T00:00:00.000Z",
+  "updated_at": "2026-04-23T20:00:00.000Z",
+  "commissionId": 3,
+  "userId": 1,
+  "transactionId": 42,
+  "satoshis": 5,
+  "keyOffset": "<string>",
+  "isRedeemed": false,
+  "lockingScript": "<base64>"
+}
+```
+
+#### 7.7 Output
+
+```json
+{
+  "created_at": "2026-04-01T00:00:00.000Z",
+  "updated_at": "2026-04-23T20:00:00.000Z",
+  "outputId": 11,
+  "userId": 1,
+  "transactionId": 42,
+  "basketId": 2,
+  "spendable": true,
+  "change": false,
+  "outputDescription": "payment output",
+  "vout": 0,
+  "satoshis": 1234,
+  "providedBy": "you",
+  "purpose": "payment",
+  "type": "P2PKH",
+  "txid": "<hex>",
+  "senderIdentityKey": "<hex>",
+  "derivationPrefix": "<base64>",
+  "derivationSuffix": "<base64>",
+  "customInstructions": "optional",
+  "spentBy": 99,
+  "sequenceNumber": 0,
+  "spendingDescription": "optional",
+  "scriptLength": 25,
+  "scriptOffset": 0,
+  "lockingScript": "<base64>"
+}
+```
+
+#### 7.8 Output Tag
+
+```json
+{
+  "created_at": "2026-04-01T00:00:00.000Z",
+  "updated_at": "2026-04-23T20:00:00.000Z",
+  "outputTagId": 4,
+  "userId": 1,
+  "tag": "invoice",
+  "isDeleted": false
+}
+```
+
+#### 7.9 Output Tag Map
+
+```json
+{
+  "created_at": "2026-04-01T00:00:00.000Z",
+  "updated_at": "2026-04-23T20:00:00.000Z",
+  "outputTagId": 4,
+  "outputId": 11,
+  "isDeleted": false
+}
+```
+
+#### 7.10 Transaction Label
+
+```json
+{
+  "created_at": "2026-04-01T00:00:00.000Z",
+  "updated_at": "2026-04-23T20:00:00.000Z",
+  "txLabelId": 5,
+  "userId": 1,
+  "label": "expenses",
+  "isDeleted": false
+}
+```
+
+#### 7.11 Transaction Label Map
+
+```json
+{
+  "created_at": "2026-04-01T00:00:00.000Z",
+  "updated_at": "2026-04-23T20:00:00.000Z",
+  "txLabelId": 5,
+  "transactionId": 42,
+  "isDeleted": false
+}
+```
+
+#### 7.12 Certificate
+
+```json
+{
+  "created_at": "2026-04-01T00:00:00.000Z",
+  "updated_at": "2026-04-23T20:00:00.000Z",
+  "certificateId": 6,
+  "userId": 1,
+  "type": "<base64>",
+  "serialNumber": "<base64>",
+  "certifier": "<hex>",
+  "subject": "<hex>",
+  "verifier": "<hex>",
+  "revocationOutpoint": "<txid>.<vout>",
+  "signature": "<hex>",
+  "isDeleted": false
+}
+```
+
+#### 7.13 Certificate Field
+
+```json
+{
+  "created_at": "2026-04-01T00:00:00.000Z",
+  "updated_at": "2026-04-23T20:00:00.000Z",
+  "userId": 1,
+  "certificateId": 6,
+  "fieldName": "email",
+  "fieldValue": "alice@example.com",
+  "masterKey": "<base64>"
+}
+```
+
+#### 7.14 Sync State
+
+```json
+{
+  "created_at": "2026-04-01T00:00:00.000Z",
+  "updated_at": "2026-04-23T20:00:00.000Z",
+  "syncStateId": 9,
+  "userId": 1,
+  "storageIdentityKey": "<hex>",
+  "storageName": "Backup Storage",
+  "status": "success",
+  "init": true,
+  "refNum": "<string>",
+  "syncMap": {
+    "provenTx": { "entityName": "provenTx", "idMap": {}, "count": 0 },
+    "outputBasket": { "entityName": "outputBasket", "idMap": {}, "count": 0 },
+    "transaction": { "entityName": "transaction", "idMap": {}, "count": 0 },
+    "provenTxReq": { "entityName": "provenTxReq", "idMap": {}, "count": 0 },
+    "txLabel": { "entityName": "txLabel", "idMap": {}, "count": 0 },
+    "txLabelMap": { "entityName": "txLabelMap", "idMap": {}, "count": 0 },
+    "output": { "entityName": "output", "idMap": {}, "count": 0 },
+    "outputTag": { "entityName": "outputTag", "idMap": {}, "count": 0 },
+    "outputTagMap": { "entityName": "outputTagMap", "idMap": {}, "count": 0 },
+    "certificate": { "entityName": "certificate", "idMap": {}, "count": 0 },
+    "certificateField": { "entityName": "certificateField", "idMap": {}, "count": 0 },
+    "commission": { "entityName": "commission", "idMap": {}, "count": 0 }
+  },
+  "when": "2026-04-23T20:00:00.000Z",
+  "satoshis": 123456,
+  "errorLocal": {
+    "code": "example",
+    "description": "example",
+    "stack": "optional"
+  },
+  "errorOther": {
+    "code": "example",
+    "description": "example"
+  }
+}
+```
+
+Each sync error object MUST conform to:
+
+```json
+{
+  "code": "string",
+  "description": "string",
+  "stack": "optional string"
+}
+```
+
+### 8. Array Ordering
+
+For canonical serialization, the arrays inside `tables` MUST be sorted ascending as follows:
+
+- `provenTxs` by `provenTxId`
+- `provenTxReqs` by `provenTxReqId`
+- `outputBaskets` by `basketId`
+- `transactions` by `transactionId`
+- `commissions` by `commissionId`
+- `outputs` by `outputId`
+- `outputTags` by `outputTagId`
+- `outputTagMaps` by `outputId`, then `outputTagId`
+- `txLabels` by `txLabelId`
+- `txLabelMaps` by `transactionId`, then `txLabelId`
+- `certificates` by `certificateId`
+- `certificateFields` by `certificateId`, then `fieldName`
+- `syncStates` by `syncStateId`
+
+### 9. Relationship Integrity
+
+An exporter MUST ensure that every foreign-key-like reference inside the payload resolves within the exported document, except where the source schema intentionally stores an optional unresolved reference.
+
+At minimum:
+
+- every exported `transaction.userId` MUST equal `user.userId`
+- every exported `output.userId` MUST equal `user.userId`
+- every exported `output.transactionId` MUST reference an exported transaction
+- every exported `commission.transactionId` MUST reference an exported transaction
+- every exported `txLabelMap.txLabelId` MUST reference an exported transaction label
+- every exported `txLabelMap.transactionId` MUST reference an exported transaction
+- every exported `outputTagMap.outputTagId` MUST reference an exported output tag
+- every exported `outputTagMap.outputId` MUST reference an exported output
+- every exported `certificateField.certificateId` MUST reference an exported certificate
+
+If `user.activeStorage` does not equal `sourceStorage.storageIdentityKey`, the exporter MUST still preserve the exact `user.activeStorage` value.
+
+### 10. Import Semantics
+
+BRC-38 defines the portable payload, not a mandatory database insertion strategy.
+
+Importers:
+
+- MUST preserve row values and relationships semantically
+- MAY preserve numeric primary IDs exactly
+- MAY remap numeric primary IDs during import, provided every internal reference is updated consistently
+- MUST preserve tombstones such as `isDeleted`
+- MUST preserve status fields exactly
+
+Importers MAY treat the following as operationally sensitive and choose whether to activate them immediately after import:
+
+- `user.activeStorage`
+- `syncStates`
+
+However, a conforming importer MUST still parse and preserve those values in the imported dataset.
+
+### 11. Privacy and Security
+
+BRC-38 exports are intentionally complete and sensitive.
+
+A BRC-38 blob may contain:
+
+- raw transactions
+- merkle proofs
+- wallet labeling and description data
+- certificate contents
+- encrypted field material and derivation metadata
+- sync history and storage topology hints
+
+Implementations MUST treat BRC-38 blobs as highly sensitive user data.
+
+### 12. Implementation Notes
+
+This specification is based on the current Wallet Toolbox schema:
+
+- `users`
+- `proven_txs`
+- `proven_tx_reqs`
+- `output_baskets`
+- `transactions`
+- `commissions`
+- `outputs`
+- `output_tags`
+- `output_tags_map`
+- `tx_labels`
+- `tx_labels_map`
+- `certificates`
+- `certificate_fields`
+- `sync_states`
+- storage `settings` as export metadata
+
+The storage-global `monitor_events` table is intentionally excluded because it is not scoped to a single user.
+
+## References
+
+- [BRC-40: User Wallet Data Synchronization](./0040.md)
+- [BRC-100: Unified, Vendor-Neutral, Unchanging, and Open BSV Blockchain Standard Wallet-to-Application Interface](../wallet/0100.md)
+- [RFC 8785: JSON Canonicalization Scheme (JCS)](https://www.rfc-editor.org/rfc/rfc8785)
+- [Wallet Toolbox Repository](https://github.com/bsv-blockchain/wallet-toolbox)

--- a/outpoints/0039.md
+++ b/outpoints/0039.md
@@ -6,7 +6,7 @@ Ty Everett (ty@projectbabbage.com)
 
 This specification defines the canonical encrypted wrapper for [BRC-38](./0038.md) user wallet data exports.
 
-It standardizes a downloadable binary file format, conventionally named `wallet.dat`, for password-protected wallet export and import. The design is intended for strong user data portability, backups, archival export, GDPR-style data access, and migration between wallet implementations and storage providers.
+It standardizes a downloadable binary file format, conventionally named `wallet.brc39`, for password-protected wallet export and import. The design is intended for strong user data portability, backups, archival export, GDPR-style data access, and migration between wallet implementations and storage providers.
 
 BRC-39 uses:
 
@@ -62,8 +62,8 @@ An implementation conforms to BRC-39 if it can:
 The canonical encrypted export artifact:
 
 - MUST be a binary file
-- SHOULD be named `wallet.dat`
-- SHOULD use media type `application/vnd.brc39.wallet-dat`
+- SHOULD be named `wallet.brc39`
+- SHOULD use media type `application/vnd.brc39.wallet`
 
 The inner plaintext payload MUST be a complete BRC-38 document serialized as canonical UTF-8 JSON.
 
@@ -101,7 +101,7 @@ The canonical default Argon2id parameters are:
 - hashLength: `32`
 - saltLength: `32`
 
-These defaults align with the current Wallet Toolbox Argon2id defaults.
+These defaults align with the Wallet Toolbox Argon2id defaults this specification is intended to standardize.
 
 Implementations MAY use stronger Argon2id parameters, but they MUST encode the exact parameters used in the file header.
 
@@ -223,7 +223,7 @@ To create a BRC-39 file, an exporter MUST:
    - key = derived key
    - nonce = header nonce
 9. append `CiphertextAndTag`
-10. emit the resulting bytes as `wallet.dat`
+10. emit the resulting bytes as `wallet.brc39`
 
 ### 8. Import Procedure
 
@@ -304,7 +304,7 @@ Wallet implementations:
 
 An example canonical new-export header therefore means:
 
-- file type: `wallet.dat`
+- file type: `wallet.brc39`
 - payload type: BRC-38
 - protection mode: password
 - KDF: Argon2id
@@ -317,7 +317,7 @@ An example canonical new-export header therefore means:
 An implementation based on Wallet Toolbox can produce a BRC-39 file by:
 
 1. exporting a full BRC-38 payload for the selected user
-2. deriving a password key with Argon2id using the current Toolbox default parameters
+2. deriving a password key with Argon2id using the standardized Toolbox-compatible default parameters
 3. encrypting the payload with AES-256-GCM
 4. writing the standardized binary envelope described above
 

--- a/outpoints/0039.md
+++ b/outpoints/0039.md
@@ -119,11 +119,9 @@ The nonce MUST be generated randomly for each export.
 
 The GCM authentication tag length MUST be 16 bytes.
 
-#### 4.5 Header Authentication
+#### 4.5 Header Validation
 
-All header bytes up to but not including the ciphertext MUST be supplied as AES-GCM Additional Authenticated Data (AAD).
-
-This ensures that tampering with version, KDF parameters, payload type, or other header fields causes decryption failure.
+Header fields are validated before decryption as specified below. BRC-39 encrypts only the BRC-38 plaintext payload.
 
 ### 5. File Layout
 
@@ -137,8 +135,8 @@ The canonical BRC-39 file layout is:
 | Format Version | 1 byte | Currently `0x01` |
 | Protector Type | 1 byte | Currently `0x01` for password-protected export |
 | Inner Format | 1 byte | Currently `0x26` (decimal 38) for BRC-38 |
-| KDF Type | 1 byte | `0x01` = Argon2id, `0x02` = PBKDF2-SHA512 legacy |
-| Flags | 1 byte | Currently `0x01`; all other bits reserved and MUST be zero |
+| KDF Type | 1 byte | Currently `0x01` = Argon2id |
+| Flags | 1 byte | Currently `0x00`; all bits reserved and MUST be zero |
 | Salt Length | 1 byte | Currently `0x20` (32) |
 | Nonce Length | 1 byte | Currently `0x20` (32) |
 | Argon2id Iterations | 4 bytes | Work factor |
@@ -149,15 +147,6 @@ The canonical BRC-39 file layout is:
 | Salt | variable | `Salt Length` bytes |
 | Nonce | variable | `Nonce Length` bytes |
 | CiphertextAndTag | variable | AES-256-GCM ciphertext followed by 16-byte tag |
-
-For `KDF Type = 0x02` (legacy PBKDF2-SHA512 import support):
-
-- `Argon2id Iterations` MUST instead contain the PBKDF2 iteration count
-- `Argon2id Memory KiB` MUST be zero
-- `Argon2id Parallelism` MUST be zero
-- `Argon2id Hash Length` MUST be 32
-
-New exports MUST NOT use `KDF Type = 0x02`.
 
 ### 6. Header Field Requirements
 
@@ -199,16 +188,23 @@ For BRC-39 wallet exports:
 
 Meaning the decrypted plaintext MUST be a valid BRC-38 document.
 
-#### 6.5 Flags
+#### 6.5 KDF Type
 
-Bit 0 indicates that the header is authenticated as AES-GCM AAD.
+The following KDF type is defined:
+
+- `0x01`: Argon2id
+
+All other KDF type values are reserved for future specifications. This version of BRC-39 defines no alternate KDF import mode.
+
+#### 6.6 Flags
+
+All flag bits are reserved for future specifications.
 
 For this specification:
 
-- bit 0 MUST be set to `1`
-- all other bits MUST be zero
+- `Flags` MUST be `0x00`
 
-#### 6.6 Reserved Bytes
+#### 6.7 Reserved Bytes
 
 All reserved bytes MUST be zero on export and MUST be ignored only if zero on import. Non-zero reserved bytes MUST cause rejection.
 
@@ -226,7 +222,6 @@ To create a BRC-39 file, an exporter MUST:
 8. encrypt the BRC-38 plaintext using AES-256-GCM with:
    - key = derived key
    - nonce = header nonce
-   - AAD = header bytes through the nonce field
 9. append `CiphertextAndTag`
 10. emit the resulting bytes as `wallet.dat`
 
@@ -235,38 +230,24 @@ To create a BRC-39 file, an exporter MUST:
 To import a BRC-39 file, an importer MUST:
 
 1. parse and validate the binary header
-2. verify `Magic`, `Format Version`, `Protector Type`, `Inner Format`, `Flags`, and reserved bytes
+2. verify `Magic`, `Format Version`, `Protector Type`, `Inner Format`, `KDF Type`, `Flags`, and reserved bytes
 3. obtain the user password
 4. normalize the password to NFC and encode it as UTF-8
 5. derive the decryption key using the encoded KDF parameters from the file
 6. decrypt `CiphertextAndTag` with AES-256-GCM using:
    - key = derived key
    - nonce = header nonce
-   - AAD = header bytes through the nonce field
 7. reject the file if GCM authentication fails
 8. parse the plaintext as UTF-8 JSON
 9. validate that the plaintext is a valid BRC-38 document
 
 Only after successful BRC-38 validation may the importer proceed to import wallet data into local storage.
 
-### 9. Legacy PBKDF2 Import Support
+### 9. KDF Compatibility
 
-For compatibility with existing Wallet Toolbox password-derived key usage, implementations MAY support:
+BRC-39 standardizes only Argon2id for password-based wallet export encryption.
 
-- `KDF Type = 0x02` for PBKDF2-SHA512
-
-The canonical legacy PBKDF2 default is:
-
-- iterations: `7777`
-- derived key length: `32`
-
-Implementations that support legacy PBKDF2:
-
-- MUST still emit the same BRC-39 binary envelope
-- MUST still use AES-256-GCM content encryption
-- MUST NOT produce new exports using PBKDF2 unless explicitly requested for legacy compatibility
-
-Canonical new exports MUST use Argon2id.
+Implementations MUST reject files whose `KDF Type` is not `0x01`. Compatibility with pre-standard password-derived wallet internals is outside the BRC-39 file format.
 
 ### 10. Relationship to BRC-2 and BRC-78
 
@@ -276,7 +257,7 @@ BRC-39 uses the same symmetric encryption primitive family as BRC-2:
 
 - AES-256-GCM
 
-Unlike BRC-2 application messages, BRC-39 stores the nonce explicitly in the binary file header instead of prepending it to a message payload, and authenticates the header via AES-GCM AAD.
+Unlike BRC-2 application messages, BRC-39 stores the nonce explicitly in the binary file header instead of prepending it to a message payload.
 
 #### 10.2 BRC-78
 
@@ -294,11 +275,12 @@ A BRC-39 file MUST be rejected if:
 - `Format Version` is unsupported
 - `Protector Type` is unsupported
 - `Inner Format` is not `38`
-- `Flags` contains unsupported bits
+- `KDF Type` is not `0x01`
+- `Flags` is not `0x00`
 - `Salt Length` is zero
 - `Nonce Length` is zero
 - reserved bytes are non-zero
-- `KDF Type = Argon2id` and any of:
+- any Argon2id parameter is invalid, including:
   - iterations is zero
   - memoryKiB is zero
   - parallelism is zero

--- a/outpoints/0039.md
+++ b/outpoints/0039.md
@@ -1,0 +1,348 @@
+# BRC-39: User Wallet Data Format Encryption Extension
+
+Ty Everett (ty@projectbabbage.com)
+
+## Abstract
+
+This specification defines the canonical encrypted wrapper for [BRC-38](./0038.md) user wallet data exports.
+
+It standardizes a downloadable binary file format, conventionally named `wallet.dat`, for password-protected wallet export and import. The design is intended for strong user data portability, backups, archival export, GDPR-style data access, and migration between wallet implementations and storage providers.
+
+BRC-39 uses:
+
+- the BRC-38 payload as its canonical plaintext inner document
+- the AES-256-GCM symmetric encryption primitive used by [BRC-2](../wallet/0002.md)
+- a portable, versioned binary envelope in the spirit of [BRC-78](../peer-to-peer/0078.md)
+- Argon2id as the mandatory password key-derivation function for new exports
+
+## Motivation
+
+BRC-38 defines what wallet data must be portable. It does not define how that data should be safely delivered to a user as a single downloadable file.
+
+For real-world portability, the default export artifact must be:
+
+- encrypted
+- password protected
+- self-describing
+- suitable for offline storage
+- stable enough to move between implementations
+
+This document defines that artifact.
+
+## Specification
+
+### 1. Scope
+
+This specification defines:
+
+- the canonical encrypted file format for a single-user BRC-38 export
+- password normalization rules
+- key derivation rules
+- authenticated encryption rules
+- file parsing, validation, export, and import behavior
+
+It does not define:
+
+- secret-sharing or recovery-key workflows
+- multi-file backup sets
+- multi-user containers
+- wallet-runtime key snapshots unrelated to BRC-38
+
+### 2. Conformance
+
+An implementation conforms to BRC-39 if it can:
+
+1. serialize a valid BRC-38 payload
+2. encrypt that payload into a valid BRC-39 file
+3. decrypt and validate a valid BRC-39 file
+4. recover the original BRC-38 payload without loss
+
+### 3. Canonical Export Artifact
+
+The canonical encrypted export artifact:
+
+- MUST be a binary file
+- SHOULD be named `wallet.dat`
+- SHOULD use media type `application/vnd.brc39.wallet-dat`
+
+The inner plaintext payload MUST be a complete BRC-38 document serialized as canonical UTF-8 JSON.
+
+### 4. Cryptographic Profile
+
+#### 4.1 Plaintext
+
+The plaintext to be encrypted is:
+
+- the exact UTF-8 byte sequence of a valid canonical BRC-38 JSON document
+
+#### 4.2 Password Encoding
+
+Before key derivation, the user password MUST be:
+
+1. interpreted as a Unicode string
+2. normalized to NFC
+3. encoded as UTF-8 bytes
+
+No additional trimming, case folding, or whitespace normalization is permitted.
+
+#### 4.3 Key Derivation
+
+New BRC-39 exports MUST use Argon2id.
+
+The canonical derived-key length is:
+
+- 32 bytes
+
+The canonical default Argon2id parameters are:
+
+- iterations: `7`
+- memoryKiB: `131072`
+- parallelism: `1`
+- hashLength: `32`
+- saltLength: `32`
+
+These defaults align with the current Wallet Toolbox Argon2id defaults.
+
+Implementations MAY use stronger Argon2id parameters, but they MUST encode the exact parameters used in the file header.
+
+#### 4.4 Authenticated Encryption
+
+The content-encryption algorithm is AES-256-GCM.
+
+The content-encryption key is the 32-byte Argon2id-derived key.
+
+The file nonce length is:
+
+- 32 bytes
+
+The nonce MUST be generated randomly for each export.
+
+The GCM authentication tag length MUST be 16 bytes.
+
+#### 4.5 Header Authentication
+
+All header bytes up to but not including the ciphertext MUST be supplied as AES-GCM Additional Authenticated Data (AAD).
+
+This ensures that tampering with version, KDF parameters, payload type, or other header fields causes decryption failure.
+
+### 5. File Layout
+
+All integers in the binary file MUST be unsigned and encoded in big-endian byte order.
+
+The canonical BRC-39 file layout is:
+
+| Field | Length | Description |
+| --- | --- | --- |
+| Magic | 4 bytes | ASCII `WDAT` |
+| Format Version | 1 byte | Currently `0x01` |
+| Protector Type | 1 byte | Currently `0x01` for password-protected export |
+| Inner Format | 1 byte | Currently `0x26` (decimal 38) for BRC-38 |
+| KDF Type | 1 byte | `0x01` = Argon2id, `0x02` = PBKDF2-SHA512 legacy |
+| Flags | 1 byte | Currently `0x01`; all other bits reserved and MUST be zero |
+| Salt Length | 1 byte | Currently `0x20` (32) |
+| Nonce Length | 1 byte | Currently `0x20` (32) |
+| Argon2id Iterations | 4 bytes | Work factor |
+| Argon2id Memory KiB | 4 bytes | Memory cost |
+| Argon2id Parallelism | 1 byte | Parallelism |
+| Argon2id Hash Length | 1 byte | Derived key length; currently 32 |
+| Reserved | 12 bytes | MUST be all zero |
+| Salt | variable | `Salt Length` bytes |
+| Nonce | variable | `Nonce Length` bytes |
+| CiphertextAndTag | variable | AES-256-GCM ciphertext followed by 16-byte tag |
+
+For `KDF Type = 0x02` (legacy PBKDF2-SHA512 import support):
+
+- `Argon2id Iterations` MUST instead contain the PBKDF2 iteration count
+- `Argon2id Memory KiB` MUST be zero
+- `Argon2id Parallelism` MUST be zero
+- `Argon2id Hash Length` MUST be 32
+
+New exports MUST NOT use `KDF Type = 0x02`.
+
+### 6. Header Field Requirements
+
+#### 6.1 Magic
+
+The file MUST begin with the ASCII bytes:
+
+```text
+57 44 41 54
+```
+
+which spell `WDAT`.
+
+#### 6.2 Format Version
+
+The current format version is `1`.
+
+Files with unsupported versions MUST be rejected.
+
+#### 6.3 Protector Type
+
+The following protector types are defined:
+
+- `0x01`: password-based encryption
+
+The following values are reserved for future extension:
+
+- `0x02` to `0xff`
+
+This version of BRC-39 standardizes only password-based encryption.
+
+#### 6.4 Inner Format
+
+The `Inner Format` field identifies the plaintext payload.
+
+For BRC-39 wallet exports:
+
+- `Inner Format` MUST be `38`
+
+Meaning the decrypted plaintext MUST be a valid BRC-38 document.
+
+#### 6.5 Flags
+
+Bit 0 indicates that the header is authenticated as AES-GCM AAD.
+
+For this specification:
+
+- bit 0 MUST be set to `1`
+- all other bits MUST be zero
+
+#### 6.6 Reserved Bytes
+
+All reserved bytes MUST be zero on export and MUST be ignored only if zero on import. Non-zero reserved bytes MUST cause rejection.
+
+### 7. Export Procedure
+
+To create a BRC-39 file, an exporter MUST:
+
+1. construct a valid BRC-38 document
+2. serialize it as canonical UTF-8 JSON
+3. normalize the user password to NFC and encode it as UTF-8
+4. generate a random 32-byte salt
+5. derive a 32-byte key using Argon2id and the encoded password
+6. generate a random 32-byte nonce
+7. construct the BRC-39 header
+8. encrypt the BRC-38 plaintext using AES-256-GCM with:
+   - key = derived key
+   - nonce = header nonce
+   - AAD = header bytes through the nonce field
+9. append `CiphertextAndTag`
+10. emit the resulting bytes as `wallet.dat`
+
+### 8. Import Procedure
+
+To import a BRC-39 file, an importer MUST:
+
+1. parse and validate the binary header
+2. verify `Magic`, `Format Version`, `Protector Type`, `Inner Format`, `Flags`, and reserved bytes
+3. obtain the user password
+4. normalize the password to NFC and encode it as UTF-8
+5. derive the decryption key using the encoded KDF parameters from the file
+6. decrypt `CiphertextAndTag` with AES-256-GCM using:
+   - key = derived key
+   - nonce = header nonce
+   - AAD = header bytes through the nonce field
+7. reject the file if GCM authentication fails
+8. parse the plaintext as UTF-8 JSON
+9. validate that the plaintext is a valid BRC-38 document
+
+Only after successful BRC-38 validation may the importer proceed to import wallet data into local storage.
+
+### 9. Legacy PBKDF2 Import Support
+
+For compatibility with existing Wallet Toolbox password-derived key usage, implementations MAY support:
+
+- `KDF Type = 0x02` for PBKDF2-SHA512
+
+The canonical legacy PBKDF2 default is:
+
+- iterations: `7777`
+- derived key length: `32`
+
+Implementations that support legacy PBKDF2:
+
+- MUST still emit the same BRC-39 binary envelope
+- MUST still use AES-256-GCM content encryption
+- MUST NOT produce new exports using PBKDF2 unless explicitly requested for legacy compatibility
+
+Canonical new exports MUST use Argon2id.
+
+### 10. Relationship to BRC-2 and BRC-78
+
+#### 10.1 BRC-2
+
+BRC-39 uses the same symmetric encryption primitive family as BRC-2:
+
+- AES-256-GCM
+
+Unlike BRC-2 application messages, BRC-39 stores the nonce explicitly in the binary file header instead of prepending it to a message payload, and authenticates the header via AES-GCM AAD.
+
+#### 10.2 BRC-78
+
+BRC-39 follows the same general design philosophy as BRC-78:
+
+- binary, versioned, self-describing encrypted envelopes
+
+BRC-78 is oriented toward portable encrypted inter-party messages using BRC-2/BRC-42/BRC-43 derivation. BRC-39 instead targets password-protected at-rest wallet export. This version does not standardize recipient-encrypted wallet exports, but future protector types MAY define such a mode.
+
+### 11. Validation Rules
+
+A BRC-39 file MUST be rejected if:
+
+- `Magic` is not `WDAT`
+- `Format Version` is unsupported
+- `Protector Type` is unsupported
+- `Inner Format` is not `38`
+- `Flags` contains unsupported bits
+- `Salt Length` is zero
+- `Nonce Length` is zero
+- reserved bytes are non-zero
+- `KDF Type = Argon2id` and any of:
+  - iterations is zero
+  - memoryKiB is zero
+  - parallelism is zero
+  - hashLength is not `32`
+- AES-GCM authentication fails
+- the decrypted payload is not valid UTF-8 JSON
+- the decrypted payload is not a valid BRC-38 document
+
+### 12. Privacy and Operational Requirements
+
+BRC-39 files contain the complete user wallet export, protected only by the chosen password and KDF parameters.
+
+Wallet implementations:
+
+- MUST warn users that weak passwords materially weaken the file
+- SHOULD encourage long passwords or passphrases
+- SHOULD avoid embedding password hints in the file
+- SHOULD default to Argon2id parameters at least as strong as the canonical defaults
+
+### 13. Canonical Example Header Semantics
+
+An example canonical new-export header therefore means:
+
+- file type: `wallet.dat`
+- payload type: BRC-38
+- protection mode: password
+- KDF: Argon2id
+- salt: 32 random bytes
+- nonce: 32 random bytes
+- plaintext: canonical UTF-8 BRC-38 JSON
+
+## Implementation
+
+An implementation based on Wallet Toolbox can produce a BRC-39 file by:
+
+1. exporting a full BRC-38 payload for the selected user
+2. deriving a password key with Argon2id using the current Toolbox default parameters
+3. encrypting the payload with AES-256-GCM
+4. writing the standardized binary envelope described above
+
+## References
+
+- [BRC-2: Data Encryption and Decryption](../wallet/0002.md)
+- [BRC-38: User Wallet Data Format](./0038.md)
+- [BRC-40: User Wallet Data Synchronization](./0040.md)
+- [BRC-78: Serialization Format for Portable Encrypted Messages](../peer-to-peer/0078.md)
+- [Argon2](https://www.rfc-editor.org/rfc/rfc9106)

--- a/outpoints/0040.md
+++ b/outpoints/0040.md
@@ -1,0 +1,287 @@
+# BRC-40: User Wallet Data Synchronization
+
+Ty Everett (ty@projectbabbage.com)
+
+## Abstract
+
+This specification defines an interoperable synchronization protocol for user wallet data between wallet storage providers. It standardizes the chunked, resumable sync model implemented by Wallet Toolbox so independent storage backends can exchange wallet state without proprietary adapters.
+
+The protocol is incremental. A consumer requests successive sync chunks for a specific wallet identity using a `since` watermark and per-entity offsets. The producer returns updated records in dependency order. The consumer merges those records, maintains a remote-to-local ID mapping, and advances the sync state until all entity arrays are present and empty.
+
+## Motivation
+
+Wallets increasingly need to replicate user state across multiple storage backends:
+
+- local and remote storage
+- active and backup providers
+- device migration and recovery flows
+- managed wallet infrastructure built from interchangeable components
+
+Without a standard sync protocol, each wallet implementation must define its own export/import format and state-reconciliation logic. That prevents interoperability even when both systems already implement the same wallet behaviors.
+
+This specification addresses that problem by defining the synchronization behavior already used in Wallet Toolbox, including:
+
+- resumable incremental replication
+- per-entity pagination
+- identity-safe replication scoped to one wallet user
+- convergent merging through persistent ID mapping
+
+## Specification
+
+### Scope
+
+This specification applies to synchronization between wallet storage providers for a single wallet user.
+
+It does not define:
+
+- wallet-to-application APIs such as [BRC-100](../wallet/0100.md)
+- backup file formats
+- encryption of exported wallet data at rest or in transit
+
+This specification is transport-agnostic. Any transport may be used provided it can faithfully convey the request and response structures defined below.
+
+### Terminology
+
+- **Producer**: The storage provider supplying wallet records.
+- **Consumer**: The storage provider receiving and merging wallet records.
+- **Sync cycle**: A sequence of one or more chunk requests sharing the same `since` value until the producer reports completion.
+- **Sync state**: Consumer-maintained state for a specific remote storage provider and wallet identity.
+- **Entity offset**: The number of records for a given entity type already received within the current sync cycle.
+- **ID map**: A mapping from producer-local numeric IDs to consumer-local numeric IDs.
+
+### Record Model
+
+Wallet data is synchronized as typed entity records. This specification defines the following entity names:
+
+1. `provenTx`
+2. `outputBasket`
+3. `outputTag`
+4. `txLabel`
+5. `transaction`
+6. `output`
+7. `txLabelMap`
+8. `outputTagMap`
+9. `certificate`
+10. `certificateField`
+11. `commission`
+12. `provenTxReq`
+
+In addition, a producer may return a single `user` record describing the synchronized user.
+
+Each synchronized entity record:
+
+- MUST belong to the wallet user identified by the request `identityKey`
+- MUST include `created_at` and `updated_at`
+- MUST NOT contain `null` values; omitted fields MUST be omitted rather than sent as `null`
+
+When serialized through JSON, timestamps SHOULD use RFC 3339 / ISO 8601 date-time strings.
+
+### Sync State
+
+The consumer MUST maintain a sync state for each pair:
+
+- wallet user identity
+- remote producer storage identity
+
+The sync state MUST include:
+
+- producer `storageIdentityKey`
+- producer `storageName`
+- current `since` watermark, if any
+- per-entity `count` offsets for the current sync cycle
+- per-entity `maxUpdated_at` observed during the current sync cycle
+- per-entity `idMap`
+
+The consumer MUST treat the sync state as durable. If synchronization is interrupted, the next attempt MUST resume from the stored `since` and offsets.
+
+### Request Structure
+
+The consumer requests a chunk using the following structure:
+
+```json
+{
+  "fromStorageIdentityKey": "<producerStorageIdentityKey>",
+  "toStorageIdentityKey": "<consumerStorageIdentityKey>",
+  "identityKey": "<userIdentityKey>",
+  "since": "2026-04-23T12:34:56.789Z",
+  "maxRoughSize": 10000000,
+  "maxItems": 1000,
+  "offsets": [
+    { "name": "provenTx", "offset": 0 },
+    { "name": "outputBasket", "offset": 0 },
+    { "name": "outputTag", "offset": 0 },
+    { "name": "txLabel", "offset": 0 },
+    { "name": "transaction", "offset": 0 },
+    { "name": "output", "offset": 0 },
+    { "name": "txLabelMap", "offset": 0 },
+    { "name": "outputTagMap", "offset": 0 },
+    { "name": "certificate", "offset": 0 },
+    { "name": "certificateField", "offset": 0 },
+    { "name": "commission", "offset": 0 },
+    { "name": "provenTxReq", "offset": 0 }
+  ]
+}
+```
+
+#### Request Rules
+
+- `fromStorageIdentityKey` MUST identify the producer.
+- `toStorageIdentityKey` MUST identify the consumer.
+- `identityKey` MUST identify the wallet user whose records are being synchronized.
+- `since` MUST be omitted for an initial full sync.
+- `maxItems` MUST bound the total number of records returned across all entity arrays.
+- `maxRoughSize` MUST bound the approximate serialized size of the returned chunk.
+- `offsets` MUST be supplied in the exact entity order defined in this specification.
+
+If an `offsets` entry is missing, duplicated, or out of order, the producer MUST reject the request.
+
+### Producer Behavior
+
+For a given request, the producer MUST build the response as follows:
+
+1. Initialize the response with `fromStorageIdentityKey`, `toStorageIdentityKey`, and `userIdentityKey`.
+2. If `since` is absent, or if the user record `updated_at` is later than `since`, include the `user` record.
+3. Process entity types in the exact order defined in this specification.
+4. For each entity type, return records for the requested user whose `updated_at` is greater than or equal to `since`.
+5. Skip the first `offset` matching records for that entity type.
+6. Continue adding records until either:
+   - no more records remain for that entity type, or
+   - `maxItems` is exhausted, or
+   - `maxRoughSize` is exceeded
+
+The producer MUST include the record that causes `maxRoughSize` to be exceeded, then stop adding further records.
+
+If the producer begins processing an entity type in the response, it MUST include that entity property in the chunk, even if the resulting array is empty.
+
+If the producer stops before reaching a later entity type because of size or count limits, the unattempted later entity properties MUST be omitted from the chunk.
+
+The producer MUST use a deterministic record order that remains stable throughout a sync cycle so the consumer can safely resume by offset.
+
+### Response Structure
+
+The producer returns a `SyncChunk`:
+
+```json
+{
+  "fromStorageIdentityKey": "<producerStorageIdentityKey>",
+  "toStorageIdentityKey": "<consumerStorageIdentityKey>",
+  "userIdentityKey": "<userIdentityKey>",
+  "user": { "...": "..." },
+  "provenTxs": [],
+  "outputBaskets": [],
+  "outputTags": [],
+  "txLabels": [],
+  "transactions": [],
+  "outputs": [],
+  "txLabelMaps": [],
+  "outputTagMaps": [],
+  "certificates": [],
+  "certificateFields": [],
+  "commissions": [],
+  "provenTxReqs": []
+}
+```
+
+Each entity array is interpreted as follows:
+
+- `undefined` / omitted: the producer did not attempt that entity type in this chunk
+- `[]`: the producer attempted that entity type and found no further matching records at the current `since` and offset
+- non-empty array: records to be merged
+
+### Completion Condition
+
+A sync cycle is complete only when all entity-array properties are present and each of them is empty.
+
+The presence or absence of the optional `user` record does not by itself determine completion.
+
+### Inclusive `since` Semantics
+
+The producer MUST treat `since` as an inclusive lower bound:
+
+- a record matches when `updated_at >= since`
+
+This means a resumed sync cycle will typically repeat at least one previously seen record. Consumers MUST therefore merge records idempotently and MUST NOT treat repeated records as an error.
+
+### Consumer Merge Behavior
+
+For each returned entity record, the consumer MUST:
+
+1. determine whether the producer record matches an existing local record under that entity's convergent equality rules
+2. update the existing local record if necessary, or insert a new local record if no match exists
+3. update the entity's `idMap` so the producer-local primary ID maps to the consumer-local primary ID
+4. update the entity's `maxUpdated_at` with the greatest `updated_at` value observed for that entity during the current sync cycle
+5. increase the entity `count` by the number of records received for that entity in the chunk
+
+The consumer MUST preserve `idMap` consistency. If an existing producer ID maps to a different local ID than previously recorded, synchronization MUST fail.
+
+For entity types whose identity is relationship-based rather than primary-ID-based, an implementation MAY omit `idMap` usage. Wallet Toolbox does this for:
+
+- `certificateField`
+- `txLabelMap`
+- `outputTagMap`
+
+### Advancing Sync State
+
+If the current chunk does not complete the sync cycle:
+
+- the consumer MUST retain the current `since`
+- the consumer MUST retain the updated per-entity `count` offsets
+- the consumer MUST request the next chunk using those updated offsets
+
+If the current chunk completes the sync cycle:
+
+- the consumer MUST set `since` to the maximum `updated_at` observed during the cycle, if any
+- the consumer MUST reset every entity `count` offset to `0`
+- the consumer MUST begin the next cycle from the new `since`
+
+If a completed cycle produced no merged records and no new maximum timestamp, the consumer MAY leave `since` unchanged.
+
+### Authentication and Authorization
+
+A producer MUST only return data for the authenticated wallet identity associated with `identityKey`.
+
+A producer MUST reject requests that attempt to synchronize another user's records.
+
+This specification does not mandate a specific authentication protocol, but an implementation MUST ensure:
+
+- the caller is authorized to read the requested user's wallet data
+- `fromStorageIdentityKey` and `toStorageIdentityKey` are not forgeable within the synchronization context
+
+### Error Handling
+
+Synchronization MUST fail if:
+
+- the requested `identityKey` is unknown or unauthorized
+- the `offsets` list is malformed or out of dependency order
+- required timestamps are missing or invalid
+- any returned entity contains `null` values
+- the consumer detects a conflicting `idMap` assignment
+
+On failure, the consumer MUST preserve enough sync state to either retry safely or report the last durable state to the operator.
+
+### Interoperability Notes
+
+This specification intentionally follows the chunked sync model implemented by Wallet Toolbox:
+
+- `getSyncChunk` on the producer side
+- `processSyncChunk` on the consumer side
+- durable per-remote `syncState`
+- persistent `syncMap` for remote-to-local ID reconciliation
+
+Implementations that follow this specification can plug into Toolbox-style sync flows interoperably without reverse-engineering private behavior.
+
+## Implementation
+
+Wallet Toolbox implements this synchronization model across its storage providers and storage manager.
+
+An implementation is considered conformant if it:
+
+- produces request and response objects compatible with this specification
+- honors inclusive `since` semantics and resumable offsets
+- merges records convergently and durably maintains sync state
+
+## References
+
+- [BRC-36: Format for Bitcoin Outpoints](./0036.md)
+- [BRC-37: Basket and Custom Instructions Extension for Bitcoin Outpoints](./0037.md)
+- [BRC-100: Unified, Vendor-Neutral, Unchanging, and Open BSV Blockchain Standard Wallet-to-Application Interface](../wallet/0100.md)

--- a/outpoints/README.md
+++ b/outpoints/README.md
@@ -2,10 +2,12 @@
 
 This directory contains standards for representing, synchronizing, and storing Bitcoin transaction outpoints.
 
+Numbers 38, 39, and 40 are placeholders in the historical index. They are not currently published specifications in this repository and should not be treated as normative references.
+
 BRC | Standard
 -----|------------------
 36   | [Format for Bitcoin Outpoints](./0036.md)
 37   | [Spending Instructions Extension for UTXO Storage Format](./0037.md)
-38   | User Wallet Data Format
-39   | User Wallet Data Format Encryption Extension
-40   | User Wallet Data Synchronization
+38   | Placeholder only, no spec published here
+39   | Placeholder only, no spec published here
+40   | Placeholder only, no spec published here

--- a/outpoints/README.md
+++ b/outpoints/README.md
@@ -2,12 +2,10 @@
 
 This directory contains standards for representing, synchronizing, and storing Bitcoin transaction outpoints.
 
-Numbers 38, 39, and 40 are placeholders in the historical index. They are not currently published specifications in this repository and should not be treated as normative references.
-
 BRC | Standard
 -----|------------------
 36   | [Format for Bitcoin Outpoints](./0036.md)
-37   | [Spending Instructions Extension for UTXO Storage Format](./0037.md)
-38   | Placeholder only, no spec published here
-39   | Placeholder only, no spec published here
-40   | Placeholder only, no spec published here
+37   | [Basket and Custom Instructions Extension for Bitcoin Outpoints](./0037.md)
+38   | [User Wallet Data Format](./0038.md)
+39   | [User Wallet Data Format Encryption Extension](./0039.md)
+40   | [User Wallet Data Synchronization](./0040.md)

--- a/overlays/0022.md
+++ b/overlays/0022.md
@@ -4,7 +4,7 @@ Ty Everett (ty@projectbabbage.com)
 
 ## Abstract
 
-This document proposes a solution for synchronizing data across UTXO-based overlay networks by specifying a secure and efficient mechanism for submitting and processing transactions. By utilizing a [BRC-31](../peer-to-peer/0031.md) protected server hosting an API endpoint, overlay network nodes can process and admit transactions based on their relevance to the hosted topics. This standard defines the parameters and processing steps needed to track topical UTXOs.
+This document proposes a solution for synchronizing data across UTXO-based overlay networks by specifying a mechanism for submitting transactions and receiving topic-specific admittance instructions. In current interoperable implementations, overlay services accept BEEF-formatted transaction submissions together with a set of topic names and return a per-topic result describing newly admitted outputs and retained historical inputs. This standard defines the parameters and processing steps needed to track topical UTXOs.
 
 ## Motivation
 
@@ -12,35 +12,62 @@ As discussed in [BRC-59](../opinions/0059.md), UTXO-based overlay networks provi
 
 ## Specification
 
-We start with a server that is set up to track the state of one or more topics. Every individual server implementing this specification decides what specific topic labels mean, and which rules they want to apply when admitting new UTXOs.
+We start with a server that is set up to track the state of one or more topics. Every individual server implementing this specification decides what specific topic labels mean, and which rules they apply when admitting new UTXOs.
 
-### API Endpoint and JSON Parameters
+### Status Note
 
-The [BRC-31](../peer-to-peer/0031.md) protected server will host a POST `/submit` API endpoint, which accepts JSON request payloads. The JSON request body will include a [BRC-8](../transactions/0008.md) transaction envelope (`rawTx`, `inputs`, `mapiResponses`, `proof`) and an additional field called `topics`. The transaction envelope facilitates SPV checking, while the `topics` field denotes which overlay network topics should be notified about the transaction.
+The earlier JSON-and-[BRC-8](../transactions/0008.md)-envelope framing described by this document is now historical. Current interoperable implementations in `bsv-blockchain/ts-sdk` and services built around it use:
+
+- a POST `/submit` endpoint,
+- an `application/octet-stream` request body containing a serialized BEEF transaction,
+- an `X-Topics` header carrying a JSON array of topic names,
+- and a structured JSON acknowledgment describing topical admittance instructions.
+
+Implementers SHOULD treat the older JSON envelope framing as deprecated unless they are explicitly maintaining backwards compatibility with a legacy deployment.
+
+### API Endpoint and Parameters
+
+The overlay service hosts a POST `/submit` API endpoint.
+
+Current interoperable request framing is:
+
+- **Body:** BEEF for the submitted transaction.
+- **Content-Type:** `application/octet-stream`
+- **Header:** `X-Topics`, containing a JSON array of topic names.
+- **Optional Header:** `x-includes-off-chain-values: true` when the request body appends off-chain values after the BEEF payload according to the sender/facilitator contract.
+
+Topic names used with current SDK tooling are expected to begin with `tm_`.
 
 ### Overlay Network Node Processing Steps
 
-Upon receiving a transaction, the overlay network node will perform the following steps:
+Upon receiving a transaction, the overlay network node performs the following steps:
 
-1. Verify the [BRC-31](../peer-to-peer/0031.md) identity of the sender and establish the required level of identity for submitting transactions, negotiating under the [BRC-31](../peer-to-peer/0031.md) protocol to the satisfaction of the network operator and the transaction sender.
+1. Parse and validate the submitted BEEF transaction.
 
-2. Check whether the node hosts at least one of the tagged topics from the payload. If none are hosted, the node returns an early response indicating no outputs were admitted. Otherwise, it can drop any unhosted topics from the list before proceeding.
+2. Check whether the node hosts at least one of the requested topics. If none are hosted, the node returns an early response indicating that no outputs were admitted.
 
-3. Use the [BRC-9](../transactions/0009.md) process to verify the submitted [BRC-8](../transactions/0008.md) envelope and confirm the transaction's legitimacy.
+3. Verify the transaction according to the node's policy and validation stack. This commonly includes SPV and/or policy checks, but the exact validation pipeline is implementation-defined.
 
 4. Apply topic-specific logic to the transaction by iterating through all specified topics and performing the following for each topic:
 
-    - Check the transaction's list of inputs for UTXOs that are part of the current topical overlay. Flag these inputs and communicate the information to the topic's management logic.
+    - Check the transaction's inputs for UTXOs that are already part of the current topical overlay.
 
-    - Apply the topic-specific management logic and protocol rules to determine output admittance for each transaction output.
+    - Apply the topic-specific management logic and protocol rules to determine:
+      - which outputs are newly admitted into the topic,
+      - which consumed topical coins should be retained for historical traversal,
+      - and which topical coins are removed from the live set.
 
-    - Update the node's tracking system, associating each relevant output with the topic labels of topics that have admitted those outpoints. If implementing [BRC-24](./0024.md), notify lookup services about the new incoming entries.
+    - Update the node's tracking system, associating admitted outputs with the topic and marking removed coins as spent. If implementing [BRC-24](./0024.md), notify lookup services about the new incoming and outgoing entries.
 
-    - Remove any now-spent inputs that were previously associated with a topic from the tracking system, as they have now become spent by this transaction. If implementing [BRC-24](./0024.md), notify lookup services about the old outgoing entries.
+5. Return a JSON response object containing, for each topic, an **Admittance Instructions** object:
 
-5. Generate and return a JSON response object containing the transaction processing results, including a `status` key with a value of `success`, and a `topics` key with an object containing topic labels and arrays of output numbers denoting which outputs were admitted into the specific topics.
+   - `outputsToAdmit`: output indices newly admitted into the topic.
+   - `coinsToRetain`: input indices whose spent topical predecessors should remain queryable for history.
+   - `coinsRemoved` (optional): input indices whose spent topical predecessors are removed from the live topical set.
 
-6. Pursuant to any peering or data synchronization arrangements or contracts that the node operator may have negotiated with other node operators with whom they would like to remain in sync, use the agreed-upon exchange mechanisms to notify the other node operators about the received transaction, potentially in conjunction with an incoming or outgoing [BRC-41](../payments/0041.md) payment.
+6. Pursuant to any peering or synchronization arrangements the operator maintains, notify peer nodes about the transaction.
+
+Authentication, payment, or additional transport requirements MAY be layered on top of this baseline by deployment-specific facilitators, but they are not part of the current minimum interoperable SHIP submission behavior.
 
 ### Example
 
@@ -51,33 +78,12 @@ We provide an example of an HTTP request and response.
 ```
 POST /submit HTTP/1.1
 Host: example-overlay-node.com
-Content-Type: application/json
-X-Authrite: 0.1
-X-Authrite-Identity-Key: ...
-X-Authrite-Signature: ...
-X-Authrite-Nonce: ...
-X-Authrite-YourNonce: ...
-X-Authrite-Certificates: ...
+Content-Type: application/octet-stream
+X-Topics: ["tm_example_1","tm_example_2"]
 ```
 
-```json
-{
-  "rawTx": "0100000001abcdef...",
-  "inputs": {
-    "...": "..."
-  },
-  "mapiResponses": [
-    {
-      "payload": "0100000001abcdef...",
-      "signature": "MEQCIGXFM...",
-      "publicKey": "036b8c86..."
-    }
-  ],
-  "topics": [
-    "example_topic_1",
-    "example_topic_2"
-  ]
-}
+```text
+<binary BEEF bytes>
 ```
 
 #### Response
@@ -85,33 +91,24 @@ X-Authrite-Certificates: ...
 ```
 HTTP/1.1 200 OK
 Content-Type: application/json
-X-Authrite: 0.1
-X-Authrite-Identity-Key: ...
-X-Authrite-Signature: ...
-X-Authrite-Nonce: ...
-X-Authrite-YourNonce: ...
-X-Authrite-Certificates: ...
 ```
 
 ```json
 {
-  "status": "success",
-  "topics": {
-    "example_topic_1": [0, 2],
-    "example_topic_2": [1, 2]
+  "tm_example_1": {
+    "outputsToAdmit": [0, 2],
+    "coinsToRetain": [1]
+  },
+  "tm_example_2": {
+    "outputsToAdmit": [1, 2],
+    "coinsToRetain": [],
+    "coinsRemoved": [0]
   }
 }
 ```
 
-In this example, a client submits a transaction to the `/submit` API endpoint. The JSON payload contains the [BRC-8](../transactions/0008.md) transaction envelope (`rawTx`, `inputs`, `mapiResponses`, `proof`) and an additional field called `topics`, which includes two example topics: `"example_topic_1"` and `"example_topic_2"`.
-
-The overlay network node processes the transaction and determines that outputs `0` and `2` are admissible for `"example_topic_1"` and outputs `1` and `2` are admissible for `"example_topic_2"`. The node then returns an HTTP response with a `status` of `"success"` and a `topics` object containing the admitted outputs for each topic.
+In this example, a client submits a BEEF transaction to the `/submit` endpoint together with two topics. The node determines which outputs are newly admitted and which consumed topical coins should be retained or removed, then returns topic-keyed admittance instructions.
 
 ## Implementation
 
-To implement this data synchronization solution, developers should first set up a [BRC-31](../peer-to-peer/0031.md) protected server to host the POST /submit API endpoint. The server should be capable of processing JSON request payloads and performing the necessary transaction validation using [BRC-9](../transactions/0009.md).
-
-Overlay network nodes must be programmed to process incoming transaction submissions following the steps outlined in the specification. This includes verifying the sender's [BRC-31](../peer-to-peer/0031.md) identity, checking for hosted topics, validating the transaction using [BRC-9](../transactions/0009.md), and applying topic-specific logic to determine output admittance.
-
-Developers should ensure that their implementation adheres to the JSON request and response structures specified in this document, enabling seamless interaction between overlay network participants.
-
+To implement this data synchronization solution, developers should expose a POST `/submit` endpoint that accepts BEEF transaction submissions, applies topic logic, and returns per-topic admittance instructions. Services that also support history queries should preserve enough ancestry information to satisfy [BRC-64](./0064.md).

--- a/overlays/0022.md
+++ b/overlays/0022.md
@@ -34,7 +34,15 @@ Current interoperable request framing is:
 - **Body:** BEEF for the submitted transaction.
 - **Content-Type:** `application/octet-stream`
 - **Header:** `X-Topics`, containing a JSON array of topic names.
-- **Optional Header:** `x-includes-off-chain-values: true` when the request body appends off-chain values after the BEEF payload according to the sender/facilitator contract.
+- **Optional Header:** `x-includes-off-chain-values: true` when the request body appends off-chain values after the BEEF payload.
+
+When `x-includes-off-chain-values: true` is present, current SDK facilitators frame the body as:
+
+```text
+VarInt(beefByteLength) || beefBytes || offChainValueBytes
+```
+
+Without that header, the body is just the raw BEEF bytes.
 
 Topic names used with current SDK tooling are expected to begin with `tm_`.
 

--- a/overlays/0023.md
+++ b/overlays/0023.md
@@ -14,6 +14,20 @@ The [BRC-22](./0022.md) standard defines a method for running a server that acce
 
 We define the various components of the Confederacy Host Interconnect architecture.
 
+### Status Note
+
+BRC-23 is historical. Current interoperable overlay host discovery in `bsv-blockchain/ts-sdk` is specified by [BRC-88](./0088.md) SHIP advertisements, not CHIP advertisements.
+
+New implementations should use:
+
+- `SHIP` PushDrop advertisement tokens,
+- host base URLs rather than bare domain names,
+- topic names following [BRC-87](./0087.md), normally beginning with `tm_`,
+- BRC-100 PushDrop locking under protocol `[2, "Service Host Interconnect"]`, key ID `1`, counterparty `self`,
+- and BRC-24 lookup service `ls_ship` with query `{ "topics": [...] }`.
+
+The `CHIP` identifier, `CHIP` topic, BRC-48 signature-linking process, and provider-style lookup naming below are retained only for historical context.
+
 ### CHIP Token Format
 
 CHIP tokens are registered on the Bitcoin SV blockchain as single-satoshi [BRC-48](../scripts/0048.md) outputs representing hosting advertisements by Confederacy network operators. The token fields are ordered as follows:

--- a/overlays/0024.md
+++ b/overlays/0024.md
@@ -4,7 +4,7 @@ Ty Everett (ty@projectbabbage.com)
 
 ## Abstract
 
-This document proposes a solution for querying the state of UTXO-based overlay networks by specifying a mechanism for accessing data using lookup services. By utilizing a [BRC-31](../peer-to-peer/0031.md) protected server hosting an API endpoint, overlay network nodes can return relevant UTXOs based on the topics they host and the user's query. This standard defines the parameters and processing steps needed to query for and access topical UTXOs.
+This document proposes a solution for querying the state of UTXO-based overlay networks by specifying a lookup-service mechanism. In current interoperable implementations, clients send a `{ service, query }` object to a `/lookup` endpoint and receive an `output-list` answer describing relevant outputs using BEEF-backed transaction data. This standard defines the parameters and processing steps needed to query for and access topical UTXOs.
 
 ## Motivation
 
@@ -12,43 +12,74 @@ As introduced in [BRC-22](./0022.md), UTXO-based overlay networks provide a secu
 
 ## Specification
 
-We build on the node first described in [BRC-22](./0022.md) and hook into the output admittance and spend events that naturally occur as transactions are submitted. When transactions are received, topical logic determines which outputs will be part of which overlay networks, and we specify that the lookup services respond to these events.
+We build on the node first described in [BRC-22](./0022.md) and hook into the output admittance and spend events that naturally occur as transactions are submitted. When transactions are received, topical logic determines which outputs will be part of which overlay networks, and lookup services respond to queries over the resulting indexed state.
 
-### API Endpoint and JSON Parameters
+### Status Note
 
-The [BRC-31](../peer-to-peer/0031.md) protected server will host a POST `/lookup` API endpoint, which accepts JSON request payloads. The JSON request body will include a `provider`, which is a string denoting the chosen provider, and a `query` field, whose meaning is determined by the specific provider being chosen.
+Older drafts of this document described provider-based lookup and [BRC-36](../outpoints/0036.md)-style JSON UTXO responses. Current interoperable behavior in `bsv-blockchain/ts-sdk` instead uses:
+
+- `service` instead of `provider`,
+- an `output-list` response type,
+- BEEF payloads rather than hydrated BRC-36 JSON objects,
+- and optional compact `application/octet-stream` responses for aggregation efficiency.
+
+The older provider/BRC-36 framing SHOULD be treated as deprecated unless required for legacy compatibility.
+
+### API Endpoint and Parameters
+
+The overlay node hosts a POST `/lookup` API endpoint which accepts a JSON request body of the form:
+
+```json
+{
+  "service": "ls_example",
+  "query": {
+    "...": "service-specific query fields"
+  }
+}
+```
+
+Service names used with current SDK tooling are expected to begin with `ls_`.
 
 ### Overlay Network Node Processing Steps
 
-Upon receiving a query, the overlay network node will perform the following steps:
+Upon receiving a query, the overlay network node performs the following steps:
 
-1. Engage in [BRC-31](../peer-to-peer/0031.md) authentication and learn the identity of the person making the request, to the extent required in order to fulfill the request.
+1. Check that the requested `service` is supported on this node. If not, return an error.
 
-2. If consistent with the policy set by the node operator, charge a [BRC-41](../payments/0041.md) payment based on the query being performed, providing a mechanism by which the node can monetize its operations.
+2. Pass the `query` object to the selected lookup service implementation.
 
-3. Check that the `provider` stipulated by the request is supported on this node. If not, return a JSON error response with a `status` key of `error`, a `code` of `ERR_LOOKUP_SERVICE_NOT_SUPPORTED`, and a `description` comprising a human-readable error message.
+3. The service produces a responsive list of currently admitted outputs and any optional service-specific `context` bytes associated with each output.
 
-4. Send the `query` to the provider for processing. The provider will use the current known state of the overlay in conjunction with its data storage and retrieval system to fulfill the query.
+4. The node returns a **Lookup Answer**. Current interoperable answers use the following structure:
 
-5. The provider returns a responsive list of current topical UTXO identifiers (topic labels + TXIDs + output numbers) to the overlay network node, where each identifier is for a UTXO that is **currently** admitted into a topical overlay.
+```json
+{
+  "type": "output-list",
+  "outputs": [
+    {
+      "beef": [/* BEEF bytes */],
+      "outputIndex": 0,
+      "context": [/* optional bytes */]
+    }
+  ]
+}
+```
 
-6. After retrieving the list of UTXOs responsive to the query from the lookup service provider, the overlay network node will hydrate each UTXO with its output script, amount, encompassing transaction, and other information. The format for the UTXOs constructed by this process is defined by [BRC-36](../outpoints/0036.md).
+5. For transport efficiency, the node MAY instead return `application/octet-stream` encoding the same information as:
 
-7. The node will then return a JSON response to the consumer, comprising an array of [BRC-36](../outpoints/0036.md)-style UTXOs.
+   - count of outpoints,
+   - for each output: txid, output index, context length, optional context bytes,
+   - followed by a shared BEEF payload sufficient to reconstruct the returned outputs.
 
-### Lookup Service Providers
+### Lookup Services
 
-Each lookup service is assigned a provider identifier by the overlay network node so that multiple can be installed simultaneously. For each provider, the overlay network node will send events when new UTXOs are added and when they later become spent. The events will contain the output script, the number of satoshis, the TXID, the output number from the transaction, and the topic identifier for the topic where the output was added or removed.
+Each lookup service is assigned a service identifier by the overlay network node so that multiple can be installed simultaneously. For each service, the overlay network node sends events when outputs are admitted and when they later become spent.
 
-Each lookup service maintains its own data storage and retrieval mechanism independently. This allows each service to use the most appropriate solution for the specific data being managed. Each service chooses how it will respond to these events, which could involve adding, removing, incrementing, decrementing, replacing, updating, or otherwise mutating data storage and retrieval systems applicable to its specific use-case or indexing methodology. Providers are under no obligation to process events for all topics and can freely drop events they deem irrelevant to their operations. Each service will do this in a way so that it can later provide effective responses to queries.
+Each service maintains its own data storage and retrieval mechanism independently. This allows each service to use the most appropriate solution for the specific data being managed. A service is under no obligation to process events for all topics and may ignore events irrelevant to its indexing model.
 
-### Payments for Queries
+### Authentication, Payment, and Policy
 
-The `/lookup` route may be behind a [BRC-41](../payments/0041.md) paywall to provide a monetization mechanism for overlay network server operators. The rules for this paywall are determined by the specific server being queried and can be based on any aspect of the query being made. All state consumers must be prepared to furnish a [BRC-41](../payments/0041.md) payment for lookup requests if enabled by the server, **unless** the client knows for certain that a payment will not be charged.
-
-This means that consumers should be prepared to handle potential payment requirements when making lookup requests, as the server operator may have implemented a [BRC-41](../payments/0041.md) paywall to monetize access to the overlay network's state.
-
-In either case, all lookup provider queries are always protected by [BRC-31](../peer-to-peer/0031.md) authentication, as with [BRC-22](./0022.md)'s `/submit` route, ensuring there are digitally signed records of all requests and responses between the parties.
+Authentication, payment, and additional policy checks MAY be layered on top of `/lookup` by deployment-specific facilitators. Current baseline SDK interoperability does not require [BRC-31](../peer-to-peer/0031.md) authentication or [BRC-41](../payments/0041.md) monetization for every lookup.
 
 ### Example Requests and Responses
 
@@ -60,19 +91,13 @@ Below are examples of an HTTP request and response for the `/lookup` route.
 POST /lookup HTTP/1.1
 Host: example-overlay-node.com
 Content-Type: application/json
-X-Authrite: 0.1
-X-Authrite-Identity-Key: ...
-X-Authrite-Signature: ...
-X-Authrite-Nonce: ...
-X-Authrite-YourNonce: ...
-X-Authrite-Certificates: ...
 ```
 
 ```json
 {
-  "provider": "example_provider",
+  "service": "ls_example",
   "query": {
-    "topic": "example_topic",
+    "topic": "tm_example",
     "search": "example_search_criteria"
   }
 }
@@ -83,33 +108,22 @@ X-Authrite-Certificates: ...
 ```
 HTTP/1.1 200 OK
 Content-Type: application/json
-X-Authrite: 0.1
-X-Authrite-Identity-Key: ...
-X-Authrite-Signature: ...
-X-Authrite-Nonce: ...
-X-Authrite-YourNonce: ...
-X-Authrite-Certificates: ...
 ```
 
 ```json
-[
-  {
-    "txid":"7001295a287fee8e7ad5de58ed30bd61923977ddc9b7a44830ebb9a68b12dc39",
-    "vout":0,"outputScript":"4104ca0a8ce950bf2bc85115bd68818455ae2f187efc96c7527dfad98b69531ae65d13cff3e6f07263dcc64c8ccfd03884983a896b0c5887f2ec5bfd7ad739b76119ac213155485250596e4d4850755135546762334146384a5871774b6b6d5a56793568472231485438347a7272467645594658567a6b5343436f6968706d33437754586a74726b200c613f338ad70e228eaee180f65c34d72a63bdf4c9e167dd5bf70a61539e80a8096164766572746973654468747470733a2f2f73746167696e672d6e616e6f73746f72652e626162626167652e73797374656d732f63646e2f54436f5a366269715743634b574b4d6e5065695854620a31383338383430313032043834303046304402205da55600d8f260d760b37491bc3286b9faacd0d408c187e69119ddc1d98bf3fe02207996fda8d6aba1b7494d7fe8a9b7e5111ea492348f11162bc898b3f7ab2ebf486d6d6d6d",
-    "topic":"UHRP",
-    "satoshis":500,
-    "rawTx":"0100000001e09afc3f6ed8842e3f231aac29d325c0f90137a5441bf861c7a9ee7499fafc9a020000006b483045022100cfef7385daedeb6f54a68c1188bf7d9061774f88eb391e132daea49cfcb883c60220010ba950bbb2952a1d4ace35c6721a254774c6370be75e804334be13544e4f3c412102dc35718aeb818a6075a926e8f68bd6656e5fa007a083d8f5b6193b7b1c34e3f7ffffffff03f401000000000000fd53014104ca0a8ce950bf2bc85115bd68818455ae2f187efc96c7527dfad98b69531ae65d13cff3e6f07263dcc64c8ccfd03884983a896b0c5887f2ec5bfd7ad739b76119ac213155485250596e4d4850755135546762334146384a5871774b6b6d5a56793568472231485438347a7272467645594658567a6b5343436f6968706d33437754586a74726b200c613f338ad70e228eaee180f65c34d72a63bdf4c9e167dd5bf70a61539e80a8096164766572746973654468747470733a2f2f73746167696e672d6e616e6f73746f72652e626162626167652e73797374656d732f63646e2f54436f5a366269715743634b574b4d6e5065695854620a31383338383430313032043834303046304402205da55600d8f260d760b37491bc3286b9faacd0d408c187e69119ddc1d98bf3fe02207996fda8d6aba1b7494d7fe8a9b7e5111ea492348f11162bc898b3f7ab2ebf486d6d6d6dc8000000000000001976a9148055582669432149141abcf887fced6881f7404288ac207c1202000000001976a9146a1a5f00deb78b2ef39e9a80d3e3ea2c97d0710c88ac00000000",
-    "proof":null,
-    "inputs":"{\"9afcfa9974eea9c761f81b44a53701f9c025d329ac1a233f2e84d86e3ffc9ae0\":{\"proof\":{\"flags\":2,\"index\":3,\"txOrId\":\"9afcfa9974eea9c761f81b44a53701f9c025d329ac1a233f2e84d86e3ffc9ae0\",\"target\":\"c99dfb20991b131142a915b086eb6413d78fb472477c31ef06495c7d712dc4e4\",\"nodes\":[\"5206842a42c144617bee40869bd73b0f65ecf6d19c75e73c7106ee2f5b271308\",\"624c68a9e2c8e83df9e55c0bc4b3a560924d6cb027285e6d6499f6445149e4ac\",\"4c02bfcd6098e40ecebab74783e1bd14d8495bccb02e4b5447057de31ed485d6\"],\"targetType\":\"merkleRoot\"},\"rawTx\":\"010000000166dee27f6d4ca528dbd664c1b6a686f9a3b18336ca396bcead7f2065ec0f07ac020000006b483045022100effd3358e1a602898e2a80b0d45b3a01bb36dfc9148b0766bc6e8185f4cf3c0c02203c3d6c6ff180d395b1300b89f96056d9ec915d6cfbf02c7cff2d6f4bb9611d1941210228ec497f7097a26ea1049ef732931d5abc40335e7693cac56d4534f15ff60aefffffffff03204e0000000000001976a9145b296c72cbec349171445808df953c2edaa3a1d388acc8000000000000001976a914d013936b4177bcbb0d934c6348b0d9ec3cc05dac88ac1e7f1202000000001976a914b281d7f257d79aebb910a5ba2c8e787f7ea635ab88ac00000000\"}}",
-    "mapiResponses":"[{\"payload\":\"{\\\"apiVersion\\\":\\\"1.5.0\\\",\\\"timestamp\\\":\\\"2023-04-10T20:55:03.2794204Z\\\",\\\"txid\\\":\\\"7001295a287fee8e7ad5de58ed30bd61923977ddc9b7a44830ebb9a68b12dc39\\\",\\\"returnResult\\\":\\\"success\\\",\\\"resultDescription\\\":\\\"\\\",\\\"minerId\\\":\\\"030d1fe5c1b560efe196ba40540ce9017c20daa9504c4c4cec6184fc702d9f274e\\\",\\\"currentHighestBlockHash\\\":\\\"00000000000004863e21305bc8cee6dd66b80a443416f14ccc5c74895fdefcac\\\",\\\"currentHighestBlockHeight\\\":1546251,\\\"txSecondMempoolExpiry\\\":0,\\\"warnings\\\":[],\\\"failureRetryable\\\":false}\",\"publicKey\":\"030d1fe5c1b560efe196ba40540ce9017c20daa9504c4c4cec6184fc702d9f274e\",\"signature\":\"304402205cd7c1b8f64de17c5824fec87549ecf46d69f122ed96971878562795d432a00702202097e309da4db38876bcaecafdd9f6234fcee999113a5fd54c909383d223a24f\"}]"
-  }
-]
+{
+  "type": "output-list",
+  "outputs": [
+    {
+      "outputIndex": 0,
+      "beef": [1, 2, 3]
+    }
+  ]
+}
 ```
 
-In this example, a client submits a query to the `/lookup` API endpoint. The JSON payload contains a `provider` field specifying the desired lookup service provider and a `query` field with the specific query parameters.
-
-The overlay network node processes the query and returns an HTTP response containing an array of [BRC-36](../outpoints/0036.md)-style UTXOs that match the query's criteria. The response includes the topic, TXID, output index, output script, number of satoshis, and other [BRC-8](../transactions/0008.md) fields for each UTXO.
+In this example, a client submits a query to the `/lookup` endpoint. The node returns an `output-list` answer containing BEEF sufficient to reconstruct the responsive output.
 
 ## Implementation
 
-Developers should extend their [BRC-31](../peer-to-peer/0031.md) protected server to host the POST `/lookup` API endpoint. For monetization, a [BRC-41](../payments/0041.md) paywall may be configured in front of the `/lookup` endpoint, and may charge for lookups based on the queries being performed or the volume of information requested. Developers should ensure that their implementation adheres to the JSON request and response structures specified in this document.
+Developers should expose a POST `/lookup` endpoint that accepts `{ service, query }` requests and returns `output-list` answers in JSON or compact octet-stream form. Services that support historical traversal should also preserve enough ancestry information to satisfy [BRC-64](./0064.md).

--- a/overlays/0025.md
+++ b/overlays/0025.md
@@ -14,6 +14,20 @@ While [BRC-23](./0023.md) provides a mechanism for resolving which topics are ho
 
 In a similar manner to [BRC-23](./0023.md) CHIP, we specify the various components of the CLAP architecture:
 
+### Status Note
+
+BRC-25 is historical. Current interoperable lookup-service discovery in `bsv-blockchain/ts-sdk` is specified by [BRC-88](./0088.md) SLAP advertisements, not CLAP advertisements.
+
+New implementations should use:
+
+- `SLAP` PushDrop advertisement tokens,
+- host base URLs rather than bare domain names,
+- lookup service names following [BRC-87](./0087.md), normally beginning with `ls_`,
+- BRC-100 PushDrop locking under protocol `[2, "Service Lookup Availability"]`, key ID `1`, counterparty `self`,
+- and BRC-24 lookup service `ls_slap` for resolving hosts that provide a service.
+
+The `CLAP` identifier, `CLAP` topic, BRC-48 signature-linking process, and provider-style lookup naming below are retained only for historical context.
+
 ### CLAP Token Format
 
 CLAP tokens are registered on the Bitcoin SV blockchain as single-satoshi [BRC-48](../scripts/0048.md) outputs representing lookup service advertisements by Confederacy network operators. The token fields are ordered as follows:

--- a/overlays/0026.md
+++ b/overlays/0026.md
@@ -19,6 +19,16 @@ This new paradigm not only streamlines content availability but also enables new
 Specification
 -------------
 
+### Status Note
+
+The content-addressing idea remains current, and `bsv-blockchain/ts-sdk` includes `StorageUtils`, `StorageDownloader`, and `StorageUploader` helpers for UHRP-style storage. Some details below are historical:
+
+- Current SDK UHRP URLs encode the SHA-256 file hash with Base58Check prefix `ce00`; callers may use the bare string or a `uhrp:` / `uhrp://` prefix.
+- Current SDK download resolution queries BRC-24 service `ls_uhrp` with `{ "uhrpUrl": "..." }` and expects an `output-list` response.
+- Current SDK resolution reads PushDrop advertisement fields with the download URL in field 3 and an expiry timestamp in field 4.
+- Current SDK upload helpers interact with storage servers through authenticated HTTP routes such as `POST /upload`, `GET /find?uhrpUrl=...`, `GET /list`, and `POST /renew`; the direct file upload itself is a `PUT` to the server-provided upload URL.
+- The older `UHRP` topic/provider naming and the NanoSeek/NanoStore tooling references below are legacy. New overlay implementations should use BRC-87 names such as `tm_uhrp` / `ls_uhrp` or another explicitly documented `tm_` / `ls_` pair.
+
 A UHRP advertisement token comprises a Bitcoin UTXO with a locking script containing the following components:
 
 -   `<public key>`: This is the public key associated with the host that is making the advertisement.
@@ -31,7 +41,7 @@ A UHRP advertisement token comprises a Bitcoin UTXO with a locking script contai
 -   `<contentLength>`: A UTF-8 encoded version of a decimal integer representing the byte length of the content.
 -   `<signature>`: A digital signature over the concatenated fields fields from the host's `<public key>`.
 
-Upon creation and submission of an advertisement to a [BRC-22](./0022.md) overlay network node for the `UHRP` topic, the node will track the UTXO and facilitate its lookup via a [BRC-24](./0024.md) lookup service with the provider name `UHRP`. If the token ever becomes spent, the advertisement is canceled. The spending transaction may contain more information justifying the host's revocation (shch as a DMCA notice), but any such stipulation is beyond the scope of this initial document, and left for others to specify later.
+Upon creation and submission of an advertisement to a [BRC-22](./0022.md) overlay network node for the historical `UHRP` topic, the node will track the UTXO and facilitate its lookup via a [BRC-24](./0024.md) lookup service with the historical provider name `UHRP`. Current SDK download resolution uses lookup service `ls_uhrp`. If the token ever becomes spent, the advertisement is canceled. The spending transaction may contain more information justifying the host's revocation (such as a DMCA notice), but any such stipulation is beyond the scope of this initial document, and left for others to specify later.
 
 Implementation
 --------------

--- a/overlays/0035.md
+++ b/overlays/0035.md
@@ -1,0 +1,496 @@
+# BRC-35: Layered Key-Value Store for Wallets and Overlay Services
+
+Ty Everett (ty@projectbabbage.com)
+
+## Abstract
+
+This document defines a layered key-value store standard for BSV systems that represent state as spendable PushDrop token outputs.
+
+It standardizes a shared lifecycle model and two interoperable profiles:
+
+1. **Global KVStore**: publicly discoverable, overlay-tracked, controller-bound KV tokens.
+2. **Local KVStore**: wallet-local, basket-backed KV persistence built entirely from existing BRC-100 wallet methods.
+
+BRC-35 is based on the currently interoperable behavior of the `bsv-blockchain/ts-sdk` `GlobalKVStore`, `LocalKVStore`, `PushDrop`, `kvStoreInterpreter`, `Historian`, `LookupResolver`, and topic-broadcasting implementations, together with their tests and surrounding wallet architecture. It uses BRC-48 PushDrop tokens, BRC-64-style retained ancestry for history, BRC-87/BRC-88 naming and overlay-service conventions, and existing BRC-100 wallet methods. It does not define any new wallet RPC methods.
+
+## Motivation
+
+Applications increasingly need both:
+
+- a **publicly discoverable** KV surface for shared or controller-addressable state, and
+- a **wallet-local** KV surface for private or application-scoped persistence.
+
+The existing `ts-sdk` implementations already provide both capabilities, but their behavior is currently defined by code and tests rather than by a single stable protocol document. Without a BRC:
+
+- wallet authors cannot easily determine which behaviors are protocol-level and which are SDK convenience,
+- overlay-service authors cannot reliably implement interoperable lookup behavior,
+- application developers are left to infer lifecycle and history semantics from library wrappers, and
+- PushDrop usage remains too generic to clearly describe what a KV token actually is.
+
+BRC-35 addresses this by specifying the shared KV model once, then defining the global and local profiles separately but consistently.
+
+## Background
+
+Readers of this document should be familiar with:
+
+- [BRC-46](../wallet/0046.md) for wallet output baskets
+- [BRC-48](../scripts/0048.md) for PushDrop
+- [BRC-64](./0064.md) for overlay transaction history tracking
+- [BRC-87](./0087.md) for topic-manager and lookup-service naming conventions
+- [BRC-88](./0088.md) for overlay service synchronization architecture
+- [BRC-99](../wallet/0099.md) for future basket permission schemes
+- [BRC-100](../wallet/0100.md) for wallet methods and object shapes
+- [BRC-116](../wallet/0116.md) for wallet trust and permission context
+
+The older [BRC-22](./0022.md) and [BRC-24](./0024.md) documents provide historical background for overlay submission and lookup. This document uses the newer **service** and **topic** terminology established by BRC-87 and BRC-88.
+
+## Normative Language
+
+The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHALL**, **SHALL NOT**, **SHOULD**, **SHOULD NOT**, **RECOMMENDED**, **MAY**, and **OPTIONAL** in this document are to be interpreted as described in RFC 2119 and RFC 8174 when, and only when, they appear in all capitals.
+
+## Specification
+
+### 1. Terminology
+
+- **KV token**: A spendable PushDrop output whose semantic fields represent one KV entry.
+- **Live token**: A KV token that is still unspent and therefore part of the current KV state.
+- **Controller**: The compressed public identity key of the entity that controls a global KV entry. In the global profile, this is a semantic token field and not merely the PushDrop locking public key.
+- **Context**: The local KV namespace. In the local profile, the context is the wallet basket name.
+- **Tuple**: The identity of a KV entry. In the global profile the tuple is `(protocolID, key, controller)`. In the local profile the tuple is `(context, key)` within one wallet.
+- **History chain**: The ancestry of prior KV tokens spent into the current live token.
+
+### 2. Shared Model and Invariants
+
+#### 2.1 State Model
+
+A BRC-35 KV store is not a mutable document database. It is a set of spendable tokens whose current state is determined by **currently unspent outputs**.
+
+For a single KV tuple:
+
+- **Create** means minting a live token when no live token currently exists for that tuple.
+- **Update** means spending the prior live token and creating a successor token for the same tuple.
+- **Delete** means spending the prior live token without replacement.
+
+The satoshi amount carried by a KV token is not semantic KV data. Implementations **SHOULD** use `1` satoshi unless another amount is needed for fee policy or wallet policy.
+
+#### 2.2 Encoding Rules
+
+Unless a profile says otherwise:
+
+- `protocolID` is encoded as the UTF-8 JSON serialization of the wallet protocol tuple, such as `"[1,\"kvstore\"]"`.
+- `key` is encoded as UTF-8 bytes.
+- `value` is represented as UTF-8 bytes of an application string.
+- `controller` is encoded as the raw bytes of the controller's compressed public key hex string.
+- `tags`, when present, are encoded as the UTF-8 JSON serialization of an array of strings.
+
+Applications that need binary values **SHOULD** encode them into a string representation at the application layer before using the interoperable profiles defined here.
+
+#### 2.3 Operational Invariants
+
+Compliant implementations:
+
+- **MUST** treat state as live-output state, not as the last record observed in a scan.
+- **MUST** preserve tuple identity across updates.
+- **SHOULD** serialize writes per tuple to avoid concurrent mutation races.
+- **MUST NOT** treat malformed or failed-verification outputs as valid state.
+
+### 3. Global KVStore Profile
+
+#### 3.1 Overview
+
+The global profile defines a publicly discoverable KV store in which each live KV entry is represented by a PushDrop token tracked by overlay services.
+
+Canonical public names are:
+
+- **Lookup service**: `ls_kvstore`
+- **Topic manager topic**: `tm_kvstore`
+
+Implementations that claim public BRC-35 interoperability **MUST** understand these names. SDK options that allow overriding them are deployment conveniences and are not the canonical public profile.
+
+#### 3.2 Canonical Token Format
+
+Global KV tokens **MUST** use a BRC-48 PushDrop locking script with lock position `before`.
+
+The canonical semantic field order is:
+
+| Field | Meaning | Encoding |
+|-------|---------|----------|
+| 1 | `protocolID` | UTF-8 JSON serialization of the protocol tuple |
+| 2 | `key` | UTF-8 |
+| 3 | `value` | UTF-8 |
+| 4 | `controller` | bytes of compressed public key hex |
+| 5 | `tags` | UTF-8 JSON serialization of string array |
+| 6 | `signature` | PushDrop signature |
+
+For backwards compatibility, the legacy no-tags form is also valid:
+
+| Field | Meaning |
+|-------|---------|
+| 1 | `protocolID` |
+| 2 | `key` |
+| 3 | `value` |
+| 4 | `controller` |
+| 5 | `signature` |
+
+Emitters **MAY** omit the `tags` field only when emitting the legacy format for compatibility. New interoperable emitters **SHOULD** emit the tagged form and **SHOULD** encode an empty tag set as absence of field 5 rather than as an empty JSON array.
+
+The `controller` field **MUST** contain the emitter's compressed identity public key. Implementations **MUST NOT** treat the PushDrop locking public key as the controller identity.
+
+The PushDrop lock for a global token **MUST** be derived under the same `protocolID` and `key` scope represented in fields 1 and 2. Current interoperable implementations do this using the public-counterparty mode associated with globally verifiable KV tokens.
+
+#### 3.3 Signature Rules
+
+The global signature field **MUST** be computed over the byte-concatenation of every preceding semantic field in emitted order:
+
+- legacy form: `protocolID || key || value || controller`
+- tagged form: `protocolID || key || value || controller || tags`
+
+For interoperability with current wallet behavior, the signature is created under the same `protocolID` and `key` scope as the token, using the public-signing behavior currently reached by omitting an explicit signature counterparty in BRC-100 signature creation.
+
+Readers of global KV tokens **MUST** verify the appended signature before accepting the token as valid state.
+
+Verification **MUST** use:
+
+- `protocolID` from field 1
+- `key` from field 2 as the `keyID`
+- `controller` from field 4 as the counterparty identity used for verification
+- the exact concatenated payload defined above
+
+Any output that fails signature verification **MUST** be ignored.
+
+#### 3.4 Lifecycle Semantics
+
+For a given `(protocolID, key, controller)` tuple:
+
+- create **MUST** mint one new live token,
+- update **MUST** spend the prior live token and create a successor token for the same tuple,
+- delete **MUST** spend the prior live token without replacement.
+
+Public overlay services **SHOULD** expose at most one live token per tuple. If multiple live tokens are observed for the same tuple, clients **SHOULD** treat the state as ambiguous or corrupted rather than silently merging values.
+
+#### 3.5 Lookup Query Schema
+
+The canonical lookup query object is:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `key` | string | Match a specific key |
+| `controller` | string | Match a specific controller public key |
+| `protocolID` | `[number, string]` | Match a specific wallet protocol tuple |
+| `tags` | `string[]` | Match tags |
+| `tagQueryMode` | `'all' \| 'any'` | Tag matching mode |
+| `limit` | integer | Page size |
+| `skip` | integer | Result offset |
+| `sortOrder` | `'asc' \| 'desc'` | Ordering hint |
+
+Queries **MUST** include at least one selector from `key`, `controller`, `protocolID`, or `tags`.
+
+When `tags` is present:
+
+- `tagQueryMode: "all"` means every supplied tag **MUST** be present on the result token.
+- `tagQueryMode: "any"` means at least one supplied tag **MUST** be present on the result token.
+- if `tagQueryMode` is omitted, services **MUST** treat it as `"all"`.
+
+This BRC standardizes the query object and matching semantics. It does not redefine the generic BRC-24/BRC-88 transport envelope, `output-list` response encoding, or BEEF packaging used by the overlay stack.
+
+#### 3.6 History
+
+History is a core part of the global profile.
+
+A BRC-35-compliant global implementation that exposes current KV state **MUST** preserve or reconstruct enough transaction ancestry to support BRC-64-style chronological history reconstruction for a live token's tuple.
+
+History:
+
+- **MUST** be reconstructable from retained ancestry rather than from a mutable service-side document record,
+- **MUST** represent prior values in chronological order from oldest to newest, and
+- **MUST** only include values from valid KV tokens for the same `(protocolID, key, controller)` tuple.
+
+### 4. Local KVStore Profile
+
+#### 4.1 Overview
+
+The local profile defines wallet-local KV persistence without introducing any new wallet RPC methods.
+
+It is a profile over existing BRC-100 capabilities. The wallet basket is the KV **context**, and the wallet output tag is the KV **key** index.
+
+#### 4.2 Required Wallet Method Mapping
+
+Local KV implementations **MUST** be expressible using the following existing wallet methods:
+
+| Capability | Existing wallet method(s) |
+|-----------|----------------------------|
+| create or update local KV tokens | `createAction`, `signAction` |
+| enumerate current local KV tokens | `listOutputs` |
+| encrypt values | `encrypt` |
+| decrypt values | `decrypt` |
+| manual recovery of corrupted outputs | `relinquishOutput` |
+
+This BRC does not define any new wallet interface surface beyond those methods.
+
+#### 4.3 Namespace and Indexing
+
+For the local profile:
+
+- the wallet basket **MUST** be the KV context,
+- the wallet output tag **MUST** be the KV key,
+- reads **MUST** query by basket plus tag,
+- duplicate live outputs for the same `(context, key)` tuple **MUST** be collapsible by `set`.
+
+This BRC relies on existing wallet basket and tag semantics from BRC-46, BRC-99, BRC-100, and related wallet specifications. It does not redefine wallet normalization rules for basket or tag identifiers. Applications **SHOULD** therefore use stable canonical strings for contexts and keys.
+
+#### 4.4 Canonical Token Format
+
+Local KV tokens **MUST** use a BRC-48 PushDrop locking script with lock position `before`.
+
+The PushDrop lock for a local token **MUST** be derived under:
+
+- `protocolID = [2, <context>]`
+- `keyID = <key>`
+- `counterparty = "self"`
+
+The local semantic payload is intentionally minimal:
+
+| Field | Meaning |
+|-------|---------|
+| 1 | value bytes |
+| 2 | optional PushDrop signature |
+
+Local parsers **MUST** accept both:
+
+- one-field payloads, and
+- two-field payloads in which only field 1 is semantic and field 2 is ignored for state purposes.
+
+Payloads with zero fields or more than two fields **MUST** be treated as invalid local KV tokens.
+
+#### 4.5 Encryption and Plaintext Profiles
+
+The default local profile is **encrypted**.
+
+When encryption is enabled:
+
+- the wallet **MUST** encrypt the UTF-8 bytes of the value using `protocolID = [2, <context>]`,
+- the wallet **MUST** use `keyID = <key>`,
+- the resulting ciphertext **MUST** be stored as field 1 of the PushDrop payload.
+
+When plaintext storage is intentionally selected:
+
+- the UTF-8 bytes of the value **MUST** be stored directly as field 1.
+
+Plaintext local storage is allowed for compatibility and explicit application choice, but encrypted local storage is the canonical default profile.
+
+#### 4.6 Local Lifecycle Semantics
+
+For a given `(context, key)` tuple within one wallet:
+
+- `get` **MUST** return the newest live value represented by the current matching outputs,
+- `set` **MUST** spend all currently matching live outputs and create one successor output,
+- `remove` **MUST** continue spending matching live outputs until none remain.
+
+If more than one live output exists for the same local tuple, that is duplicate live state. A compliant `set` implementation **MUST** collapse such duplicates into one successor token.
+
+#### 4.7 Corrupted State Handling
+
+If a local token cannot be decoded as a valid one-field or two-field local KV token, or if the encrypted value cannot be decrypted, the implementation **MUST NOT** return it as valid state.
+
+A compliant implementation **SHOULD** support one or both of these recovery paths:
+
+- overwrite the tuple with a new `set` operation that collapses the bad state, or
+- allow manual administrative recovery using `relinquishOutput`.
+
+Automatic relinquish-on-failure is not required by this BRC.
+
+### 5. KV-Specific PushDrop Clarification
+
+BRC-48 defines the generic PushDrop construction. BRC-35 defines the KV-specific profile needed for interoperable KVStore systems.
+
+For BRC-35:
+
+- emitters **MUST** use PushDrop lock position `before`,
+- the signature field, when present, **MUST** be the final field,
+- signature payload bytes **MUST** be formed by concatenating all preceding fields exactly as emitted,
+- global readers **MUST** verify the signature before accepting state,
+- local readers **MAY** ignore the signature field because trust is anchored in wallet-managed local storage rather than in public overlay validation.
+
+The PushDrop locking public key and the semantic controller field serve different roles:
+
+- the locking public key governs spendability of the output,
+- the controller field identifies who the global KV entry belongs to and anchors public verification semantics.
+
+### 6. Compatibility and Implementation Guidance
+
+#### 6.1 Normative Versus SDK-Only Surface
+
+The following are **normative** under BRC-35:
+
+- the KV token lifecycle model,
+- the global and local token formats,
+- the global query schema,
+- controller and signature verification semantics,
+- the canonical public names `ls_kvstore` and `tm_kvstore`,
+- BRC-64-style history expectations,
+- local use of baskets, tags, and existing BRC-100 wallet methods.
+
+The following are **not normative protocol surface** and are SDK or deployment conveniences:
+
+- `overlayBroadcast`
+- `acceptDelayedBroadcast`
+- `originator`
+- human-readable description strings supplied to wallet actions
+- `overlayHost`
+- tracker lists, host overrides, additional hosts, network presets, or host-reputation heuristics
+- TypeScript wrapper return ergonomics such as returning a single object for `key + controller` queries and arrays for broader queries
+- wrapper token objects included for local library convenience
+
+#### 6.2 Known Divergences
+
+| Current artifact | Status under BRC-35 | Note |
+|------------------|---------------------|------|
+| `LocalKVStore` comments describing automatic relinquish-on-failure | Non-normative stale commentary | Current interoperable behavior does not automatically call `relinquishOutput` during normal failure handling |
+| `overlayHost` config surface in current SDK types | Non-normative | Present as a configuration artifact, but not part of the current interoperable protocol behavior |
+| Legacy global no-tags tokens | Normatively valid compatibility input | Parsers **MUST** continue to accept them |
+
+#### 6.3 Multi-Protocol Guidance
+
+Current global deployments commonly use a single default KV protocol such as `[1, "kvstore"]`. Implementations that support multiple global KV protocols **SHOULD** manage live state by the full `(protocolID, key, controller)` tuple and **SHOULD NOT** assume that `key + controller` alone is globally unique across protocols.
+
+### 7. Examples
+
+#### 7.1 Global Token Example
+
+Example semantic token contents:
+
+| Field | Example value |
+|-------|---------------|
+| `protocolID` | `[1, "kvstore"]` |
+| `key` | `profile.displayName` |
+| `value` | `Ty` |
+| `controller` | `02ab...` |
+| `tags` | `["profile", "public"]` |
+
+Example exact-match lookup query:
+
+```json
+{
+  "key": "profile.displayName",
+  "controller": "02ab...",
+  "protocolID": [1, "kvstore"]
+}
+```
+
+Example tag query:
+
+```json
+{
+  "controller": "02ab...",
+  "tags": ["profile", "public"],
+  "tagQueryMode": "all",
+  "limit": 50,
+  "skip": 0,
+  "sortOrder": "desc"
+}
+```
+
+#### 7.2 Local Token Example
+
+For a local tuple:
+
+- `context = "notes"`
+- `key = "welcome"`
+- encryption protocol = `[2, "notes"]`
+- encryption `keyID = "welcome"`
+- basket = `notes`
+- output tag = `welcome`
+
+In the encrypted profile, field 1 contains ciphertext derived from the UTF-8 bytes of the value. In the plaintext profile, field 1 contains the raw UTF-8 value bytes.
+
+## Security and Privacy Considerations
+
+- Global KV values are public. Their keys, values, controllers, and tags are visible to overlay operators and anyone who can inspect the chain or the overlay state.
+- Tags can leak classification metadata even when values themselves are not sensitive.
+- Global readers **MUST** verify signatures on read. Overlay services are indexing infrastructure, not trust anchors for token authenticity.
+- Global history reconstruction reveals prior values. Applications **SHOULD** assume that a historical value chain is publicly linkable.
+- Local encrypted storage is the canonical default because it protects the value payload from casual exposure outside the wallet's authorized decryption path.
+- Even in the encrypted local profile, context names and key tags may remain visible to the wallet and to any local administrative interface. Applications **SHOULD** avoid sensitive naming if that metadata matters.
+- Implementations **SHOULD** serialize writes per tuple to reduce races and duplicate live state.
+
+## Conformance Appendix
+
+### A. Parser Requirements
+
+Global parsers:
+
+- **MUST** accept the legacy no-tags and current tagged token forms.
+- **MUST** reject or ignore malformed tokens.
+- **MUST** verify the global signature before accepting state.
+- **MUST** decode `protocolID` and `tags` from their JSON string forms.
+
+Local parsers:
+
+- **MUST** accept one-field and two-field payloads.
+- **MUST** treat only field 1 as semantic state.
+- **MUST** reject zero-field and greater-than-two-field payloads.
+- **MUST NOT** return undecodable or undecryptable values as valid state.
+
+### B. Emitter Requirements
+
+Global emitters:
+
+- **MUST** emit PushDrop with lock position `before`.
+- **MUST** order fields exactly as defined in Section 3.2.
+- **MUST** include the controller identity key in the `controller` field.
+- **MUST** sign the exact concatenated semantic field bytes.
+- **SHOULD** use the canonical public names `ls_kvstore` and `tm_kvstore`.
+
+Local emitters:
+
+- **MUST** store local KV outputs in the basket named by the context.
+- **MUST** tag the output with the key.
+- **MUST** use `[2, <context>]` and `keyID = <key>` for encrypted local storage.
+- **MUST** collapse duplicate live outputs during `set`.
+
+### C. Overlay Service Requirements
+
+Overlay services implementing the public profile:
+
+- **MUST** recognize `ls_kvstore` as the canonical lookup-service name.
+- **MUST** recognize `tm_kvstore` as the canonical topic-manager topic.
+- **MUST** filter by the query schema defined in Section 3.5.
+- **MUST** treat omitted `tagQueryMode` as `"all"`.
+- **MUST** return live outputs rather than spent historical records when serving current state.
+- **MUST** preserve or reconstruct retained ancestry sufficient for BRC-64-style history reconstruction.
+
+### D. Wallet-Local Behavior Requirements
+
+Wallet-local implementations:
+
+- **MUST NOT** require new wallet RPC methods beyond those listed in Section 4.2.
+- **MUST** map local KV namespace to baskets and tags.
+- **MUST** support encrypted local values by default.
+- **MAY** offer plaintext local storage as an explicit option.
+- **SHOULD** expose or permit manual recovery of corrupted outputs, such as through `relinquishOutput`.
+
+### E. Recommended Conformance Scenarios
+
+Implementations **SHOULD** be tested against at least the following scenarios:
+
+- global create, lookup, update, and delete for one `(protocolID, key, controller)` tuple
+- global queries by `key`, `controller`, `protocolID`, and tags with both `all` and `any`
+- global rejection of malformed or forged tokens via read-side signature verification
+- global history reconstruction across successive updates
+- local encrypted `set`, `get`, update, and `remove`
+- local plaintext profile operation
+- local duplicate-output collapse and newest-live-value selection
+- local corrupted-token handling and recovery guidance
+- canonical service/topic naming and current overlay host-resolution expectations
+
+## References
+
+- [BRC-46: Wallet Transaction Output Tracking (Output Baskets)](../wallet/0046.md)
+- [BRC-48: Pay to Push Drop](../scripts/0048.md)
+- [BRC-64: Overlay Network Transaction History Tracking](./0064.md)
+- [BRC-87: Standardized Naming Conventions for BRC-22 Topic Managers and BRC-24 Lookup Services](./0087.md)
+- [BRC-88: Overlay Services Synchronization Architecture](./0088.md)
+- [BRC-99: P Baskets: Allowing Future Wallet Basket and Digital Asset Permission Schemes](../wallet/0099.md)
+- [BRC-100: Unified, Vendor-Neutral, Unchanging, and Open BSV Blockchain Standard Wallet-to-Application Interface](../wallet/0100.md)
+- [BRC-116: Wallet Permissions and Counterparty Trust](../wallet/0116.md)
+- [`bsv-blockchain/ts-sdk`](https://github.com/bsv-blockchain/ts-sdk)

--- a/overlays/0064.md
+++ b/overlays/0064.md
@@ -4,7 +4,7 @@ Ty Everett (ty@projectbabbage.com)
 
 ## Abstract
 
-This document proposes a solution for tracking transaction histories within UTXO-based overlay networks by extending the BRC-22 standard to include transaction inputs and the BRC-24 standard's query responses to include such data in extended BRC-36 input envelopes. By associating previous transaction inputs with topic-specific UTXOs and facilitating history traversal, it allows network participants to access a more complete record of UTXO histories. This standard outlines the parameters and steps needed to capture, maintain, and access historical transactional data in overlay networks.
+This document proposes a solution for tracking transaction histories within UTXO-based overlay networks by extending the BRC-22 submission result model to identify which spent topical coins should be retained for history and by extending BRC-24 lookup behavior to return BEEF that preserves source-transaction ancestry. This allows clients to traverse the lifecycle of topical outputs directly from returned transaction data. The older notion of extending BRC-36 JSON envelopes is now historical and is not the current interoperable mechanism.
 
 ## Motivation
 
@@ -12,24 +12,27 @@ BRC-22 successfully enables the tracking and synchronization of UTXOs across var
 
 ## Specification
 
-We introduce extensions to the BRC-22 and BRC-24 standards to encapsulate the input history of network transactions. Topic managers in BRC-22 can now prescribe which transaction inputs should be conserved and linked with the admitted transaction outputs, designating inputs that are pertinent for tracking. The BRC-24 standard, meanwhile, is adjusted to support the retrieval of past renditions of UTXOs.
+We introduce extensions to the BRC-22 and BRC-24 standards to encapsulate the input history of network transactions. Topic managers in BRC-22 can prescribe which transaction inputs should be conserved and linked with admitted transaction outputs, designating inputs pertinent for later history traversal. BRC-24 lookups then return enough BEEF to reconstruct those relationships.
 
 ### Changes to the BRC-22 Standard
 
 Topic managers in overlay networks now perform the following additional steps:
 
 - Verify the inputs from the transaction tagged with their topic labels to determine their relevance.
-- Provide a return value back to the Confederacy node directing it to retain these relevant transaction inputs, so that the node can maintain them alongside admitted transaction outputs for the specified topic.
-- Relative location metadata and other associated data should be stored by the Confederacy node along with these inputs, enabling efficient topic-specific historical data retrieval.
+- Return `coinsToRetain` input indices for any spent topical predecessors that should remain queryable for history.
+- Optionally return `coinsRemoved` input indices for spent topical predecessors that are removed from the live topical set.
+- Preserve enough transaction ancestry to later reconstruct source transactions for those retained historical coins.
 
 ### Changes to the BRC-24 Standard
 
 The lookup services specified under BRC-24 can now:
 
 - Accept queries for the previous renditions of specific UTXOs (formats for these queries depend on the specific lookup service).
-- Assemble and return a responsive list comprising of the series of transactions that involve the queried UTXOs along their states across the network's history.
-- Extend the BRC-36 envelope return format, including transactions as inputs when they contribute to the history of the queried UTXOs.
+- Assemble and return BEEF sufficient to reconstruct the responsive outputs and their ancestry.
+- Optionally associate service-defined `context` bytes with each returned output when that helps identify the role of a historical rendition.
+
+Current SDK-side historical reconstruction is performed by traversing `Transaction.inputs[].sourceTransaction` ancestry. Implementations that wish to support interoperable history traversal SHOULD therefore ensure that returned BEEF is rich enough for clients to rebuild this chain.
 
 ## Implementation
 
-Developers should adapt their existing BRC-22 based systems to collect and preserve pertinent transaction inputs when admitting new transaction outputs. Lookup services following the BRC-24 standard must be updated to handle queries for prior renditions of UTXOs and effectively traverse transactional histories, extending their BRC-36 envelope returns to incorporate key transaction input data for the queried UTXOs. By adhering to the changes specified in this document, network participants can ensure interoperability, efficient data access and complete historical tracking of UTXOs across overlay networks.
+Developers should adapt their existing BRC-22 based systems to collect and preserve pertinent transaction inputs when admitting new transaction outputs. Lookup services following BRC-24 should return BEEF with sufficient ancestry for clients to traverse historical state transitions. The older BRC-36-envelope approach SHOULD be considered deprecated for new interoperable implementations.

--- a/overlays/0088.md
+++ b/overlays/0088.md
@@ -74,6 +74,14 @@ Current resolver implementations also:
 - reuse stale host sets while refreshing them in the background,
 - and temporarily back off failing hosts rather than hammering them continuously.
 
+Current broadcaster implementations also:
+
+- reject topic names that do not start with `tm_`,
+- use `ls_ship` lookups with a query shaped as `{ "topics": ["tm_example"] }` to find interested hosts,
+- use `http://localhost:8080` for local-development presets,
+- require HTTPS host URLs in production unless an implementation explicitly enables local HTTP,
+- and, by default, consider a broadcast successful only when at least one responsive host acknowledges every requested topic. Applications may tighten this by requiring acknowledgment from all interested hosts for selected topics, or may configure more specific host requirements.
+
 ### SHIP and SLAP Token Formats
 
 #### SHIP Token Format
@@ -98,8 +106,8 @@ Field 4 | The service name, represented by a [BRC-24](./0024.md) service ID.
 
 The advertiser creates a transaction output containing the token and submits it to known nodes, including their own. The process involves:
 
-1. Deriving the locking key using the advertiser's identity key.
-2. Computing the signature over the token fields.
+1. Encoding the advertisement fields as a PushDrop token.
+2. Locking the token using the advertiser's wallet identity under the BRC-100 protocol `[2, "Service Host Interconnect"]` for SHIP or `[2, "Service Lookup Availability"]` for SLAP, key ID `1`, counterparty `self`.
 3. Creating and submitting the transaction output containing the token.
 
 ### Token Validation and Admission

--- a/overlays/0088.md
+++ b/overlays/0088.md
@@ -25,10 +25,22 @@ The Overlay Services Synchronization Architecture comprises two fundamental prot
 
 Each node running overlay services will implement topic managers and lookup services for both SHIP and SLAP, ensuring alignment between advertised services and their actual configuration.
 
+### Status Note
+
+The core SHIP/SLAP concepts in this document remain current, but several transport details have evolved in current interoperable implementations:
+
+- SHIP submissions are commonly BEEF over `POST /submit` with topics provided separately.
+- SLAP/lookup resolution is performed against **service** names such as `ls_kvstore`.
+- Topic names used with current SDK tooling are expected to start with `tm_`.
+- Returned lookup data is now standardized around `output-list` responses backed by BEEF, rather than hydrated JSON UTXO objects.
+- Host resolution includes caching, stale-while-revalidate refresh, and host backoff/reputation behavior.
+
+Readers should therefore interpret this document together with the updated [BRC-22](./0022.md), [BRC-24](./0024.md), and [BRC-64](./0064.md) documents.
+
 ### Components
 
-- **SHIP/SLAP Topic Managers**: Manage topic-specific transaction admittance.
-- **SHIP/SLAP Lookup Services**: Provide mechanisms for querying UTXO states within topics.
+- **SHIP Topic Managers**: Manage topic-specific transaction admittance for topics such as `tm_example`.
+- **SLAP Lookup Services**: Provide mechanisms for querying indexed overlay state for services such as `ls_example`.
 - **Advertiser**: Handles the creation and revocation of SHIP and SLAP advertisements.
 - **Overlay Services Engine**: Coordinates the processing of transactions, alignment of advertisements, and synchronization of data across various services.
 
@@ -42,7 +54,7 @@ Each node must ensure alignment between the SHIP and SLAP advertisements it has 
 
 Nodes host copies of the SHIP and SLAP overlay networks, ensuring they are updated with new advertisements or revocations.
 
-- **Submission**: Any node can submit SHIP/SLAP advertisements to another node if it knows its domain name, updating the overlay network.
+- **Submission**: Any node can submit SHIP/SLAP advertisements to another node if it knows its host base URL, updating the overlay network.
 - **Internal Updates**: Nodes submit their own advertisement transactions to themselves to update the overlay networks about new advertisements or revocations, thereby ensuring their hosted copies are always current and propagating them to other nodes.
 
 #### 3. Transaction Propagation
@@ -50,9 +62,17 @@ Nodes host copies of the SHIP and SLAP overlay networks, ensuring they are updat
 As part of the transaction submission process, nodes notify each other about transactions on topics they host and care about.
 
 When new transactions are submitted to a node, the Engine:
-  - Ensures transactions are propagated to relevant nodes based on SHIP/SLAP advertisements made by them.
-  - Updates lookup services with new or spent UTXOs.
-  - Delegates transaction submission, verification, and output admittance to the SHIP/SLAP topic managers.
+- Ensures transactions are propagated to relevant nodes based on SHIP advertisements.
+- Updates lookup services with new or spent outputs.
+- Delegates transaction submission, verification, and output admittance to the relevant topic managers.
+- Returns per-topic admittance instructions indicating admitted outputs and retained historical coins.
+
+Current resolver implementations also:
+
+- query multiple SLAP trackers in parallel,
+- cache resolved competent hosts per service,
+- reuse stale host sets while refreshing them in the background,
+- and temporarily back off failing hosts rather than hammering them continuously.
 
 ### SHIP and SLAP Token Formats
 
@@ -62,7 +82,7 @@ Field   | Meaning
 --------|------------
 Field 1 | The string `SHIP`, denoting a SHIP advertisement.
 Field 2 | The [BRC-31](../peer-to-peer/0031.md) identity key of the advertiser.
-Field 3 | The domain name of the HTTPS server hosting the network node.
+Field 3 | The host base URL advertised for submissions. Current interoperable implementations expect an HTTPS base URL in production and allow plain HTTP only for local development.
 Field 4 | The topic name hosted by the advertiser.
 
 #### SLAP Token Format
@@ -71,8 +91,8 @@ Field   | Meaning
 --------|------------
 Field 1 | The string `SLAP`, denoting a SLAP advertisement.
 Field 2 | The [BRC-31](../peer-to-peer/0031.md) identity key of the advertiser.
-Field 3 | The domain name of the HTTPS server hosting the network node.
-Field 4 | The service name, represented by a [BRC-24](./0024.md) provider ID.
+Field 3 | The host base URL advertised for lookups. Current interoperable implementations expect an HTTPS base URL in production and allow plain HTTP only for local development.
+Field 4 | The service name, represented by a [BRC-24](./0024.md) service ID.
 
 ### Token Creation and Submission
 
@@ -93,4 +113,6 @@ Nodes validate the identity key's link to the signature-producing key before adm
 
 ### Implementation
 
-Developers should implement an HTTPS server that hosts the SHIP and SLAP topic managers and lookup services. The server should be responsible for notifying other nodes of relevant transactions and maintaining synchronization.
+Developers should implement a server that hosts SHIP topic managers and SLAP lookup services. Production interoperability currently assumes HTTPS host URLs. Local-development interoperability commonly uses `http://localhost:8080`.
+
+The custom multi-scheme facilitator ideas discussed in [BRC-101](./0101.md) are not part of the current minimum interoperable behavior and should be treated as future extensions rather than baseline requirements.

--- a/overlays/0101.md
+++ b/overlays/0101.md
@@ -2,7 +2,20 @@
 
 Ty Everett (ty@projectbabbage.com)
 
-Currently, there are only HTTPS URLs within SHIP and SLAP advertisements
+## Status
+
+This document is currently **aspirational** rather than descriptive of the interoperable behavior implemented by `bsv-blockchain/ts-sdk`.
+
+Current resolver and broadcaster implementations:
+
+- expect concrete host base URLs in SHIP and SLAP advertisements,
+- use `https:` in production,
+- allow plain `http:` only for the SDK's `local` preset,
+- and do **not** currently negotiate composite schemes such as `https+bsvauth+smf:` or non-HTTP transports directly from advertisement URLs.
+
+Implementers SHOULD therefore treat the mechanisms described below as future extension ideas, not as present-day interoperability requirements.
+
+Currently, there are only HTTPS URLs within SHIP and SLAP advertisements.
 
 This `https:` scheme indicates that, according to pre-defined rules (like headers and the /submit or /lookup paths), submission or lookups are facilitated over the HTTPS protocol.
 
@@ -33,6 +46,6 @@ SLAP `wss://example.com` (real-time event-listening live web-socket lookup respo
 
 SLAP `js8c+bsvauth+smf:?lat=40&long=130&freq=40meters&radius=1000miles` (lookup is advertised using JS8 Call protocol at a given set of GPS coordinates, a given frequency and radius, with BSV Auth and Service Monetization Framework enabled.
 
-These new SHIP and SLAP schemes allow for the advertisement of new Overlay Services that have more advanced capabilities, including real-time updates from lookup services, non-final transaction submission, mutual authentication, payment, off-chain / private value submission, non-HTTP transport mechanisms, and much more.
+These proposed SHIP and SLAP schemes would allow the advertisement of Overlay Services with more advanced capabilities, including real-time updates from lookup services, non-final transaction submission, mutual authentication, payment, off-chain/private value submission, and non-HTTP transport mechanisms.
 
-Compared to plain HTTPS, they make a significant improvement. Facilitators for each of these custom "protocol" fields in the advertised SHIP/SLAP URLs can be implemented into standard libraries, the associated lookup services can be updated to facilitate querying by them, and new default SLAP trackers can be added so that users are able to stay connected in more ways than one.
+Compared to plain HTTPS, they may eventually provide a significant improvement. However, until a concrete facilitator specification and interoperable implementation exist, wallets and overlay clients SHOULD assume plain HTTPS base URLs (or local HTTP for development) when processing SHIP and SLAP advertisements.

--- a/overlays/README.md
+++ b/overlays/README.md
@@ -9,6 +9,7 @@ BRC | Standard
 24   | [Overlay Network Lookup Services](./0024.md)
 25   | [Confederacy Lookup Availability Protocol (CLAP)](./0025.md)
 26   | [Universal Hash Resolution Protocol](./0026.md)
+35   | [Layered Key-Value Store for Wallets and Overlay Services](./0035.md)
 64   | [Overlay Network Transaction History Tracking](./0064.md)
 81   | [Private Overlays with P2PKH Transactions](./0081.md)
 87   | [Standardized Naming Conventions for BRC-22 Topic Managers and BRC-24 Lookup Services](./0087.md)

--- a/payments/0027.md
+++ b/payments/0027.md
@@ -12,6 +12,12 @@ The DPP addresses these challenges by re-evaluating and baselining the existing 
 
 ## Concepts
 
+### Status Note
+
+BRC-27 defines DPP as a standalone invoice/payment protocol. It is not part of the current `bsv-blockchain/ts-sdk` or `bsv-blockchain/wallet-toolbox` wallet API surface, which centers on [BRC-100](../wallet/0100.md), [BRC-29](./0029.md), [BRC-105](./0105.md), [BRC-118](./0118.md), and [BRC-121](./0121.md) for the payment behavior implemented in those repositories.
+
+Implementers should treat DPP as an external or legacy payment protocol unless they intentionally adopt BRC-27/BRC-54/BRC-55. It should not be inferred as required behavior for BRC-100 wallets.
+
 The Direct Payment Protocol (DPP) is a standard for facilitating direct payments between a customer and a merchant by specifying the necessary messages, objects, and components required for secure and efficient transactions. This section outlines the high-level concepts involved in the DPP standard.
 
 ### Messages

--- a/payments/0028.md
+++ b/payments/0028.md
@@ -14,6 +14,12 @@ Furthermore, Paymail provides a scalable solution to the problem of blockchain s
 
 ## Specification
 
+### Status Note
+
+BRC-28 describes Paymail payment-destination and transaction-delivery capabilities. These capabilities are external to the current `bsv-blockchain/ts-sdk` and `bsv-blockchain/wallet-toolbox` BRC-100 wallet implementations, which do not implement Paymail destination discovery as part of their wallet interface.
+
+New wallet integrations using the current SDK/toolbox should use BRC-100 payment construction and BRC-29/BRC-105/BRC-121 remittance flows unless they explicitly need Paymail interoperability. The AtFinder implementation listed below is deprecated.
+
 The BRC-28 specification comprises two main components: P2P Transactions and P2P Payment Destination. These components work in tandem to facilitate the exchange of Paymail transactions in a peer-to-peer manner, eliminating the need for blockchain scanning services and enabling scalable Bitcoin SV wallet applications.
 
 ### P2P Transactions

--- a/payments/0029.md
+++ b/payments/0029.md
@@ -4,15 +4,21 @@ Ty Everett (ty@projectbabbage.com)
 
 ## Abstract
 
-This BRC specifies a protocol for exchanging simple P2PKH payments between a sender and a recipient in a way that is SPV-compliant and cross-compatible. The protocol makes use of [BRC-42](../key-derivation/0042.md) key derivation to derive public and private keys between users, [BRC-8](../transactions/0008.md) transaction envelopes to relay SPV-related information between the sender and the recipient, and a [BRC-9](../transactions/0009.md) SPV implementation to enable the recipient to obtain confidence that the transactions are valid and legitimate. This BRC specifies the JSON version of the payment message format used by the sender when exchanging the payment with the recipient, and the steps and processes involved in constructing and validating a payment message.
+This BRC specifies a protocol for exchanging simple P2PKH payments between a sender and a recipient in a way that is SPV-compliant and cross-compatible. The protocol makes use of [BRC-42](../key-derivation/0042.md) key derivation to derive public and private keys between users and [BRC-62](../transactions/0062.md) / [BRC-95](../transactions/0095.md) BEEF data to relay transaction validation information. Current wallet implementations use [BRC-100](../wallet/0100.md) `createAction` and `internalizeAction` to construct and receive these payments.
 
 ## Motivation
 
 The motivation for this BRC is to establish a simple, secure, and cross-compatible payment protocol that facilitates P2PKH payments across the BSV ecosystem. The protocol utilizes [BRC-42](../key-derivation/0042.md) key derivation to provide a privacy-enhanced approach to P2PKH transactions. The incorporation of [BRC-9](../transactions/0009.md) SPV checking ensures secure validation of transactions while maintaining efficient processing times. This standard aims to simplify the process of P2PKH payments for wallets and applications, providing a straightforward implementation path for developers.
 
+## Status Note
+
+The original JSON payment message in this document used extended [BRC-8](../transactions/0008.md) transaction envelopes. That framing is historical for new wallet integrations. Current `bsv-blockchain/ts-sdk` and `wallet-toolbox` integrations use BRC-100 transaction creation, Atomic BEEF transport, and `internalizeAction` remittance metadata.
+
+Implementers SHOULD treat the legacy `transactions` array of BRC-8 envelopes as deprecated unless explicitly maintaining compatibility with older systems.
+
 ## Specification
 
-We specify a protocol for exchanging simple P2PKH payments between a sender and a recipient. The protocol employs [BRC-42](../key-derivation/0042.md) key derivation to derive related public and private keys with invoice numbers, [BRC-8](../transactions/0008.md) transaction envelopes to relay SPV-related information, and [BRC-9](../transactions/0009.md) SPV checks to enable the recipient to validate the transactions.
+We specify a protocol for exchanging simple P2PKH payments between a sender and a recipient. The protocol employs [BRC-42](../key-derivation/0042.md) key derivation to derive related public and private keys with invoice numbers, BEEF transaction data to relay SPV-related information, and recipient-side wallet validation to internalize the payment.
 
 ### Key Derivation Scheme
 
@@ -25,8 +31,8 @@ We start with the need for a unique identifier for the payment, used for key der
 
 The keys that protect the funds exchanged under this protocol are derived with [BRC-42](../key-derivation/0042.md) key derivation by the sender from the identity key of the recipient. The invoice number is specified as follows:
 
-```
-“2-3241645161d8-<derivationPrefix> <derivationSuffix>”
+```text
+2-3241645161d8-<derivationPrefix> <derivationSuffix>
 ```
 
 Where:
@@ -36,28 +42,56 @@ Where:
 - `<derivationPrefix>` is the payment-specific prefix used to arrive at a common key universe for all outputs in this payment
 - `<derivationSuffix>` is the UTXO-specific suffix used to arrive at a unique key for a specific P2PKH UTXO
 
-### Payment Message Construction (JSON)
+### Current BRC-100 Payment Construction
 
-The payment message format used by the sender when exchanging the payment with the recipient is a JSON object comprising:
+The sender creates one or more P2PKH outputs spendable by the recipient-derived key:
 
-- `"protocol"`: This field denotes that the JSON object comprises a payment message according to this protocol. Its value should be set to `3241645161d8`.
-- `"senderIdentityKey"`: The recipient will need to know the public identity key of the sender in order to validate the incoming payment. This field's value should be the 33-byte, compressed, hex-encoded secp256k1 public key of the sender
-- `"derivationPrefix"`: This field denotes the payment-wide derivation prefix used by the sender when the keys for the payment UTXOs were derived
-- `"transactions"`: This field comprises an array of one or more extended [BRC-8](../transactions/0008.md) transaction envelopes. Each of the envelopes is extended with an additional "outputs" field, which is specified below
+1. Obtain the recipient identity key.
+2. Generate a payment-wide `derivationPrefix`.
+3. Generate a unique `derivationSuffix` for each payment output.
+4. Derive the recipient public key with BRC-42 using:
+   - protocol ID `[2, "3241645161d8"]`
+   - key ID `<derivationPrefix> <derivationSuffix>`
+   - counterparty equal to the recipient identity key
+5. Convert the derived public key into a P2PKH locking script as defined by [BRC-16](../scripts/0016.md).
+6. Call BRC-100 `createAction` with outputs paying those locking scripts.
 
-### The Outputs Extension
+For each BRC-100 output, `customInstructions` SHOULD carry enough remittance data for the recipient or service layer to identify the payment, commonly:
 
-Within each of the [BRC-8](../transactions/0008.md) transaction envelopes, there is an additional field called `outputs`. This field is an object whose keys are integers that correspond to the output numbers in the specific transaction, all of which are intended by the sender to be redeemable by the recipient as part of this payment. The object values are objects that contain the suffix property, which is the derivation suffix for the specific UTXO being referenced. Here is an example of the outputs field:
-
-```
-outputs: {
-  3: { suffix: 'abcdefg' },
-  4: { suffix: 'hijklmnop' },
-  7: { suffix: 'qrstuvwxyz' }
+```json
+{
+  "derivationPrefix": "<payment prefix>",
+  "derivationSuffix": "<output suffix>",
+  "payee": "<recipient identity key>"
 }
 ```
 
-This example would be affixed onto an envelope that contained a transaction where the fourth, fifth, and eighth outputs (zero-indexing) are intended by the sender to be redeemable by the recipient as part of a payment.
+When a protocol requires a known payment output index, the sender SHOULD set `options.randomizeOutputs` to `false`.
+
+### Current Payment Message Construction
+
+Current integrations transport the resulting transaction as Atomic BEEF. A JSON payment message for a single transaction commonly contains:
+
+```json
+{
+  "derivationPrefix": "<payment prefix>",
+  "derivationSuffix": "<output suffix>",
+  "transaction": "<base64 AtomicBEEF>"
+}
+```
+
+If multiple outputs or transactions are used, the message MUST include the derivation suffix and output index for every output intended for the recipient. The exact outer envelope may be defined by the higher-level protocol carrying the payment, such as [BRC-105](./0105.md) for HTTP service monetization.
+
+### Legacy JSON Envelope
+
+The legacy payment message was a JSON object with:
+
+- `"protocol"` equal to `3241645161d8`
+- `"senderIdentityKey"` as the sender identity key
+- `"derivationPrefix"` as the payment-wide prefix
+- `"transactions"` as an array of extended BRC-8 transaction envelopes
+
+Each legacy envelope included an `outputs` object mapping output indices to suffix values. This format is deprecated for new BRC-100 integrations.
 
 ### Sending Payments
 
@@ -67,13 +101,35 @@ The steps for a sender to send a payment under this protocol are as follows:
 2. Decide on the number of outputs (across one or multiple transactions) that will comprise the payment.
 3. For each output, generate a derivation suffix for the output and decide on the number of satoshis in the output.
 4. For each output, use [BRC-42](../key-derivation/0042.md) key derivation to derive a public key for the recipient for the output, and use the public key to construct a P2PKH Bitcoin output script as per [BRC-16](../scripts/0016.md).
-5. Use any wallet capable of creating [BRC-8](../transactions/0008.md) Transaction Envelopes to construct and sign transactions that contain the output scripts derived for the recipient from the previous step.
-6. With all of the transactions, the derivation prefix, the derivation suffixes, and your sender identity key in hand, construct a payment message for the recipient that contains this information.
+5. Use a BRC-100 wallet to construct and sign transactions that contain the output scripts derived for the recipient from the previous step.
+6. With the Atomic BEEF transaction data, derivation prefix, derivation suffixes, output indices, and sender identity key in hand, construct a payment message for the recipient that contains this information.
 
-### Recipient Validation:
+### Recipient Validation
 
-When the recipient processes their incoming transactions, they check that the public key hashes in the output scripts are properly derived. The recipient should also perform the standard [BRC-9](../transactions/0009.md) SPV checks. If these checks pass, the payment is marked as accepted and acknowledged, and goods or services can be rendered to the payee.
+When the recipient processes an incoming payment, it checks that the public key hashes in the output scripts are properly derived from the sender and recipient identities, the derivation prefix, and the output suffixes. The recipient should also validate the supplied BEEF data according to its wallet policy.
+
+Current BRC-100 wallets receive the payment by calling `internalizeAction` with output metadata such as the following. The `tx` value shown is a placeholder for the Atomic BEEF byte array:
+
+```json
+{
+  "tx": [1, 1, 1, 1],
+  "outputs": [
+    {
+      "outputIndex": 0,
+      "protocol": "wallet payment",
+      "paymentRemittance": {
+        "derivationPrefix": "<payment prefix>",
+        "derivationSuffix": "<output suffix>",
+        "senderIdentityKey": "<sender identity key>"
+      }
+    }
+  ],
+  "description": "Incoming BRC-29 payment"
+}
+```
+
+If these checks pass, the payment is marked as accepted and acknowledged, and goods or services can be rendered to the payee.
 
 ## Implementations
 
-Implementations of this protocol should adhere to the key derivation scheme and the payment message format specified in this BRC. The transaction submission system within any wallet can implement this protocol and validate that incoming transactions submitted under this protocol contain UTXOs that are properly derivable by the recipient. The protocol is intended to be cross-compatible and SPV-compliant.
+Implementations of this protocol should adhere to the key derivation scheme and current BRC-100 remittance behavior specified in this BRC. The transaction submission system within any wallet can implement this protocol and validate that incoming transactions submitted under this protocol contain UTXOs that are properly derivable by the recipient. The protocol is intended to be cross-compatible and SPV-compliant.

--- a/payments/0041.md
+++ b/payments/0041.md
@@ -10,6 +10,10 @@ This standard describes PacketPay, a mechanism for facilitating micropayments us
 
 The rapid growth of web services and APIs has created a need for efficient, secure, and scalable methods of monetizing these services. Traditional payment methods are often cumbersome and impose high fees, making them unsuitable for micropayments. PacketPay addresses this need by providing a secure, efficient, and low-cost solution for facilitating micropayments in HTTP requests. By leveraging Bitcoin SV's capabilities, PacketPay enables API providers to monetize their services on a per-request basis, and API consumers to pay only for the resources they use.
 
+## Status Note
+
+BRC-41 is historical. Current authenticated HTTP monetization is specified by [BRC-105](./0105.md), with [BRC-118](./0118.md) for multipart payment body transport where needed. Simple unauthenticated 402 payment profiles are covered separately by [BRC-121](./0121.md). The PacketPay JavaScript packages referenced below are deprecated for new integrations.
+
 ## Specification
 
 ### HTTP Headers

--- a/payments/0054.md
+++ b/payments/0054.md
@@ -10,6 +10,12 @@ The motivation behind the Hybrid Payment Mode is to provide a flexible and versa
 
 ## Specification
 
+### Status Note
+
+BRC-54 is a DPP payment-mode extension. It is not implemented by the current `bsv-blockchain/ts-sdk` or `bsv-blockchain/wallet-toolbox` wallet API surface. Current SDK/toolbox payment support uses BRC-100 wallet actions, BRC-29 remittance metadata, and the HTTP payment profiles in BRC-105/BRC-118/BRC-121.
+
+Treat this document as an external or legacy DPP extension unless a project explicitly opts into BRC-27 DPP.
+
 HybridPaymentMode (BRFCID: `ef63d9775da5`) will be described together with related Payment and PaymentACK objects. It is the first defined payment mode capable of fulfilling numerous requirements due to its flexible nature.
 
 ### HybridPaymentMode Structure

--- a/payments/0055.md
+++ b/payments/0055.md
@@ -10,6 +10,12 @@ HTTPS is one of the most widely used transport mechanisms for internet traffic. 
 
 ## Specification
 
+### Status Note
+
+BRC-55 is the HTTPS transport for BRC-27 DPP. It is not implemented by the current `bsv-blockchain/ts-sdk` or `bsv-blockchain/wallet-toolbox` wallet substrates. Do not confuse the DPP `/api/v1/payment/{paymentID}` routes below with current BRC-100 wallet HTTP routes such as `/createAction` and `/internalizeAction`, or with BRC-105/BRC-121 402 payment headers.
+
+Treat this document as external or legacy unless a deployment explicitly opts into DPP.
+
 Below is the table with messages requested from client (wallet) to merchant (server).
 
 The `paymentID` parameter is assumed to be known as a result of request between client-server before DPP protocol operation.

--- a/payments/0070.md
+++ b/payments/0070.md
@@ -1,4 +1,4 @@
-# BRC-69: Paymail Receieve BEEF
+# BRC-70: Paymail Receive BEEF
 
 Deggen (deggen@kschw.com)
 
@@ -23,6 +23,10 @@ version: 1.0.0
 ```
 
 ## Specification
+
+### Status Note
+
+BRC-70 is a Paymail capability extension and is external to the current `bsv-blockchain/ts-sdk` / `bsv-blockchain/wallet-toolbox` BRC-100 wallet implementation. It remains useful for Paymail-specific interoperability, but current SDK/toolbox payment flows should not be expected to expose this capability unless a Paymail integration is added explicitly.
 
 We specify that an endpoint for delivery of transaction data ought to be added to the capabilities object in the .well-known response of a paymail service with the label: `5c55a7fdb7bb`.
 

--- a/payments/0105.md
+++ b/payments/0105.md
@@ -13,6 +13,12 @@ This document specifies an **HTTP-based micropayment** framework that extends [B
 
 this specification enables an **authenticated, verifiable** mechanism to **monetize any web service** with micropayments. The server could even cryptographically bind each payment to the mutual-authenticated session, ensuring that the payment correlates uniquely to the requested action.
 
+## 1.1 Status Note
+
+This document defines the primary BSV-native HTTP monetization framework in this repository.
+
+[BRC-118](./0118.md) extends this specification with multipart body transport for large payment payloads without deprecating the original header transport. [BRC-120](./0120.md) documents conformance to the frozen external x402 specification, and [BRC-121](./0121.md) defines a smaller BSV-specific 402 profile. Those documents do not replace the semantics defined here unless they are being adopted explicitly for a given integration.
+
 ## 2. Motivation
 
 Current HTTP-based APIs often rely on subscription models or external billing/invoicing solutions. This approach can be **cumbersome** for fine-grained (micropayment-level) usage-based billing. By contrast, BSV Blockchain capabilities allow **on-chain** micropayments. However, bridging these seamlessly into existing HTTP flows requires:
@@ -41,7 +47,7 @@ BRC-103 defines **mutual authentication** and **certificate exchange** but **doe
 
 - **`identityKey`**: The user’s 33-byte compressed public key from the BRC-103 session.  
 - **Nonce generation**: The server can generate derivation prefixes that are cryptographically bound to its identity key, used by the parties to derive an ephemeral key pair for the payment.  
-- **HTTP 402** status code**: A recognized but typically unused code, repurposed here for BSV micropayments.
+- **HTTP 402** status code**: A reserved status code in current HTTP semantics, used here by ecosystem convention for BSV micropayments.
 
 ## 5. Payment Protocol Overview
 
@@ -226,6 +232,7 @@ If payment is successful, the server responds with a normal (e.g., `200 OK`) plu
 - [BRC-103](https://github.com/bitcoin-sv/BRCs/blob/master/peer-to-peer/0103.md): *Peer-to-Peer Mutual Authentication and Certificate Exchange Protocol*  
 - [BRC-104](https://github.com/bitcoin-sv/BRCs/blob/master/peer-to-peer/0104.md): *HTTP Transport for BRC-103*  
 - [BRC-29](./0029.md): *Derivation-based Payment Protocol*  
+- [RFC 9110 Section 15.5.3: 402 Payment Required](https://www.rfc-editor.org/rfc/rfc9110#section-15.5.3)
 - [402 Payment Required](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/402)
 
 ## 11. Conclusion

--- a/payments/0105.md
+++ b/payments/0105.md
@@ -61,7 +61,9 @@ BRC-103 defines **mutual authentication** and **certificate exchange** but **doe
 
 3. **402 Payment Required** (if fee > 0 and no valid payment provided)  
    - If the client has **not** included a valid `x-bsv-payment` header, the server responds with HTTP status **402** and sets:
+     - **`x-bsv-payment-version`**: Protocol version, currently `1.0`.
      - **`x-bsv-payment-satoshis-required`**: Number of satoshis required.  
+     - **`x-bsv-auth-identity-key`**: The server identity key to which the payment derivation is bound.
      - **`x-bsv-payment-derivation-prefix`**: A random nonce ([BRC-29](./0029.md)) for the transaction.  
 
 4. **Client Submits Payment**  
@@ -94,6 +96,10 @@ BRC-103 defines **mutual authentication** and **certificate exchange** but **doe
 - **`x-bsv-payment-derivation-prefix`**  
   - Payment-level nonce for deriving the payment output script.  
   - Sent **from server** → client in `402 Payment Required`.
+- **`x-bsv-auth-identity-key`**
+  - The server/payee identity key used as the BRC-29 payment counterparty.
+  - Sent **from server** → client in `402 Payment Required`.
+  - A client MUST NOT construct the payment if this value is absent or invalid.
 - **`x-bsv-payment`**  
   - JSON structure containing the actual transaction data.  
   - Sent **from client** → server in a subsequent request or retry after 402.
@@ -117,6 +123,7 @@ When the server determines a payment is needed but not yet provided or invalid:
 2. **Headers**:  
    - `x-bsv-payment-version`: `1.0`
    - `x-bsv-payment-satoshis-required`: `<price in satoshis>`  
+   - `x-bsv-auth-identity-key`: `<server identity key>`
    - `x-bsv-payment-derivation-prefix`: `<nonce>` (often base64 or hex)  
 3. **Body**: Optional JSON describing the error or instructions for convenience:
    ```json
@@ -144,6 +151,8 @@ After receiving this, the **client** is expected to construct and broadcast a pa
 
 - `derivationPrefix`: Must match what the server gave in the `402` response.  
 - `transaction`: A fully signed transaction paying an output script derived from the prefix, acceptable on the BSV network.  
+
+Current `ts-sdk` AuthFetch behavior constructs this transaction with BRC-29 derivation using protocol ID `[2, "3241645161d8"]`, key ID `<derivationPrefix> <derivationSuffix>`, and counterparty equal to `x-bsv-auth-identity-key`. It sets `randomizeOutputs` to `false` when creating the payment action so the payment output can be identified deterministically by the verifier.
 
 ### 6.4 Server Payment Verification
 
@@ -177,7 +186,7 @@ If payment is successful, the server responds with a normal (e.g., `200 OK`) plu
    - Parse and verify. If valid, continue. If invalid, return `400 Bad Request`.  
 
 4. **If Not Paid**  
-   - Return `402` + `x-bsv-payment-version` + `x-bsv-payment-derivation-prefix` + `x-bsv-payment-satoshis-required`.  
+   - Return `402` + `x-bsv-payment-version` + `x-bsv-payment-derivation-prefix` + `x-bsv-payment-satoshis-required` + `x-bsv-auth-identity-key`.
 
 5. **If Paid**  
    - Proceed to business logic.
@@ -185,7 +194,7 @@ If payment is successful, the server responds with a normal (e.g., `200 OK`) plu
 ### 7.2 Client-Side Steps
 
 1. **Send Request**  
-   - If server returns `402`, parse `x-bsv-payment-version` + `x-bsv-payment-satoshis-required` + `x-bsv-payment-derivation-prefix`.  
+   - If server returns `402`, parse `x-bsv-payment-version` + `x-bsv-payment-satoshis-required` + `x-bsv-payment-derivation-prefix` + `x-bsv-auth-identity-key`.
 
 2. **Construct Payment**  
    - Create transaction paying the server’s derivation.  

--- a/payments/0121.md
+++ b/payments/0121.md
@@ -6,9 +6,15 @@ Deggen (d.kellenschwiler@bsvassociation.org)
 
 This BRC specifies a lightweight protocol for monetizing HTTP resources using the `402 Payment Required` status code and a set of custom HTTP headers. A server advertises a price and its identity key in the 402 response. A client constructs a [BRC-29](./0029.md) payment transaction, encodes it in [BRC-95 BEEF](../transactions/0095.md) format, and retransmits the original request with payment headers. The server validates the transaction, internalizes the payment via its wallet, and serves the protected resource. The protocol is stateless from the server's perspective: each request is independently authorized by the presence or absence of valid payment headers.
 
+## Status Note
+
+This document specifies a deliberately small BSV-specific 402 payment profile.
+
+It should be read as an alternative to, not a replacement for, [BRC-105](./0105.md). Implementers that need the broader BRC-103/BRC-104-authenticated monetization framework should use BRC-105, optionally with [BRC-118](./0118.md) for multipart transport. Implementers that want conformance to the frozen external x402 specification should use [BRC-120](./0120.md).
+
 ## Motivation
 
-HTTP 402 was reserved in the original HTTP/1.1 specification (RFC 7231) for future use in micropayment schemes, but no standard mechanism was adopted. Meanwhile, BSV transaction fees are low enough to make per-request payments practical for content such as articles, API calls, and media.
+HTTP 402 remains reserved for future use in current HTTP semantics ([RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#section-15.5.3)), but no general web-standard payment mechanism was adopted. Meanwhile, BSV transaction fees are low enough to make per-request payments practical for content such as articles, API calls, and media.
 
 Existing BSV payment protocols ([BRC-27](./0027.md) Direct Payment Protocol, [BRC-105](./0105.md) HTTP Service Monetization Framework, [BRC-120](./0120.md) x402) each define comprehensive negotiation mechanisms. This BRC targets a simpler use case: a client that already holds a [BRC-42](../key-derivation/0042.md)-compatible wallet pays for an HTTP resource in a single round-trip pair (one 402 response, one paid request) using only standard HTTP headers and [BRC-29](./0029.md) payment remittance.
 
@@ -135,6 +141,6 @@ A client MAY cache the set of URLs for which payment has been accepted and skip 
 - [BRC-95: BEEF Transaction Format](../transactions/0095.md)
 - [BRC-105: HTTP Service Monetization Framework](./0105.md)
 - [BRC-120: x402 Stateless Settlement-Gated HTTP Protocol](./0120.md)
-- RFC 7231 Section 6.5.2: 402 Payment Required
+- RFC 9110 Section 15.5.3: 402 Payment Required
 - Reference server implementation: https://github.com/bsv-blockchain-demos/402-articles
 - Reference client implementation: https://github.com/bsv-blockchain/bsv-browser

--- a/payments/README.md
+++ b/payments/README.md
@@ -2,6 +2,15 @@
 
 This directory contains standards relating to protocols for exchanging payments in various contexts.
 
+Current orientation:
+
+- [BRC-105](./0105.md) is the main BSV-native HTTP monetization framework in this repository.
+- [BRC-118](./0118.md) extends BRC-105 with multipart transport and does not deprecate header transport.
+- [BRC-120](./0120.md) assigns a BRC identifier to the frozen external x402 v1.0 specification rather than restating that spec inline.
+- [BRC-121](./0121.md) defines a smaller BSV-specific 402 payment profile.
+
+HTTP `402 Payment Required` remains a reserved status code in RFC 9110; these BRCs define ecosystem conventions layered on top of that reserved code.
+
 BRC | Standard
 -----|------------------
 27   | [Direct Payment Protocol (DPP)](./0027.md)
@@ -10,7 +19,7 @@ BRC | Standard
 41   | [PacketPay HTTP Payment Mechanism](./0041.md)
 54   | [Hybrid Payment Mode for DPP](./0054.md)
 55   | [HTTPS Transport Mechanism for DPP](./0055.md)
-70   | [Paymail Receieve BEEF](./0070.md)
+70   | [Paymail BEEF Transaction](./0070.md)
 105  | [HTTP Service Monetization Framework](./0105.md)
 118  | [Multipart Body Transport for BRC-105 Payments](./0118.md)
 120  | [x402 Stateless Settlement-Gated HTTP Protocol](./0120.md)

--- a/peer-to-peer/0031.md
+++ b/peer-to-peer/0031.md
@@ -12,6 +12,12 @@ Identity on the internet relies heavily on trusted third parties to authenticate
 
 ## Specification
 
+### Status Note
+
+BRC-31 is the Authrite-era predecessor to the current mutual-authentication specifications. Current `bsv-blockchain/ts-sdk` peer authentication behavior is specified by [BRC-103](./0103.md), with HTTP transport specified by [BRC-104](./0104.md). BRC-103 preserves the same broad message family (`initialRequest`, `initialResponse`, `certificateRequest`, `certificateResponse`, and `general`) but binds certificate semantics to current [BRC-52](./0052.md) certificate formats and BRC-100 wallet methods.
+
+New integrations should reference BRC-103/BRC-104. The Authrite package references and BRC-53/BRC-56 dependencies below are retained only for historical context.
+
 Authrite facilitates the exchange of identity information between two parties over a communications channel, allowing them to mutually authenticate each other. The following sections describe the requisite data structures, nonce exchanges, negotiation protocol, and message signing scheme for Authrite.
 
 ### High-level Overview

--- a/peer-to-peer/0033.md
+++ b/peer-to-peer/0033.md
@@ -140,7 +140,7 @@ We leave it to higher-level protocols and systems to implement appropriate digit
 
 ### Federation and Synchronization
 
-[BRC-34](./0034.md) and [BRC-35](./0035.md) define the mechanism by which multiple servers can discover and route messages to one another, making use of an overlay network. When properly implemented, this enables two parties to exchange messages with one another even when not using the same server.
+[BRC-34](./0034.md) defines the mechanism by which multiple servers can discover and route messages to one another, making use of an overlay network. When properly implemented, this enables two parties to exchange messages with one another even when not using the same server.
 
 ### Monetization
 

--- a/peer-to-peer/0052.md
+++ b/peer-to-peer/0052.md
@@ -1,281 +1,269 @@
 # BRC-52: Identity Certificates
 
+<!-- markdownlint-disable MD013 MD034 -->
+
 - Brayden Langley (brayden@projectbabbage.com)
 - Ty Everett (ty@projectbabbage.com)
 
 ## Abstract
 
-Identity on the internet has come to rely almost exclusively on trusted third parties acting as gatekeepers for user authentication. Digital signatures provide part of the solution, but there is still a need to link the public key with the true identity of the signer, while still tolerating key compromises. We define an open-ended, ubiquitous and privacy-centric version of digital identity certificates that facilitate selective revelation and UTXO-based revocation. [BRC-3](../wallet/0003.md) digital signatures ensure the authenticity of certified fields, while [BRC-2](../wallet/0002.md) encryption facilitates an approval-based access control scheme. In this standard, we define the data structures, key derivation protocols, signing and verification procedures for identity certificates. We also discuss how responsible certificate issuers can handle key compromises.
+This specification defines identity certificates for BRC-100 wallets and peer-to-peer authentication systems. A certificate binds an identity key to encrypted certified fields under a certifier signature, while allowing the holder to reveal selected fields to selected verifiers. The specification covers the core certificate JSON and binary formats, the canonical signature preimage, certificate field encryption, master keyrings, verifier keyrings, and revocation outpoints.
+
+This specification is authoritative for certificate primitives used by [BRC-100](../wallet/0100.md), [BRC-103](./0103.md), and [BRC-104](./0104.md). Older certificate descriptions in Authrite-era specifications, including BRC-31, BRC-53, and BRC-56, are not normative for BRC-100 certificate behavior.
 
 ## Motivation
 
-The motivation behind this standard is to address the limitations of digital signatures for verifying the true identity of internet users, a verification process which currently relies heavily on passwords and trusted third parties. 
+Digital signatures prove control of keys, but applications also need a privacy-preserving way to verify claims about the controller of a key. Identity certificates provide that linkage without requiring the holder to reveal every certified attribute to every verifier. The certifier signs encrypted field values, so the certificate remains tamper-evident even when no fields are revealed. The holder can later provide encrypted field-revelation keys for only the fields a verifier is allowed to inspect.
 
-The goal is to create an open-ended, privacy-centric, and ubiquitous solution for digital identity certificates that facilitates selective revelation and UTXO-based revocation. This standard aims to provide a decentralized and reliable method for identity verification without compromising user privacy, and could be useful in various scenarios, including e-commerce, financial transactions, and secure communication. 
+## Terminology
 
-By providing a secure method for linking a user's public key to their true identity, the standard would enable secure and private online transactions and collaborations, while also protecting against fraudulent activities and identity theft. By recognizing that key compromises do occur and supporting certificate revocation, we allow users to recover from breaches without tying their entire digital identity to a single key.
+- **Subject**: The identity key whose holder is certified.
+- **Certifier**: The identity key that signs the certificate.
+- **Verifier**: A party receiving a certificate and optionally receiving keys for selected fields.
+- **Core certificate**: The signed certificate fields, excluding all keyrings.
+- **Master certificate**: A core certificate plus a master keyring that lets the subject or certifier decrypt all certificate fields.
+- **Verifiable certificate**: A core certificate plus a verifier keyring that lets a specific verifier decrypt selected certificate fields.
+- **Field revelation key**: A random 32-byte symmetric key used to encrypt one certificate field value.
+- **Keyring**: A map from field names to encrypted field revelation keys.
 
-## Specification
+The key words "MUST", "MUST NOT", "SHOULD", and "MAY" are to be interpreted as normative requirements.
 
-We start by specifying the data structures needed to represent various components of identity certificates, then proceed to key derivation schemes, signing and verification procedures, the secure verifier field revelation protocol, and finally UTXO-based revocation and responsible key compromise handling procedures.
+## Primitive Types
 
-### Data Structures
- 
-**PublicKey**
- 
-The PublicKey structure is a compressed, DER-encoded secp256k1 public key (only the X coordinate), formatted as a 33-byte hexadecimal string.
- 
-*Example:*
- 
-`02e087b19a205ae13f512341d1cfc0c712d66cacad24a809fce7edb3529e78b5da`
- 
-**Nonce**
- 
-The Nonce structure is a 256-bit number, converted to a base64 string.
- 
-*Example:*
- 
-`L9t1aQLkWkmMw1Poi1ofIjHV6GO+BNN63v8Na8/gW4Y=`
- 
- 
-**Signature**
- 
-The Signature structure is a DER-encoded ECDSA signature converted into a hexadecimal string.
- 
-Example
- 
-`3045022100c0686907d8914abfa7f356c560c7d17045dde5c10135b1cbf9bf6e4cc52e09820220366eec15372bc34db10f997e21755f603a2023c96578e9d71fca2570f23055d6`
- 
- 
-**RevocationOutpoint**
- 
-The Outpoint structure is a Bitcoin SV TXID (a hexadecimal string) and output index (a decimal integer), separated by a decimal point (“.”). When a certificate outpoint has been spent, the certificate has been revoked.
- 
-Example
- 
-`48645047cd66f7b48b24efb080ec7e27f3f448c21109939b80afd11e40898c92.1`
- 
- 
-**CertificateTypeID**
- 
-The CertificateTypeID structure is a 256-bit number that represents the distinct type or class of certificate issued by the certifier, converted to a base64 string. All certificate types with the same unique Type ID can be expected to have the same fields, and fields can be expected to have the same meanings.
- 
-Example
- 
-8l5phhdm2Hi80s6QqFOLS0NwUzDzJhlUTWv2BezmstE=
- 
- 
-**CertificateValidationKey**
- 
-The CertificateValidationKey structure is a 256-bit key converted to a base64 string. The key is used by verifiers to check the signature on the certificate.
- 
-Example
- 
-G4pBfpBEZ7n5iEHrtG5MFOnIO0U1D758naHJilcK/RU=/7lzk4XTKI=+BNN63v8Na8/gW4Y=
- 
- 
- 
-**CertificateSerialNumber**
- 
-The CertificateSerialNumber structure is a 128-bit number that represents the unique identifier of the certificate, converted to a base64 string. No two certificates should have the same serial number, especially certificates from the same certifier or of the same type.
- 
-Example
- 
-kUahacBHmYL2nkzemkatFg==
- 
- 
-**CertificateFieldValue**
- 
-The CertificateFieldValue structure is a piece of certified information that is encrypted with one of the CertificateFieldRevelationKeys. The 256-bit initialization vector used is prepended to the beginning of the data, and the AES-256-GCM algorithm is used. The structure is represented as a base64 string.
- 
-Example
- 
-IlgngMNcUM0d4GyzkSGqXaIBw6/n8bB6BG0pprO6oGhxUcivP6wDfuMWjWrG64KQJYUMN3QjHoX40r3SvAyWQaAA9ldVuPLgZwi9q2TCECKHCyEuiATCM9PdB/Ba2rxp
- 
- 
-**CertificateFieldRevelationKey**
- 
-The CertificateFieldRevelationKey structure is a 256-bit AES-GCM encryption key used to decrypt and reveal one of the CertificateFieldValues. It is represented as a base64 string.
- 
-Example
- 
-ZG3C7x11lIeqd5Fi9BDzeTXMEAIlh+uDOB53d03EV5s=
- 
- 
-**CertificateFields**
- 
-The CertificateFields structure is an object whose keys are certificate field names, and whose values are CertificateFieldValue structures.
- 
-*Example*
- 
+| Type | JSON representation | Binary representation | Requirements |
+| - | - | - | - |
+| `CertificateTypeID` | Base64 string | 32 bytes | Identifies the certificate type. Certificates with the same type are expected to use the same field names and meanings. |
+| `CertificateSerialNumber` | Base64 string | 32 bytes | Uniquely identifies a certificate from a certifier. |
+| `PublicKey` | Hex string | 33 bytes | Compressed secp256k1 public key. |
+| `RevocationOutpoint` | `<txid>.<vout>` string | 32-byte txid followed by VarInt vout | Identifies the UTXO whose spend revokes the certificate. The disabled sentinel is `0000000000000000000000000000000000000000000000000000000000000000.0`. |
+| `Signature` | Hex string | DER-encoded ECDSA bytes | Certifier signature over the canonical core certificate preimage. |
+| `CertificateFieldName` | UTF-8 string | VarInt length followed by UTF-8 bytes | 1 to 50 UTF-8 bytes. For interoperable signed certificates, field names SHOULD be printable ASCII so all implementations sort them identically. |
+| `CertificateFieldValue` | Base64 string | UTF-8 bytes of the Base64 string in `CertificateBinary` | Encrypted field value, encoded as Base64 for JSON and signed as that Base64 string. |
+| `KeyringValue` | Base64 string | Base64-decoded bytes in keyring-map binary encodings | BRC-2 encrypted field revelation key. |
+
+## Core Certificate JSON
+
+A core certificate is a JSON object with exactly these signed members:
+
+| Field | Type | Description |
+| - | - | - |
+| `type` | `CertificateTypeID` | Certificate type identifier. |
+| `serialNumber` | `CertificateSerialNumber` | Certificate serial number. |
+| `subject` | `PublicKey` | Subject identity key. |
+| `certifier` | `PublicKey` | Certifier identity key. |
+| `revocationOutpoint` | `RevocationOutpoint` | Revocation UTXO reference. |
+| `fields` | map of `CertificateFieldName` to `CertificateFieldValue` | Encrypted certified fields. |
+| `signature` | `Signature` | Certifier signature. |
+
+Example:
+
 ```json
 {
-  “first_name”: “IlgngMNcUM0d4GyzkSGqXaIBw6/n8bB6BG0pprO6oGhxUcivP6wDfuMWjWrG64KQJYUMN3QjHoX40r3SvAyWQaAA9ldVuPLgZwi9q2TCECKHCyEuiATCM9PdB/Ba2rxp”,
-  “last_name”: “3o0jTew8WMW54svE8Btx9Aks1FlQCHOxGKLZpc7SR0ESSIomToAYFtCq6U7NUuf3ktwLgnv5XdCrCTo+mOTHl/H+oyjcxB7xfdwav+bBx6vG5y9voDI/Z2MQGxE/Pmeg”,
-  “address_line_1”: “WGqZGJo7VHeQ5tx7uqeyA5q08tRVxJLUoprjAiJ8FmzOoe4gt0+6PGDgvrhkbzauSxGY9yRyOeP+irHclCIrzjwjbfkK19thoyUhr8u1283FobikPs2xKrhUvcYhDOV7”,
-  “address_line_2”: “IjI5UXJnMbcSEqIVkH8B5a9cY8EtWO7RvJH9gAWuIq0Y3koINgfqNjmockAgXnGxLvdQXvWdlCIm+foedIdHhqs9Xi60wR7hLSs9emjo6nq1Mx01wYFRW1le//Sup80x”,
-  “city”: “Ed4Nr8UL3h7AqX3PlExwLQ0Mi/QLBH9wCIpdeMb442HDbQlodF1eUuJQRXt+0ajzmXEqaGNSD59xEXmsFouLDLa6sOOzXr2psCKMXkU1+IFHGv8TgJx/vDTCxMvL7t2T”,
-  “state”: “6oiC8AMFFrLRGhpbWUO1HkA05/QPmfaUg1be4cP2vbcadIv4quaBgfwmNWE6xItpQNAfEwrx1ub9b4cNIKnN+6JAsiDiqs42mbjsgTuZL90fSEL9yPTwRuvW1ccvJ43z”,
-  “zipcode”: “Y+iqr8cSMEMMq8WqpIudzni1DIiQT5BsK29ld8lFCZddrrjep0qQyKoaP9+46ikIu9VOQIoOJayhiW7KifUSYt+D/WODyPei4Ru7tqfgR47Vo4u0EFI3KLBXyC3DgiN+”
-}
-```
- 
-### CertificateFieldRevelationKeyring
- 
-The CertificateFieldRevelationKeyring structure is an object whose keys are certificate field names and whose values are encrypted versions of the corresponding CertificateFieldRevelationKeys that decrypt them.
- 
-When a sender is communicating with a counterparty over a communications channel, the sender encrypts the field revelation keys by following the [BRC-2](../wallet/0002.md) Encryption process (each CertificateFieldRevelationKey is encrypted with AES-256-GCM, and the 256-bit initialization vector is prepended to the ciphertext).
-
-For each field revelation key that is included, the sender and recipient of the information use the following [BRC-43](../key-derivation/0043.md) protocol and key IDs:
-
-[BRC-43](../key-derivation/0043.md) Attribute | Value
------------------|----------------
-Security Level   | `2`
-Protocol ID      | `authrite certificate field encryption xxxxx`
-Key ID           | `yyyyy zzzzz`
-Counterparty     | The sender uses the recipient's identity key, the recipient uses the sender's identity key.
-
-**Where:**
-- `xxxxx` is the certificate type ID
-- `yyyyy` is the certificate Serial Number
-- `zzzzz` is the field name which the CertificateFieldRevelationKey decrypts
- 
-> **NOTE:** The bearer of a certificate is not obligated to reveal the keys to all certificate fields at all times to all parties. Therefore, a Certificate structure that contains an incomplete CertificateFieldRevelationKeyring (lacking keys for certain fields) can still be considered valid. It is up to the verifier how much information they need to examine.
- 
-*Example*
-
-```json 
-{
-  “first_name”: “G2GmxIWNPkO2SUP0XpQvQqX31yz58aLHk9e7JxO+q/MT3k9ZjTe3t8aN2Qwg2+AtBulXZpKhuvxOgxicfd8GqCjFkGtyUrbSdmCFjPUJm7z/P/LWkJHByeBzh3/yOWa7”,
-  “last_name”: “YZAHgs+P8Tgci3+5uuAuHr0k3CXPEcB3trpqtEUygV+uwoTgDWk01XTT1eOW6n7qjcDt4g7tlzuWtkawDkvRbCcVe3oBsEI5X8+A10s8TAsyNQV5O1R8mkGoL8/Hec4K”
-}
-```
- 
-### Certificate
-
-<img src="./media/Certificate.png"  width="530" height="800">
-
-The Certificate structure is an object with the following JSON fields:
-
-Field         | Description
----------| ------------------------------------------
-`type` | A CertificateTypeID structure indicating the type of certificate.
-`subject` | A PublicKey structure denoting the key belonging to the party being certified.
-`validationKey` | A CertificateValidationKey structure representing the validation key of the certificate.
-`serialNumber` | A CertificateSerialNumber structure representing the unique serial number of the certificate.
-`fields` | A CertificateFields structure containing all of the encrypted fields that were certified by the certifier.
-`certifier` | A PublicKey structure denoting the well-known public key of the entity issuing the certificate.
-`revocationOutpoint` | A RevocationOutpoint structure pointing to a Bitcoin SV UTXO. If the UTXO has been spent by the certifier, the certificate should be considered revoked. If all zeroes, this functionality is disabled for the certificate. Disabling UTXO-based revocation should be in accordance with the rules defining this certificate type.
-`signature` | A Signature structure denoting the signature made by the certifying entity over the certified fields of the subject.
-`keyring` | A CertificateRevelationKeyring structure containing keys for some or all of the fields of the certificate. If no fields are being revealed, this is optional.
- 
-*Example*
-```json
-{
-  “type”: ”8l5phhdm2Hi80s6QqFOLS0NwUzDzJhlUTWv2BezmstE=”,
-  “subject”: ”0376d67c86b45be3c36c328c2aa5c5dd79c546d22859e39439bd5d934058345abc”,
-  “validationKey”: ”G4pBfpBEZ7n5iEHrtG5MFOnIO0U1D758naHJilcK/RU=/7lzk4XTKI=+BNN63v8Na8/gW4Y=”,
-  “serialNumber”: ”kUahacBHmYL2nkzemkatFg==”,
-  “fields”: {
-    “first_name”: “IlgngMNcUM0d4GyzkSGqXaIBw6/n8bB6BG0pprO6oGhxUcivP6wDfuMWjWrG64KQJYUMN3QjHoX40r3SvAyWQaAA9ldVuPLgZwi9q2TCECKHCyEuiATCM9PdB/Ba2rxp”,
-    “last_name”: “3o0jTew8WMW54svE8Btx9Aks1FlQCHOxGKLZpc7SR0ESSIomToAYFtCq6U7NUuf3ktwLgnv5XdCrCTo+mOTHl/H+oyjcxB7xfdwav+bBx6vG5y9voDI/Z2MQGxE/Pmeg”,
-    “address_line_1”: “WGqZGJo7VHeQ5tx7uqeyA5q08tRVxJLUoprjAiJ8FmzOoe4gt0+6PGDgvrhkbzauSxGY9yRyOeP+irHclCIrzjwjbfkK19thoyUhr8u1283FobikPs2xKrhUvcYhDOV7”,
-    “address_line_2”: “IjI5UXJnMbcSEqIVkH8B5a9cY8EtWO7RvJH9gAWuIq0Y3koINgfqNjmockAgXnGxLvdQXvWdlCIm+foedIdHhqs9Xi60wR7hLSs9emjo6nq1Mx01wYFRW1le//Sup80x”,
-    “city”: “Ed4Nr8UL3h7AqX3PlExwLQ0Mi/QLBH9wCIpdeMb442HDbQlodF1eUuJQRXt+0ajzmXEqaGNSD59xEXmsFouLDLa6sOOzXr2psCKMXkU1+IFHGv8TgJx/vDTCxMvL7t2T”,
-    “state”: “6oiC8AMFFrLRGhpbWUO1HkA05/QPmfaUg1be4cP2vbcadIv4quaBgfwmNWE6xItpQNAfEwrx1ub9b4cNIKnN+6JAsiDiqs42mbjsgTuZL90fSEL9yPTwRuvW1ccvJ43z”,
-    “zipcode”: “Y+iqr8cSMEMMq8WqpIudzni1DIiQT5BsK29ld8lFCZddrrjep0qQyKoaP9+46ikIu9VOQIoOJayhiW7KifUSYt+D/WODyPei4Ru7tqfgR47Vo4u0EFI3KLBXyC3DgiN+”
+  "type": "AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=",
+  "serialNumber": "AgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI=",
+  "subject": "024d4b6cd1361032f49d6c5cb7198fdd0458d4fd5f2d0f418da24ff2b63243a6f7",
+  "certifier": "03531fe6068134503d846f476d6b2e3c000d70bb7c3937c8d537ef7d24c7d9e6c8",
+  "revocationOutpoint": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef.1",
+  "fields": {
+    "email": "uS49rSc3jHRjmE3+/sT1Kf12p2vISiVfDX4SzsqKXWQJdVfuZJcgxjp34MBzEP9PIzK+8j7JqUs=",
+    "name": "CSDUXeL3aMCSdWGMZmkAPq4iH0K2FfCUvYZZF/7l4hRLIgSJg+gMojGZrXJ+6qKQ"
   },
-  “certifier”: ”035ce8cc44dbcf4c991d666d381d67263aed9123f9b15cca215b54f1314152d23c”,
-  “revocationOutpoint”: “48645047cd66f7b48b24efb080ec7e27f3f448c21109939b80afd11e40898c92.1”,
-  “signature”: “3045022100c0686907d8914abfa7f356c560c7d17045dde5c10135b1cbf9bf6e4cc52e09820220366eec15372bc34db10f997e21755f603a2023c96578e9d71fca2570f23055d6”,
-  “keyring”: {
-    “first_name”: “G2GmxIWNPkO2SUP0XpQvQqX31yz58aLHk9e7JxO+q/MT3k9ZjTe3t8aN2Qwg2+AtBulXZpKhuvxOgxicfd8GqCjFkGtyUrbSdmCFjPUJm7z/P/LWkJHByeBzh3/yOWa7”,
-    “last_name”: “YZAHgs+P8Tgci3+5uuAuHr0k3CXPEcB3trpqtEUygV+uwoTgDWk01XTT1eOW6n7qjcDt4g7tlzuWtkawDkvRbCcVe3oBsEI5X8+A10s8TAsyNQV5O1R8mkGoL8/Hec4K”
+  "signature": "304402201f0f2c2d86ad4c2271170cf967f7a9d6106d81e5b7d273decae34d284fcfced9022023cccf38074113a7e8620d9b97b860c7cb7b54805af343c03d3f44ce12da55b8"
+}
+```
+
+The `signature` member MUST NOT be included when computing the signature preimage. Keyrings and decrypted fields MUST NOT be included in the core certificate signature.
+
+There is no `validationKey` field in this specification. Implementations MUST verify certificates using the certifier identity key and the BRC-100 signature derivation described below.
+
+## Certificate Binary Format
+
+`CertificateBinary` is the canonical binary form of the core certificate and the canonical signature preimage source. It is serialized in this exact order:
+
+| Order | Field | Encoding |
+| - | - | - |
+| 1 | `type` | 32 bytes, Base64-decoded from JSON. |
+| 2 | `serialNumber` | 32 bytes, Base64-decoded from JSON. |
+| 3 | `subject` | 33 bytes, hex-decoded from JSON. |
+| 4 | `certifier` | 33 bytes, hex-decoded from JSON. |
+| 5 | `revocationOutpoint.txid` | 32 bytes, hex-decoded txid. |
+| 6 | `revocationOutpoint.vout` | VarInt output index. |
+| 7 | `fields.count` | VarInt number of fields. |
+| 8 | each field | Field entries sorted by field name, each as `VarInt nameLength`, `name UTF-8 bytes`, `VarInt valueLength`, `value UTF-8 bytes`. |
+| 9 | `signature` | DER signature bytes, only when serializing with the signature included. |
+
+Field entries MUST be ordered lexicographically by field name before serialization. For current SDK interoperability, field values in `CertificateBinary` are the UTF-8 bytes of the Base64 string, not the Base64-decoded ciphertext bytes.
+
+Because the raw signature is the final field and is not length-prefixed in `CertificateBinary`, any enclosing binary protocol that appends extension data after a certificate MUST length-prefix the complete `CertificateBinary` first.
+
+## Signature Creation and Verification
+
+The signature preimage is `CertificateBinary` serialized with `includeSignature = false`. The preimage MUST be hashed with SHA-256 by the BRC-100 signature method before ECDSA signing.
+
+The certifier signs using:
+
+| BRC-100 signature parameter | Value |
+| - | - |
+| `protocolID` | `[2, "certificate signature"]` |
+| `keyID` | `<type> <serialNumber>` using the JSON Base64 strings separated by one U+0020 space |
+| `counterparty` | Publicly verifiable signature semantics. In current `ts-sdk`, this is produced by omitting `counterparty`, which defaults to `anyone`. |
+| `data` | The preimage bytes from `CertificateBinary(false)`. |
+
+A verifier verifies using:
+
+| BRC-100 verification parameter | Value |
+| - | - |
+| `protocolID` | `[2, "certificate signature"]` |
+| `keyID` | `<type> <serialNumber>` |
+| `counterparty` | The certificate `certifier` public key. |
+| `data` | The same preimage bytes from `CertificateBinary(false)`. |
+| `signature` | DER signature bytes decoded from the certificate `signature` hex string. |
+
+JSON member ordering is irrelevant for signature verification. Implementations MUST NOT use stable JSON stringification as the certificate signature preimage.
+
+## Field Encryption
+
+Each certificate field value is encrypted independently:
+
+1. Generate a random 32-byte field revelation key `K_f`.
+2. UTF-8 encode the plaintext field value.
+3. Encrypt the plaintext with AES-256-GCM using `K_f`.
+4. Encode the encrypted field value as `Base64(IV || ciphertext || tag)`.
+
+The IV MUST be 32 bytes. The authentication tag MUST be 16 bytes. No additional authenticated data is used by the current reference implementation.
+
+The certifier signs only the encrypted `fields` map. Plaintext field values, field revelation keys, keyrings, and decrypted field caches MUST NOT be signed as part of the core certificate.
+
+## Keyring Encryption
+
+A keyring value is a BRC-2/BRC-100 encrypted field revelation key. The plaintext is the raw 32-byte `K_f`. The ciphertext is encoded as `Base64(IV || ciphertext || tag)` where the IV and tag follow BRC-2 encryption behavior.
+
+All certificate keyring encryption uses:
+
+| BRC-100 encryption parameter | Master keyring | Verifier keyring |
+| - | - | - |
+| `protocolID` | `[2, "certificate field encryption"]` | `[2, "certificate field encryption"]` |
+| `keyID` | `<fieldName>` | `<serialNumber> <fieldName>` using one U+0020 space |
+| `plaintext` | Raw 32-byte field revelation key | Raw 32-byte field revelation key |
+
+For a master keyring, the encrypting party sets `counterparty` to the other party that must be able to decrypt the keyring value. In direct or certifier-issued flows, this is normally the certifier when the subject creates the encrypted fields, or the subject when the certifier creates the encrypted fields.
+
+For a verifier keyring, the subject decrypts the applicable master keyring entries and re-encrypts the raw field revelation keys with `counterparty = verifier`. The verifier decrypts those keyring entries with `counterparty = subject`.
+
+## Master Certificates
+
+A master certificate is a core certificate plus a complete keyring that can reveal every field in `fields`.
+
+Canonical JSON extension:
+
+```json
+{
+  "type": "...",
+  "serialNumber": "...",
+  "subject": "...",
+  "certifier": "...",
+  "revocationOutpoint": "...",
+  "fields": {
+    "name": "..."
+  },
+  "signature": "...",
+  "masterKeyring": {
+    "name": "..."
   }
 }
 ```
 
-### Signing and Verification
+The `masterKeyring` member MUST contain exactly one non-empty keyring value for every field in `fields`. SDK and wallet API contexts MAY name the same data `keyringForSubject` or `keyring`; those names are aliases for the master keyring in that context and MUST NOT alter signature semantics.
 
-The signature for a certificate is over all the fields, the subject, the certifier, the type, the serial number, the revocation outpoint, and the validation key. Each field is organized deterministically, in alphabetical order, in a JSON object. We stipulate the use of the (default) [Stable Stringify Algorithm](https://www.npmjs.com/package/json-stable-stringify) to avoid ambiguous ordering.
+Before storing or accepting a master certificate, a wallet SHOULD verify:
 
-When the certificate is signed, we specify that the certifier utilizes the [BRC-3](../wallet/0003.md) signing process with their certifier private key and the following [BRC-43](../key-derivation/0043.md) attributes:
+1. The core certificate signature is valid.
+2. The master keyring contains an entry for every field.
+3. Every master keyring entry decrypts to a field revelation key that decrypts its corresponding encrypted field value.
 
-[BRC-43](../key-derivation/0043.md) Attribute | Value
------------------|----------------
-Security Level   | `2`
-Protocol ID      | `authrite certificate signature xxxxx`
-Key ID           | `yyyyy`
-Counterparty     | The public key of the validation key included in the certificate.
+## Verifiable Certificates
 
-**Where:**
-- `xxxxx` is the certificate type ID
-- `yyyyy` is the certificate Serial Number
+A verifiable certificate is a core certificate plus a verifier-specific keyring for zero or more selected fields.
 
-> **NOTE:** The validation key is part of the certificate, so anyone with this key can check the certificate signature.
+Canonical JSON extension:
 
-For signature verification, we specify that the verifier checks the [BRC-3](../wallet/0003.md) signature by using the certificate's validation key as the [BRC-42](../key-derivation/0042.md) identity private key and the certifier's identity public key as the counterparty.
+```json
+{
+  "type": "...",
+  "serialNumber": "...",
+  "subject": "...",
+  "certifier": "...",
+  "revocationOutpoint": "...",
+  "fields": {
+    "email": "...",
+    "name": "...",
+    "organization": "..."
+  },
+  "signature": "...",
+  "keyring": {
+    "email": "...",
+    "name": "..."
+  }
+}
+```
 
-### Revelation Key Generation
+The `keyring` member MUST contain only fields present in `fields`. It MAY be empty or omitted when no fields are revealed. The verifier MUST verify the core certificate signature before relying on any decrypted field. The verifier MUST decrypt only fields for which keyring entries are present.
 
-The subject (the person being certified) may use this key derivation scheme to derive the field revelation keys used to encrypt the various fields of their certificate, based on their own identity private key.
+The BRC-100 `proveCertificate` result returns this verifier keyring as `keyringForVerifier`; a transmitted verifiable certificate uses `keyring`.
 
-[BRC-43](../key-derivation/0043.md) Attribute | Value
------------------|----------------
-Security Level   | `2`
-Protocol ID      | `authrite certificate field xxxxx`
-Key ID           | `yyyyy zzzzz`
-Counterparty     | `self`
+## Extension Binary Encodings
 
-**Where:**
-- `xxxxx` is the certificate type ID
-- `yyyyy` is the certificate Serial Number
-- `zzzzz` is the field name from the certificate
+The raw `CertificateBinary` format is the only signed binary format. Extension binary formats are unsigned envelopes for carrying keyrings next to a length-prefixed core certificate.
 
-### Secure Verifier Field Revelation Protocol
+`KeyringMapBinary`:
 
-In order to preserve data integrity, we need a way to keep certificate fields encrypted such that only particular fields can be revealed as needed.
-We stipulate the use of a keyring structure for selective field revelation to verifiers. As the keyring is not included in the certificate's signature (only the encrypted field values themselves), verifiers can still check the authenticity of the certificate without access to all keyring keys.
+| Order | Field | Encoding |
+| - | - | - |
+| 1 | `entryCount` | VarInt. |
+| 2 | each entry | `VarInt fieldNameLength`, field name UTF-8 bytes, `VarInt valueLength`, Base64-decoded keyring value bytes. |
 
-When a prover reveals the fields to a verifier, they will follow these steps:
+`CertificateWithKeyringBinary`:
 
-1. Retrieve the relevant symmetric field encryption keys
-2. Encrypt the keys for the verifier following the [BRC-2](../wallet/0002.md) process for counterparty encryption.
-3. Construct the keyring with the field revelation keys and their associated field names according to the structure defined above.
+| Order | Field | Encoding |
+| - | - | - |
+| 1 | `certificateLength` | VarInt length of the complete `CertificateBinary` including signature. |
+| 2 | `certificate` | `CertificateBinary`. |
+| 3 | `keyring` | `KeyringMapBinary`. |
 
-For step 2, we stipulate the use of the following [BRC-43](../key-derivation/0043.md) attributes when deriving the encryption keys:
+The same envelope is used for master certificates and verifiable certificates; the interpretation of the keyring is determined by context. When the keyring is absent, protocols SHOULD transmit the raw `CertificateBinary` rather than an empty envelope.
 
-[BRC-43](../key-derivation/0043.md) Attribute | Value
------------------|----------------
-Security Level   | `2`
-Protocol ID      | `authrite certificate field encryption`
-Key ID           | `xxxxx yyyyy`
-Counterparty     | `self`
+BRC-100 wallet-wire methods use method-specific envelopes around the same primitives. For example, `proveCertificate` submits a core certificate structure and receives a `KeyringMapBinary`; `listCertificates` length-prefixes each certificate and may append a keyring flag, keyring map, and verifier value. Those wallet-wire envelopes do not change the BRC-52 core certificate format.
 
-**Where:**
-- `xxxxx` is the certificate Serial Number
-- `yyyyy` is the field name from the certificate
+## Certificate Acquisition and Revelation
 
-It is strictly forbidden for a verifier to store or reveal the field revelation keys or the field values themselves to anyone else without the consent of the certificate holder. Doing so would be a violation of the terms of agreement and would result in the revocation of the certificate for that verifier.
+### Direct Acquisition
 
-### UTXO-based Certificate Revocation
+In direct acquisition, a wallet receives a signed core certificate and a master keyring from a certifier or other keyring revealer. The wallet MUST set or confirm `subject` as its own identity key before storage. The wallet MUST verify the signature and confirm that the master keyring decrypts the fields before storing the certificate.
 
-One of the problems with identity certificates of the past is that certificate authorities would have to maintain a list of any certificates that were revoked due to key compromises, violation of the terms of agreements, or other reasons. Then anyone that wanted to check if a certificate was still valid would have to check against this list, assuming it wasn't compromised, to make sure it hadn't been revoked.
+### Issuance Acquisition
 
-A simple solution to this problem is to make use of an associated Bitcoin transaction and output created at the time the certificate is issued. As described above, this revocation outpoint structure points to a UTXO that, if ever spent, indicates that the certificate is revoked.
+In issuance acquisition, the subject prepares encrypted fields and a master keyring for the certifier, then sends the encrypted fields to the certifier for signing. The certifier returns a signed core certificate. The subject stores the returned certificate with the master keyring it generated, after verifying that the returned type, subject, certifier, fields, serial number derivation, revocation outpoint, and signature are acceptable for the issuance protocol being used.
 
-This allows verifiers to easily check if a certificate has been revoked, without having to rely on a trusted centralized revocation list.
+### Selective Revelation
 
-### Handling Key Compromises Responsibly
+To reveal fields to a verifier:
 
-If the private key corresponding to a certificate issuer's public key ever becomes compromised, it is important that the issuer generate a new key pair, revoke existing certificates, and issue new certificates to the relevant certificate holders.
+1. The subject locates the stored master certificate.
+2. The subject verifies the requested field names are a subset of the certificate fields.
+3. The subject decrypts each requested master keyring value to recover `K_f`.
+4. The subject re-encrypts each `K_f` for the verifier using the verifier keyring parameters above.
+5. The subject returns the verifier keyring, either as a `keyringForVerifier` result or embedded in a verifiable certificate as `keyring`.
 
-If one of the certificate holders has a key compromised, there needs to be a standard way to request a new certificate.
+## Revocation
 
-Certifiers should establish a process for coordinating with certificate holders to manage the reissuance of certificates.
+The `revocationOutpoint` points to a UTXO controlled according to the certifier's revocation policy. If that UTXO has been spent, the certificate MUST be treated as revoked. If the disabled sentinel `0000000000000000000000000000000000000000000000000000000000000000.0` is used, UTXO-based revocation is disabled and verifiers MUST rely on the policy for that certificate type.
 
-Future BRCs can define protocols by which this process can occur.
+Certifiers SHOULD publish clear rules for revocation monitoring, reissuance, and key compromise handling. If a certifier identity key is compromised, the certifier SHOULD revoke affected certificates and reissue under a new certifier identity key.
 
-## Implementations
+## Implementation Basis
 
-An example implementation of Identity Certificates can be seen in Authrite, and the [MYAC](https://github.com/p2ppsr/myac-tutorial) tutorial can be followed for creating your own Authrite Certifier.
+This revision is grounded in the current reference behavior of:
+
+- `bsv-blockchain/ts-sdk` master commit `740d5f128c40a3fdd7c8cc46bea3cc06b14f2c8d`, including `Certificate`, `MasterCertificate`, `VerifiableCertificate`, and wallet-wire certificate methods.
+- `bsv-blockchain/wallet-toolbox` master commit `4e965cc1a32bff4249b52a47482e1366e1487959`, including certificate lifecycle tests, wallet storage schema, `acquireCertificate`, `listCertificates`, and `proveCertificate`.
+- npm `@bsv/sdk@2.0.13` and `@bsv/wallet-toolbox@2.1.22`, the latest package releases observed on 2026-04-23.

--- a/peer-to-peer/0052.md
+++ b/peer-to-peer/0052.md
@@ -262,8 +262,7 @@ Certifiers SHOULD publish clear rules for revocation monitoring, reissuance, and
 
 ## Implementation Basis
 
-This revision is grounded in the current reference behavior of:
+This revision is grounded in the reference behavior of the BSV SDK and Wallet Toolbox certificate implementations, including:
 
-- `bsv-blockchain/ts-sdk` master commit `740d5f128c40a3fdd7c8cc46bea3cc06b14f2c8d`, including `Certificate`, `MasterCertificate`, `VerifiableCertificate`, and wallet-wire certificate methods.
-- `bsv-blockchain/wallet-toolbox` master commit `4e965cc1a32bff4249b52a47482e1366e1487959`, including certificate lifecycle tests, wallet storage schema, `acquireCertificate`, `listCertificates`, and `proveCertificate`.
-- npm `@bsv/sdk@2.0.13` and `@bsv/wallet-toolbox@2.1.22`, the latest package releases observed on 2026-04-23.
+- `Certificate`, `MasterCertificate`, and `VerifiableCertificate` behavior in `bsv-blockchain/ts-sdk`.
+- Certificate lifecycle, wallet storage, `acquireCertificate`, `listCertificates`, and `proveCertificate` behavior in `bsv-blockchain/wallet-toolbox`.

--- a/peer-to-peer/0103.md
+++ b/peer-to-peer/0103.md
@@ -37,59 +37,29 @@ A standard protocol for **mutual authentication** and **certificate exchange** a
 
 ### 4.1 Certificate Format
 
-Certificates are stored and transmitted in a **binary format** to optimize size and parsing consistency. We specify each field in table form, together with how it is *conventionally* represented when not in binary. The binary format is always used for signing and verification, but the conventions are useful for human readability. A certificate has the following primary fields:
+BRC-103 uses the certificate formats, signature preimage, field encryption rules, master keyrings, and verifier keyrings defined by [BRC-52](./0052.md). BRC-103 messages MUST NOT define an alternate certificate binary layout or alternate certificate signature preimage.
 
-| Field Name           | Type                          | Description                                                      |
-|----------------------|-------------------------------|------------------------------------------------------------------|
-| Type                 | 32-byte (base64) string       | Certificate category identifier (e.g., unique type associated with “social handles”).   |
-| SerialNumber         | 32-byte (base64) string       | Uniquely identifies this certificate instance.                   |
-| Subject              | 33-byte compressed pubkey (hex) | The wallet’s (subject’s) public key.                             |
-| Certifier            | 33-byte compressed pubkey (hex) | The certifier's public identity key.                             |
-| RevocationOutpoint   | 32-byte TXID + varint output idx | On-chain reference to track revocation (if spent, revoked).      |
-| Fields               | Varint count + repeated pairs  | Pairs of: <fieldNameLength, fieldName, fieldValueLength, fieldValue>  |
-| Signature            | Varint length + bytes          | Certifier’s signature over all fields (excluding itself).        |
-
-**Important**: Each certificate field is encrypted with a field-specific key. The encrypted version is signed.
+When BRC-103 carries a certificate in JSON, it carries a BRC-52 core certificate plus any applicable BRC-52 unsigned extension members, such as a verifier `keyring`. When BRC-103 carries a certificate in binary, it carries either BRC-52 `CertificateBinary` or a BRC-52 length-prefixed certificate-with-keyring envelope, as required by the surrounding message encoding.
 
 ### 4.2 Master Certificate
 
-A **Master Certificate** includes a **master keyring**. Each field in the certificate is encrypted with a unique symmetric key. Those keys, in turn, are encrypted for the certificate holder (subject). Hence, a master certificate is able to decrypt any of its own fields locally but can selectively re-encrypt only some fields for a verifier.
+A **Master Certificate** is a BRC-52 core certificate plus a complete master keyring. It is normally stored by the wallet and is not sent to ordinary verifiers.
 
 ### 4.3 Verifiable Certificate
 
-A **Verifiable Certificate** is derived from a master certificate. It still contains all fields in ciphertext form (so that signatures can be verified) but also includes a “verifier-specific keyring.” For fields the subject wishes to disclose, the subject decrypts the corresponding symmetric key from the master keyring and re-encrypts it for the verifier. Consequently, the verifier can decrypt only those chosen fields.
+A **Verifiable Certificate** is derived from a master certificate and contains the BRC-52 core certificate plus a verifier-specific `keyring`. It still contains all encrypted fields so the verifier can check the certifier signature over the complete certificate, but it only includes field revelation keys for fields disclosed to that verifier.
 
 ### 4.4 Selective Field Encryption
 
-1. **Master Keyring Generation**  
-   - For each field `f`, create a random symmetric key `K_f`.  
-   - Encrypt the field’s plaintext using `K_f`, store as `Fields[f] = E(K_f, fPlaintext)`.  
-   - After all fields are encrypted, the certifier signs the assembled certificate, comprising all encrypted fields.
-   - The certifier can then encrypt the key `K_f` for the subject’s own identity: `EncryptedKey_f -> E_subject(K_f)`, the subject can store in the master keyring.  
+BRC-103 selective disclosure is the BRC-52 selective revelation process:
 
-2. **Disclosure to a Verifier**  
-   - When selectively disclosing field `f`, the subject decrypts `EncryptedKey_f`, obtains `K_f`, and re-encrypts `K_f` with the verifier’s identity key, producing `K_f_for_verifier`.  
-   - The subject includes `K_f_for_verifier` in the **verifier’s** keyring for that verifiable certificate.
+1. The holder keeps a master certificate whose master keyring can decrypt all fields.
+2. For a verifier, the holder decrypts the selected field revelation keys from the master keyring.
+3. The holder re-encrypts those field revelation keys for the verifier and includes them in the verifiable certificate `keyring`.
 
 ### 4.5 Creation and Verification Processes
 
-**Certificate Creation**  
-1. **User** (subject) or **certifier** forms certificate fields (including `Type`, `SerialNumber`, etc.).  
-2. Each field is encrypted.  
-3. The certifier signs the certificate data.  
-
-**Certificate Verification**  
-1. A party verifying a certificate reassembles the binary structure.  
-2. Checks the signature against the “signature preimage” (all primary certificate fields except the signature itself, and not including their verifier keyring).  
-3. Considers the `RevocationOutpoint` to confirm the certificate is not on-chain revoked (if it is not 36 zero bytes).  
-
-**Selective Disclosure**  
-- The subject issues a **Verifiable Certificate** containing:
-  - Original field ciphertext.  
-  - Re-encrypted field keys for fields to reveal.  
-  - The certifier’s signature.  
-
-The verifier can decrypt each revealed field’s ciphertext with the provided key, verifying the signature across the entire certificate to ensure authenticity.
+Certificate creation, signature verification, field decryption, and revocation checks MUST follow BRC-52. The verifier MUST verify the BRC-52 core certificate signature before accepting any decrypted field and MUST treat a spent non-sentinel `revocationOutpoint` as revoked.
 
 ## 5. Peer-to-Peer Messaging Overview
 

--- a/peer-to-peer/0104.md
+++ b/peer-to-peer/0104.md
@@ -193,7 +193,7 @@ BRC-103 specifies that the preimage is constructed by concatenating these fields
 2. Request method: length + UTF-8 bytes.  
 3. Path: length + UTF-8 bytes (use `/` if the path is empty).  
 4. Query string (including `?`): length + UTF-8 bytes (or `-1` if none).  
-5. **Included headers**: count them in the order they are transmitted. For each header:  
+5. **Included headers**: count them in canonical lexicographic order by lowercase header name. For each header:
    - VarInt of key length, followed by key bytes  
    - VarInt of value length, followed by value bytes  
 6. Body: length + body bytes (or `-1` if none).
@@ -206,7 +206,7 @@ In response to client request the server creates a BRC-103 payload as follows:
 
 1. `x-bsv-auth-request-id` (echoing back the client's requestId as seen on line 174).  
 2. Response status (varInt)
-3. **Included headers** count, given in order of transmittal over the wire. For each header:
+3. **Included headers** count, given in canonical lexicographic order by lowercase header name. For each header:
    - VarInt of key length, key bytes
    - VarInt of value length, value bytes  
 4. Body length + body bytes (or `-1` if none).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,7 +10,7 @@ BRC  | Standard
 17   | [Pay to R Puzzle Hash](./0017.md)
 18   | [Pay to False Return](./0018.md)
 19   | [Pay to True Return](./0019.md)
-20   |
+20   | See [tokens/0020.md](../tokens/0020.md)
 21   | [Push TX](./0021.md)
 47   | [Bare Multi-Signature](./0047.md)
 48   | [Pay to Push Drop](./0048.md)

--- a/transactions/0008.md
+++ b/transactions/0008.md
@@ -12,6 +12,10 @@ The use of Bitcoin as a means of payment and store of value has gained significa
 
 The SPV process, outlined in [BRC-9](./0009.md), allows payment recipients to verify the validity of a transaction without downloading and verifying the entire blockchain. However, without a standard methodology for exchanging the required merkle proofs and input transactions, applications and businesses are unable to fully benefit from adopting SPV. BRC-8 addresses this issue by providing a consistent format for transaction envelopes that can be used for SPV.
 
+## Status Note
+
+BRC-8 is a historical JSON transaction-envelope format. Current wallet, payment, and overlay implementations in `bsv-blockchain/ts-sdk` and `bsv-blockchain/wallet-toolbox` generally use [BRC-62](./0062.md) BEEF and [BRC-95](./0095.md) Atomic BEEF instead of BRC-8 envelopes. Specs that previously embedded or returned BRC-8 envelopes should be read as legacy unless they explicitly opt into this format for backwards compatibility.
+
 ## Specification:
 
 We specify that the Everett-style Transaction Envelope is a JSON object that consists of the following fields:

--- a/transactions/0009.md
+++ b/transactions/0009.md
@@ -12,6 +12,12 @@ The Bitcoin blockchain is a decentralized, distributed ledger that records every
 
 ## Specification
 
+### Status Note
+
+BRC-9 describes SPV validation for the older [BRC-8](./0008.md) JSON envelope and mAPI response model. Current `bsv-blockchain/ts-sdk` and `bsv-blockchain/wallet-toolbox` wallet/payment flows generally use [BRC-62](./0062.md) BEEF, [BRC-95](./0095.md) Atomic BEEF, BUMP proofs, and chain trackers instead of `mapiResponses`.
+
+The validation principles in this document remain useful, but implementers should treat the BRC-8 envelope and mAPI-specific checks below as historical unless they are maintaining a legacy protocol that explicitly still exchanges BRC-8 envelopes.
+
 The steps for verifying the validity of a payment transaction using the BRC-9 SPV protocol are as follows:
 
 1. Ensure that the received [BRC-8](../transactions/0008.md) Envelope is in the correct format

--- a/transactions/0076.md
+++ b/transactions/0076.md
@@ -5,6 +5,10 @@ Ragnar Friedman <ragnar.friedman@proton.me>
 ## Abstract
 GASP is designed to synchronize transaction data between two parties in a blockchain environment. It ensures the legitimacy and completeness of transaction data using a recursive reconciliation method.
 
+## Status Note
+
+This document is an exploratory graph synchronization proposal. It is not the current wallet-toolbox user wallet storage synchronization protocol. Current wallet-toolbox storage synchronization is the chunked, resumable storage-provider protocol specified by [BRC-40](../outpoints/0040.md). Current transaction exchange and wallet APIs generally use BEEF / Atomic BEEF rather than the bloom-filter INV flow described here.
+
 ## Participants
 - **Alice**: Initiates the sync process.
 - **Bob**: Responds and participates in the sync process.

--- a/wallet/0001.md
+++ b/wallet/0001.md
@@ -16,6 +16,20 @@ Implementing this specification will provide a standard way for web and mobile a
 
 Overall, this specification aims to provide a simple, open-ended, and extensible approach to Bitcoin transaction creation, with a transport-independent method of communication that enables wallets and applications to work together seamlessly.
 
+## Status Note
+
+BRC-1 is historical. Current wallet transaction creation is specified by [BRC-100](./0100.md) `createAction`, `signAction`, and `abortAction`.
+
+For new implementations:
+
+- use `lockingScript` rather than the legacy `script` output field,
+- use BEEF / Atomic BEEF rather than BRC-8 envelopes for transaction return data,
+- use BRC-100 `inputBEEF`, `inputs`, `outputs`, `labels`, and `options` for the full action model,
+- use BRC-100 HTTP substrate routes such as `/createAction` without the historical `/v1` prefix,
+- and treat mAPI response fields as legacy.
+
+The remainder of this document is retained to explain the origin of the wallet action model and for compatibility with older deployments.
+
 ## Pre-Requisites
 
 In order to implement this specification, Bitcoin wallet software must be able to perform the following functions:

--- a/wallet/0002.md
+++ b/wallet/0002.md
@@ -10,6 +10,10 @@ We devise a method for applications to request the encryption and decryption of 
 
 The Bitcoin ecosystem has demonstrated a clear desire for wallets to support data encryption between parties<sup>[1](#footnote-1)</sup>. This capability facilitates secure exchange of information, improves user privacy, and enables novel applications that require direct and secure communication between users. The unique economic incentives of micropayment-based applications, particularly those facilitated by Bitcoin wallets, make user privacy paramount, and have led to the adoption of end-to-end encryption by many applications<sup>[2](#footnote-2)</sup>. While several encryption systems have been developed and integrated into various platforms, there is currently no standard methodology that supports both single-party and multi-party encryption, protocol-level permissions management, and leverages [BRC-42](../key-derivation/0042.md) key derivation. The [BRC-2](./0002.md) standard aims to fill this gap and provide a secure and standardized framework for encryption and decryption within the Bitcoin ecosystem.
 
+## Status Note
+
+The cryptographic construction in this document remains the basis for wallet `encrypt` and `decrypt`, but the BRC-1 message framing and legacy SDK references are historical. Current implementations expose these operations through [BRC-100](./0100.md), using `protocolID`, `keyID`, `counterparty`, `privileged`, `privilegedReason`, and `seekPermission` arguments.
+
 ## Specification
 
 We start with the same constructs defined in [BRC-43](../key-derivation/0043.md): users with clients, protocols and applications. We stipulate the use of [BRC-43](../key-derivation/0043.md) invoice numbers in the context of [BRC-42](../key-derivation/0042.md) key derivation, and we build on top of the permissions architecture defined by [BRC-43](../key-derivation/0043.md).
@@ -137,7 +141,7 @@ BRC-2 HMAC Compliance Validated!
 
 ## Implementations
 
-- This encryption capability is incorporated into the [Babbage SDK](https://github.com/p2ppsr/babbage-sdk)
+- This encryption capability is incorporated into current `bsv-blockchain/ts-sdk` BRC-100 wallet interfaces and `bsv-blockchain/wallet-toolbox` permission enforcement. Older Babbage SDK references are retained only for historical context.
 
 ## References
 

--- a/wallet/0003.md
+++ b/wallet/0003.md
@@ -16,6 +16,10 @@ To address this issue, the BRC-3 standard has been created to enable the creatio
 
 The BRC-3 standard not only provides a secure and interoperable solution for wallet implementations, but it also enables new use cases and experiences that were previously not possible. With a unified standard, different wallets can create and verify each other's digital signatures seamlessly, reducing friction and enabling greater innovation.
 
+## Status Note
+
+The key-derivation signature scheme in this document remains the basis for wallet `createSignature` and `verifySignature`, but the BRC-1 message framing and legacy SDK references are historical. Current implementations expose these operations through [BRC-100](./0100.md), using `protocolID`, `keyID`, `counterparty`, optional `privileged` controls, `seekPermission`, and byte-array payloads.
+
 ## Specification
 
 We start with the same constructs defined in [BRC-43](../key-derivation/0043.md): users with clients, protocols and applications. We stipulate the use of [BRC-43](../key-derivation/0043.md) invoice numbers in the context of [BRC-42](../key-derivation/0042.md) key derivation, and we build on top of the permissions architecture defined by [BRC-43](../key-derivation/0043.md).
@@ -124,5 +128,4 @@ BRC-3 Compliance Validated!
 
 ## Implementations
 
-- This digital signature capability is incorporated into the [Babbage SDK](https://github.com/p2ppsr/babbage-sdk)
-
+- This digital signature capability is incorporated into current `bsv-blockchain/ts-sdk` BRC-100 wallet interfaces and `bsv-blockchain/wallet-toolbox` permission enforcement. Older Babbage SDK references are retained only for historical context.

--- a/wallet/0004.md
+++ b/wallet/0004.md
@@ -10,6 +10,10 @@ We define a mechanism by which [BRC-1](./0001.md) applications can denote UTXOs 
 
 [BRC-1](./0001.md) defines a mechanism for an application to request the creation of a Bitcoin transaction by a wallet, but it is incomplete without a way for applications to consume and use tokens that previously existed. Allowing applications to unlock and redeem inputs as part of their transactions also facilitates their ability to update, extend or delete assets that are tokenized within Bitcoin UTXOs.
 
+## Status Note
+
+BRC-4 is historical. Current wallets consume application-provided inputs through [BRC-100](./0100.md) `createAction` with `inputBEEF`, `inputs[].outpoint`, `inputs[].unlockingScript` or `inputs[].unlockingScriptLength`, `inputs[].inputDescription`, and optional `sequenceNumber`. Extended BRC-8 input envelopes are deprecated for current implementations.
+
 ## Specification
 
 We extend the [BRC-1](./0001.md) Transaction Creation Request message with an additional field, the `inputs` field. This is an object whose keys are the TXIDs of transactions that contain outputs which are to be spent as part of this transaction, and whose values comprise extended [BRC-8](../transactions/0008.md) transaction envelopes.
@@ -54,4 +58,4 @@ Here is an example of a Transaction Creation Request object that contains an inp
 
 ## Implementations
 
-This functionality has been implemented as part of the [Babbage SDK](https://github.com/p2ppsr/babbage-sdk), in the `createAction` function.
+This functionality is implemented by current `bsv-blockchain/ts-sdk` BRC-100 wallet interfaces and `bsv-blockchain/wallet-toolbox` storage/action processing.

--- a/wallet/0005.md
+++ b/wallet/0005.md
@@ -11,64 +11,103 @@ The Bitcoin Wallet HTTP Interface is a standard interface that enables applicati
 
 The motivation for this standard interface is to provide a common way for applications to connect with Bitcoin wallets. Currently, many Bitcoin wallets provide their own APIs, which makes it difficult for applications to support multiple wallets. The Bitcoin Wallet HTTP Interface standardizes the way that applications can interact with wallets, enabling them to be more easily integrated into various applications. This interface is designed to be flexible enough to support a range of wallets and use cases, while also providing a secure and standardized method of communication.
 
+## Status Note
+
+This document originally described the pre-BRC-100 localhost HTTP API. The `/v1/...` routes, mixed GET/POST method table, and legacy method names such as `createCertificate` and `findCertificates` are historical. Current interoperable implementations in `bsv-blockchain/ts-sdk` expose the [BRC-100](./0100.md) wallet interface over HTTP substrates without a versioned URL prefix.
+
+Implementers SHOULD use the current substrates below for new work. The older route table is deprecated except where a deployment explicitly maintains backwards compatibility with legacy wallets.
+
 ## Specification
 
-We define a standard HTTP substrate by which wallets can provide a communication channel to applications for the necessary tasks such as creating transactions, creating certificates, signature verification, and more.
+Current wallet HTTP interoperability is defined by two localhost substrates for the BRC-100 wallet interface:
 
-All implementors of the HTTP substrate should conform to the following standard for the wallet HTTP API that allows applications to communicate in a predefined and standard way.
+1. **Binary wallet wire**
+   - Default base URL: `http://localhost:3301`
+   - Route: `POST /<BRC-100 methodName>`
+   - Request body: `application/octet-stream`
+   - Body framing: the BRC-100 wallet-wire parameter payload for the selected method, excluding the method call code and originator frame that are used by the client-side substrate to choose the route and `Origin` header.
+   - Originator: conveyed through the HTTP `Origin` header when available.
 
-### Host
+2. **JSON wallet API**
+   - Default base URL: `http://localhost:3321`
+   - Secure development base URL: `https://localhost:2121`
+   - Route: `POST /<BRC-100 methodName>`
+   - Request body: JSON arguments for the BRC-100 method
+   - Response body: JSON result
+   - Originator: Node clients may set `Origin` and `Originator`; browser clients rely on the browser-managed `Origin` header.
 
-We define the wallet HTTP server to support communication over localhost on port `3301`. New API versions can be specified as needed using the standard of v1, v2, etc.
+No `/v1` prefix is used by the current `ts-sdk` HTTP wallet substrates.
 
-```
-Host URL: http://localhost
-Standard Port: 3301
-Versioning Standard: v1, v2, etc
-```
+### Standard HTTP Routes
 
-Example Encrypt Request URL:
-`http://localhost:3301/v1/encrypt`
+Every current BRC-100 wallet method is addressed by its method name:
 
-### Standard HTTP Requests
+| Route | Request Method | Substrate |
+|-------|----------------|-----------|
+| `/createAction` | POST | Binary wire or JSON |
+| `/signAction` | POST | Binary wire or JSON |
+| `/abortAction` | POST | Binary wire or JSON |
+| `/listActions` | POST | Binary wire or JSON |
+| `/internalizeAction` | POST | Binary wire or JSON |
+| `/listOutputs` | POST | Binary wire or JSON |
+| `/relinquishOutput` | POST | Binary wire or JSON |
+| `/getPublicKey` | POST | Binary wire or JSON |
+| `/revealCounterpartyKeyLinkage` | POST | Binary wire or JSON |
+| `/revealSpecificKeyLinkage` | POST | Binary wire or JSON |
+| `/encrypt` | POST | Binary wire or JSON |
+| `/decrypt` | POST | Binary wire or JSON |
+| `/createHmac` | POST | Binary wire or JSON |
+| `/verifyHmac` | POST | Binary wire or JSON |
+| `/createSignature` | POST | Binary wire or JSON |
+| `/verifySignature` | POST | Binary wire or JSON |
+| `/acquireCertificate` | POST | Binary wire or JSON |
+| `/listCertificates` | POST | Binary wire or JSON |
+| `/proveCertificate` | POST | Binary wire or JSON |
+| `/relinquishCertificate` | POST | Binary wire or JSON |
+| `/discoverByIdentityKey` | POST | Binary wire or JSON |
+| `/discoverByAttributes` | POST | Binary wire or JSON |
+| `/isAuthenticated` | POST | Binary wire or JSON |
+| `/waitForAuthentication` | POST | Binary wire or JSON |
+| `/getHeight` | POST | Binary wire or JSON |
+| `/getHeaderForHeight` | POST | Binary wire or JSON |
+| `/getNetwork` | POST | Binary wire or JSON |
+| `/getVersion` | POST | Binary wire or JSON |
 
-We define standardized HTTP requests that applications can use to communicate with wallets for performing various tasks.
+The method names, argument structures, result structures, and binary call codes are specified normatively in [BRC-100](./0100.md).
 
-Message Type                      | Request Method |  Route Name              | URL Query String Params | Request Body | Response Body
-----------------------------------|------------| ---------------------------| ------------------- | ----------------------------------- | -----------
-[BRC-1](./0001.md) Transaction Creation        | POST | `createAction` | No Params | JSON | JSON
-[BRC-2](./0002.md) Encryption                  | POST | `encrypt` | [BRC-56](./0056.md) defined | Binary or String | Binary
-[BRC-2](./0002.md) Decryption                  | POST | `decrypt` | [BRC-56](./0056.md) defined | Binary or String | Binary
-[BRC-3](./0003.md) Signature Creation          | POST | `createSignature` | No Params | JSON | Binary
-[BRC-3](./0003.md) Signature Verification      | POST | `verifySignature` | [BRC-56](./0056.md) defined | Binary or String | JSON
-[BRC-53](./0053.md) Certificate Creation       | POST | `createCertificate` | No Params | JSON | JSON
-[BRC-53](./0053.md) Certificate Verification   | POST | `proveCertificate` | No Params | JSON | JSON
-[BRC-56](./0056.md) HMAC Creation              | POST | `createHmac` | [BRC-56](./0056.md) defined | Binary or String | Binary
-[BRC-56](./0056.md) HMAC Verification          | POST | `verifyHmac` | [BRC-56](./0056.md) defined | Binary or String | Boolean
-[BRC-56](./0056.md) Public Key Derivation      | GET | `getPublicKey` | [BRC-56](./0056.md) defined | None | JSON
-[BRC-56](./0056.md) Certificate List           | POST | `findCertificates` | No Params | JSON | JSON
-[BRC-56](./0056.md) Version Request            | GET | `getVersion` | No Params | None | String
-[BRC-56](./0056.md) Network Request            | POST | `getNetwork` | No Params | None | String
-[BRC-56](./0056.md) Authentication Request     | GET | `isAuthenticated` | No Params | None | JSON
-[BRC-56](./0056.md) Async Auth Request         | POST | `waitForAuthentication` | No Params | JSON | JSON
-
-### JavaScript Code Example
+### JSON Code Example
 
 ```javascript
 const httpResult = await makeHttpRequest(
-      'http://localhost:3301/v1/<routeName>',
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          <requestBody>
-        })
-      }
-    )
+  'http://localhost:3321/createAction',
+  {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      description: 'Create a wallet action',
+      outputs: []
+    })
+  }
+)
+```
+
+### Binary-Wire Code Example
+
+```javascript
+const httpResult = await makeHttpRequest(
+  'http://localhost:3301/createAction',
+  {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/octet-stream'
+    },
+    body: walletWireParameterBytes
+  }
+)
 ```
 
 ## Implementation
 
-Implementers of applications and wallets will need to create and process HTTP requests in the manner described, according to the various fields and properties as required by [BRC-56](./0056.md), and in a manner consistent with the reference implementation, which is the [Babbage SDK](https://github.com/p2ppsr/babbage-sdk)'s HTTP substrate functionality.
+Applications and wallets should implement the current BRC-100 method set and one or more of the current HTTP substrates above. The current reference implementation is the `bsv-blockchain/ts-sdk` wallet substrate implementation.

--- a/wallet/0006.md
+++ b/wallet/0006.md
@@ -10,6 +10,10 @@ Cross-document messaging enables web-based applications to communicate with one 
 
 [BRC-56](./0056.md) defines a suite of abstract messages used by applications and wallets to facilitate various Bitcoin and MetaNet operations that enable micropayments, protect user privacy and ensure secure authentication without the need for each application to maintain a separate user account. While [BRC-5](./0005.md) defines a method of using a [BRC-56](./0056.md) wallet over HTTP on the local machine, some mobile devices are unable to support running HTTP servers due to platform-specific limitations. Additionally, it is sometimes desirable for a MetaNet environment to run fully in the browser, enabling users to access their identities on devices or platforms where a desktop-based [BRC-5](./0005.md) client cannot be installed. This specification provides a ubiquitous communications substrate enabling the use of [BRC-56](./0056.md) functionality across a wide range of devices and deployment contexts, including fully in-browser experiences.
 
+## Status Note
+
+The XDM substrate concept remains relevant, but this document's BRC-56 method table is historical. Current XDM-style wallet bridges SHOULD expose the [BRC-100](./0100.md) wallet method set. Legacy call names such as `createCertificate` and `ninja.findCertificates` are deprecated for new implementations.
+
 ## Specification
 
 We specify that the parent page runs the wallet, responding to messages from child pages. This has several advantages:
@@ -160,7 +164,7 @@ Message Pair                      | `call` Value              | Specific Impleme
 
 ## Implementations
 
-Implementers of applications and wallets will need to create and process XDM messages in the manner described, according to the various fields and properties as required by [BRC-56](./0056.md), and in a manner consistent with the reference implementation, which is the [Babbage SDK](https://github.com/p2ppsr/babbage-sdk)'s XDM substrate functionality.
+Implementers of applications and wallets should create and process XDM messages in the manner described, using [BRC-100](./0100.md) method names and payloads for current interoperability. Older Babbage SDK references are retained only for historical context.
 
 Implementation questions should be directed to the author.
 

--- a/wallet/0007.md
+++ b/wallet/0007.md
@@ -14,6 +14,10 @@ Although [BRC-5](./0005.md) defines a standard for local communication over HTTP
 
 This also eliminates the need for users to switch between multiple applications when approving permissions, creating transactions, etc. They can perform all wallet-related tasks within the web application they are already using, resulting in a more cohesive and convenient user experience.
 
+## Status Note
+
+The `window.CWI` substrate remains relevant, but this document's BRC-56 function table is historical. Current browser wallet injections SHOULD expose the [BRC-100](./0100.md) wallet method set. Legacy function names such as `window.CWI.createCertificate()` and `window.CWI.findCertificates` are deprecated for new implementations; use `acquireCertificate` and `listCertificates`.
+
 ## Specification
 
 We define a specification for providing access to Bitcoin wallet functionality via the global window object that is directly available in all standard browser implementations.
@@ -71,7 +75,6 @@ const ciphertext = await window.CWI.encrypt({
 
 ## Implementation
 
-Implementors of this BRC should follow the abstract messaging layer as defined by [BRC-56](./0056.md) to provide support for standard messaging types, and then modify the window object created to include this functionality in a CWI object.
+Implementors of this BRC should follow the current wallet method set in [BRC-100](./0100.md), then expose those methods on the window object in a CWI-compatible object where this substrate is used.
 
 <img src="./media/Window_CWI_Diagram.png" width="500px">
-

--- a/wallet/0046.md
+++ b/wallet/0046.md
@@ -10,113 +10,129 @@ We define an extension to [BRC-1](./0001.md) that enables a wallet to facilitate
 
 Transaction outputs in Bitcoin take many forms, and serve many purposes. While [BRC-1](./0001.md) defines a way for applications to request the creation of transaction outputs by wallets, there is no way for applications to request that a wallet tracks these outputs. Enabling applications to request that wallets track outputs provides a number of advantages: First, applications may no longer need to rely on external data storage and retrieval systems, simplifying their architecture. Second, there is the potential to represent different types of Bitcoin-native tokens within specific baskets, and define protocols for manipulating specific types of tokens based on which baskets they are stored in. Finally, when permission to access a basket is decided by the user on a per-application basis, it facilitates a greater degree of control for users over their tokens, enabling multiple applications to access and use the same tokens.
 
+## Status Note
+
+This specification remains the conceptual basis for wallet output baskets, but the legacy BRC-1/BRC-8 message shapes below have been superseded by the [BRC-100](./0100.md) wallet interface. New implementations MUST use BRC-100 `createAction`, `internalizeAction`, `listOutputs`, and `relinquishOutput` semantics for basket operations.
+
+The historical fields `includeEnvelope`, `amount`, `txid`, `vout`, `outputScript`, and `envelope` are deprecated in this context. Current wallet implementations return `outpoint`, `satoshis`, optional `lockingScript`, optional `customInstructions`, and optional [BRC-62](../transactions/0062.md) BEEF data through BRC-100.
+
 ## Specification
 
-We extend the [BRC-1](./0001.md) Transaction Creation Request message so that, in addition to the normal `script` and `satoshis` fields defined in each element of the `outputs` array, there is another `basket` field. The new `basket` field is a string comprising the name of the basket into which this output is to be inserted and tracked by the wallet. We specify that, when a wallet creates a transaction responsive to the Transaction Creation Request, it utilizes some internal storage and retrieval system (beyond the scope of this specification) to associate the specified output with the specified basket.
+### Basket Naming
 
-To allow applications to specify information that would later be needed to unlock and use outputs that are stored in baskets, an optional `customInstructions` field can also be added when `basket` is given. This field is retained by the wallet and included as part of the Transaction Outputs Response (defined below).
+A basket name is an application-defined identifier for a wallet-managed set of tracked outputs. In current BRC-100 implementations, basket identifiers are normalized by trimming whitespace and lowercasing the value, and must be between 1 and 300 UTF-8 bytes.
 
-To facilitate permissioned access to baskets by applications, we stipulate that the wallet, upon receiving a transaction creation request, may prompt the user to grant permission for the application to use the basket. The method by which the wallet seeks the consent of the user is out-of-scope for this standard, but the process, if it occurs, must be facilitated by the wallet asynchronously between the receipt of the Transaction Creation Request and the furnishment of any Transaction Creation Response or Transaction Creation Error messages.
+Basket names beginning with `p ` are reserved for future or installed permission modules as defined by [BRC-99](./0099.md). Wallets may also reserve implementation-internal admin basket names; wallet-toolbox uses `admin ...` baskets for permission-token storage and denies non-admin access.
 
-To facilitate access to the tokens stored within baskets by applications, we define a new set of messages across the abstract communications channel between the wallet and the application, as follows:
+### Inserting Outputs During Transaction Creation
 
-### Transaction Outputs Request
+Applications insert new transaction outputs into baskets by providing `basket` on a BRC-100 `createAction` output:
 
-This message constitutes a request by the application for a list of Bitcoin UTXOs that are responsive to the request. The message contains the following information:
+```json
+{
+  "description": "Create a todo token",
+  "outputs": [
+    {
+      "lockingScript": "76a914...88ac",
+      "satoshis": 1,
+      "outputDescription": "Todo token",
+      "basket": "todo tokens",
+      "customInstructions": "{\"unlock\":\"context\"}",
+      "tags": ["open"]
+    }
+  ]
+}
+```
 
-Field             | Required |Description
-------------------|----------|----------------
-`basket`          | yes      | The basket from which outputs should be returned
-`includeEnvelope` | no       | Whether [BRC-8](../transactions/0008.md) transaction envelopes are requested for the outputs
-`limit`           | no       | The maximum number of outputs to return
-`offset`          | no       | The number of outputs from the beginning of the list to skip
-`spendable`       | no       | Always considered to be `true`, included by some implementations for historical reasons
+The optional `customInstructions` value is retained by the wallet as application metadata for later spending. The optional `tags` array supports filtering and categorization within the basket.
 
-This provides the wallet with enough information to furnish the outputs requested by the application. Here is an example of a simple Transaction Outputs Request in JSON:
+### Internalizing Existing Outputs Into Baskets
+
+Applications or services can import an existing Atomic BEEF transaction using BRC-100 `internalizeAction`. To insert a specific output into a basket, the output metadata uses:
+
+```json
+{
+  "outputIndex": 0,
+  "protocol": "basket insertion",
+  "insertionRemittance": {
+    "basket": "todo tokens",
+    "customInstructions": "{\"unlock\":\"context\"}",
+    "tags": ["open"]
+  }
+}
+```
+
+The only current `internalizeAction` protocol strings are `wallet payment` and `basket insertion`.
+
+### Listing Outputs
+
+Applications list basketed outputs with BRC-100 `listOutputs`.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `basket` | yes | Basket whose tracked outputs should be returned |
+| `tags` | no | Tags used to filter outputs |
+| `tagQueryMode` | no | `any` or `all`; defaults to `any` |
+| `include` | no | `locking scripts` or `entire transactions` |
+| `includeCustomInstructions` | no | Include stored custom instructions |
+| `includeTags` | no | Include output tags |
+| `includeLabels` | no | Include labels on the containing actions |
+| `limit` | no | Maximum number of outputs to return; current validation defaults to 10 |
+| `offset` | no | Offset into the result set; negative offsets count back from the end |
+| `seekPermission` | no | Whether the wallet may seek user permission if needed; defaults to true |
+
+Example:
 
 ```json
 {
   "basket": "todo tokens",
-  "includeEnvelope": true,
+  "tags": ["open"],
+  "tagQueryMode": "all",
+  "include": "locking scripts",
+  "includeCustomInstructions": true,
+  "includeTags": true,
   "limit": 25,
-  "offset": 0,
-  "spendable": true
+  "offset": 0
 }
 ```
 
-In this example, the application is stipulating that a maximum of 25 outputs from the `todo tokens` basket are to be returned, including their [BRC-8](../transactions/0008.md) transaction envelopes.
-
-### Transaction Outputs Response
-
-The response comprises a list of transaction outputs currently in the specified basket. This is an array of objects where each object has the following fields:
-
-Field                | Description
----------------------|--------------------------
-`amount`             | The number of satoshis in the transaction output
-`txid`               | The TXID of the transaction that created the output, given as a hex string
-`vout`               | The output index number of this output within the transaction that created it
-`outputScript`       | The hex-encoded Bitcoin script program that locks the output
-`customInstructions` | The spending instructions that were stored when the output was created
-`envelope`           | If envelopes were requested, the [BRC-8](../transactions/0008.md) Transaction Envelope for this transaction
-
-Here is an example of a simple Transaction Outputs Response:
-
-```json
-[{
-  "amount":1000,
-  "customInstructions":null,
-  "envelope":{
-    "rawTx":"010000000135620d3a8fb626b763cb7b9a3c3197eda9bd6709ef1e4ebc2b359607800eaa95020000006b483045022100c3ec1792f1780e453c6ea692271bcc5388fb179d6455897f4b4200706e8b9f150220352cc2ff81a5c698e4626aec8976643134efab91ca1c80729670c2d007c77cfd4121037798f038cb7fc18b9d67baa87ed33122eb7be65b95b0dd304dc476c60043773dffffffff03e803000000000000c4210399322f558d92ced9c45d3bfe7dc5c01b830a4b61d71695ab0a1fa2cd90aba8b9ac2131546f446f44744b7265457a6248594b466a6d6f42756475466d53585855475a473462812d4eeb030fa496c2965f7e0f0b0e825d0547aceb7a9d4c76fd17e795753d8e2e0e82274ab36744a7968a43dc45b1cbdfab6c473045022100a58914da5346960ecb4de964f0f1e1be43a7645a11449c3a209f3fd69b34209b02205d4d4294d04c5f87fb16c2cdc3d9b41f9866fb3d7a690da08089c972d1393d816d75c8000000000000001976a91473a95c0b12e33b3d79f80508200a075bbab0906588ac4ea80200000000001976a91478daf10df51b3ea4c9292a72bf2e1e1d48ebe11288ac00000000",
-    "mapiResponses":[{
-      "publicKey":"030d1fe5c1b560efe196ba40540ce9017c20daa9504c4c4cec6184fc702d9f274e",
-      "payload":"{\"apiVersion\":\"1.5.0\",\"timestamp\":\"2023-04-07T08:19:10.2186219Z\",\"txid\":\"900b7e9ced44f8a7605bd4c1b7054b8fb958385998954d772820a8b81eabb56f\",\"returnResult\":\"success\",\"resultDescription\":\"\",\"minerId\":\"030d1fe5c1b560efe196ba40540ce9017c20daa9504c4c4cec6184fc702d9f274e\",\"currentHighestBlockHash\":\"000000000000032b2a17b3003b5cbb484b284bda4ffd7c15edd6c038429840ed\",\"currentHighestBlockHeight\":1545664,\"txSecondMempoolExpiry\":0,\"warnings\":[],\"failureRetryable\":false}",
-      "signature":"30440220066e711073f08d6302a33acb2863557b13465f5381a3355eaee9a5e08909abfc0220695fedf9800226d9f430f8a0177c1e4bde8134d350a8eb3bfd0d5d77925cac4d"
-    }],
-    "inputs":{
-      "95aa0e800796352bbc4e1eef0967bda9ed97313c9a7bcb63b726b68f3a0d6235":{
-        "rawTx":"0100000001ce31fcf049468a1e3a2cd56c598d5452f6bfbc95bac036eda769531795e3198c020000006a4730440220721e1e12c2540cccf01fed09560daf2dddebec959e39481c6f27bf366d8b3c5d0220040562db8f91b13b7ad33ac9f01adbbfa748c375ff2c8201929828537e7fb81841210306d6a463a7f204b050ffeba596fe9a2466f416b008d6954ce425304660abe450ffffffff0322020000000000001976a914268b68eb0ee5ed10decbf38fa47cdc2e3df7af2b88acc8000000000000001976a91426db399bdfe2ff5e413c60930b3f760a4db625db88ac30ad0200000000001976a9149cbb583bcc1d80d37669e930dca22655d621990088ac00000000",
-        "proof":{
-          "txOrId":"95aa0e800796352bbc4e1eef0967bda9ed97313c9a7bcb63b726b68f3a0d6235","target":"a4f45102baefabafb1ad7376f754c219411e45439fd31c2b082051f0e58e08e3",
-          "targetType":"merkleRoot",
-          "nodes":[
-            "8d8403f47e3e9a461848b5d45ee173d49ef4afb2c952e26ff2ffa95e2ae96a7c",
-            "04f653cc1e2e5376600ec83c93d3ac7309dd29662b69f329511a020c9ecf5b67",
-            "3c8a8b183008fa56dfe432ab7ccb10e47e36537c21a152466de7e1a3572a5286",
-            "cb798749f39ce21c360cea90973a2eeb4740a7db05b7f42f1b33b81448369753",
-            "3fb4036561bb38c0c2096512818bcfc425ead33f0a10272def77d8bf6243ae94"
-          ],
-          "index":15
-        }
-      }
-    }
-  },
-  "outputScript":"210399322f558d92ced9c45d3bfe7dc5c01b830a4b61d71695ab0a1fa2cd90aba8b9ac2131546f446f44744b7265457a6248594b466a6d6f42756475466d53585855475a473462812d4eeb030fa496c2965f7e0f0b0e825d0547aceb7a9d4c76fd17e795753d8e2e0e82274ab36744a7968a43dc45b1cbdfab6c473045022100a58914da5346960ecb4de964f0f1e1be43a7645a11449c3a209f3fd69b34209b02205d4d4294d04c5f87fb16c2cdc3d9b41f9866fb3d7a690da08089c972d1393d816d75",
-  "spendable":true,
-  "txid":"900b7e9ced44f8a7605bd4c1b7054b8fb958385998954d772820a8b81eabb56f",
-  "vout":0
-}]
-```
-
-### Transaction Outputs Error
-
-If the Bitcoin wallet is unable to fulfill the Transaction Outputs Request for any reason, we specify that it should respond with a JSON-formatted Transaction Outputs Error. The fields for the object are specified as follows:
-
-Field         | Description
---------------|--------------------------
-`status`      | This should always be a string comprising `"error"`.
-`code`        | A machine-readable error code. Extensions to this standard can define specific error codes and standardize additional fields. Codes are strings, for example `"ERR_PERMISSION_DENIED"`.
-`description` | All errors must have a human-readable `description` field that describes the error. This allows the application to represent the error for the user.
-
-One example of a Transaction Outputs Error is given below:
+The BRC-100 response is:
 
 ```json
 {
-  "status": "error",
-  "code": "ERR_PERMISSION_DENIED",
-  "description": "You have denied permission for accessing this output basket."
+  "totalOutputs": 1,
+  "outputs": [
+    {
+      "outpoint": "900b7e9ced44f8a7605bd4c1b7054b8fb958385998954d772820a8b81eabb56f.0",
+      "satoshis": 1000,
+      "lockingScript": "76a914...88ac",
+      "spendable": true,
+      "customInstructions": "{\"unlock\":\"context\"}",
+      "tags": ["open"]
+    }
+  ]
 }
 ```
 
+When `include` is `entire transactions`, the response may also contain a `BEEF` property carrying transaction data needed to validate or inspect the returned outputs.
+
+### Removing Outputs From Basket Tracking
+
+Applications relinquish wallet tracking for a basketed output with BRC-100 `relinquishOutput`:
+
+```json
+{
+  "basket": "todo tokens",
+  "output": "900b7e9ced44f8a7605bd4c1b7054b8fb958385998954d772820a8b81eabb56f.0"
+}
+```
+
+Relinquishment removes the wallet's basket tracking for the output; it is not a Bitcoin spend by itself.
+
+### Permission Behavior
+
+Wallets may require user authorization before allowing an originator to insert, list, or relinquish basket outputs. Current wallet-toolbox permission behavior is specified in [BRC-116](./0116.md), including grouped basket permissions, admin basket restrictions, and P-basket module delegation.
+
 ## Implementations
 
-This functionality is implemented as part of the [Babbage SDK](https://github.com/p2ppsr/babbage-sdk), via the `getTransactionOutputs` function.
+This functionality is implemented by current `bsv-blockchain/ts-sdk` BRC-100 wallet interfaces and `bsv-blockchain/wallet-toolbox` storage and permission layers.

--- a/wallet/0050.md
+++ b/wallet/0050.md
@@ -10,6 +10,10 @@ To ensure a seamless process for submitting payments to a wallet, there must be 
 
 BRC-50 standardizes payment submission to a wallet, improving the user experience for incoming Bitcoin payments. This enables higher-layer applications to add funds to a user's wallet without needing to maintain their own external balance. By standardizing payment submission, developers can create interoperable, extensible, and SPV compliant applications. This ensures a seamless and secure payment process, benefiting both wallet providers and end-users.
 
+## Status Note
+
+BRC-50 is historical. Current incoming transaction submission is specified by [BRC-100](./0100.md) `internalizeAction`. For BRC-29 payments, the current `outputs[].protocol` value is `wallet payment`; for basket insertions, it is `basket insertion`. The legacy `submitDirectTransaction` route and BRC-8 envelope payload are deprecated for new implementations.
+
 ## Specification
 
 For this specification, we assume that there exists a wallet that facilitates a channel by which communication can occur with an application, such as over HTTP as defined in [BRC-5](./0005.md). Based on this premise, we specify a standard by which payments can be submitted from an application to a wallet which then receives and processes the payment.

--- a/wallet/0053.md
+++ b/wallet/0053.md
@@ -10,6 +10,10 @@ We define methods for an application to request that a wallet create and prove [
 
 The [BRC-52](../peer-to-peer/0052.md) identity certificate standard provides a decentralized, privacy-centric solution to digital identity, allowing users to selectively reveal their identity data. However, without a standard method for applications to create and prove these certificates, wallet support will be limited. BRC-53 provides a set of standardized methods for applications to request and interact with [BRC-52](../peer-to-peer/0052.md) certificates, enabling wider adoption and integration of [BRC-52](../peer-to-peer/0052.md) certificates within the ecosystem.
 
+## Status Note
+
+BRC-53 is historical as an application-to-wallet method set. Current wallet certificate behavior is specified by [BRC-100](./0100.md) and [BRC-52](../peer-to-peer/0052.md). New implementations use `acquireCertificate`, `listCertificates`, `proveCertificate`, and `relinquishCertificate`; the older `createCertificate` and `findCertificates` naming is deprecated.
+
 ## Specification
 
 We define two new sets of messages to be sent over the abstract [BRC-1](./0001.md) messaging layer:
@@ -155,4 +159,4 @@ The certifier processes the CSR and signs the certificate using its private sign
 
 ## Implementations
 
-These processes have been implemented into the `createCertificate` and `proveCertificate` functions of the [Babbage SDK](https://github.com/p2ppsr/babbage-sdk). The Computing with Integrity kernel (currently proprietary) implements the wallet-to-certifier communications protocol, and [CoolCert](https://github.com/p2ppsr/coolcert) implements the certifier side of the protocol.
+These processes are represented in current form by `bsv-blockchain/ts-sdk` BRC-100 certificate methods and `bsv-blockchain/wallet-toolbox` certificate storage and permission behavior. Legacy `createCertificate` references are retained only for historical context.

--- a/wallet/0056.md
+++ b/wallet/0056.md
@@ -11,6 +11,18 @@ The importance of a standard interface by which Bitcoin applications can communi
 
 Computing has long been subject to shortfalls in the areas of information centralization and architectural cross-compatibility. Users on the internet struggle with complex and insecure authentication systems which leave them vulnerable and leak their data. Websites rely on advertising to monetize their offerings, but ads warp the incentives of platforms and creators in ways that ultimately harm everyone involved. By defining a standard interface by which users can identify themselves, protect their data and engage in e-commerce with Bitcoin, this standard offers a solution to problems that have long plagued the existing model.
 
+## Status Note
+
+BRC-56 is historical. The current unified wallet interface is [BRC-100](./0100.md). New implementations should use BRC-100 method names, argument structures, return structures, and call codes.
+
+Important current differences include:
+
+- certificates use `acquireCertificate`, `listCertificates`, `proveCertificate`, and `relinquishCertificate`,
+- `getNetwork` returns `mainnet` or `testnet`,
+- authentication methods return structured result objects such as `{ "authenticated": true }`,
+- wallet version strings are not constrained to the historical `0.3.x` range,
+- and transaction data is BEEF / Atomic BEEF rather than BRC-8 plus mAPI.
+
 ## Specification
 
 We specify a baseline standard for an abstract messaging layer which facilitates an identity interface between an application and an underlying MetaNet Client. As part of this messaging layer, we incorporate various message types defined by other BRC standards:
@@ -217,11 +229,11 @@ The asynchronous authentication request requires no parameters and waits until t
 
 ## Implementations
 
-Implementations of this specification will need to decide on a concrete transport layer (referred to as a "substrate") to facilitate communication between the wallet and applications. Application developers will then need to write their applications in a way that facilitates communication over the substrate, and wallets will need to properly handle incoming requests from applications.
+Implementations should treat this document as historical context and implement [BRC-100](./0100.md) over a current substrate such as the binary wallet wire, JSON HTTP API, window CWI, XDM, React Native, or an implementation-specific bridge.
 
 Some examples of communication substrates include:
 - [BRC-5](./0005.md), for operating a wallet over HTTP on a local machine, enabling applications on that machine to interact with the running wallet.
 - [BRC-6](./0006.md), for cross-document messaging between a parent page which runs a wallet and a set of child pages which run various applications.
 - [BRC-7](./0007.md), for exposing an identity interface via the `window` object in web browsers.
 
-The BRC-56 functions and messages, across these three substrates, have been implemented by the Babbage team in the [Babbage SDK](https://github.com/p2ppsr/babbage-sdk).
+The historical BRC-56 functions were implemented by earlier Babbage tooling. Current interoperable code should follow BRC-100 and the current `bsv-blockchain/ts-sdk` / `bsv-blockchain/wallet-toolbox` behavior.

--- a/wallet/0056.md
+++ b/wallet/0056.md
@@ -33,7 +33,7 @@ We specify a baseline standard for an abstract messaging layer which facilitates
 
 - **[BRC-3](./0003.md):** We incorporate by reference the message types relating to digital signatures as specified by [BRC-3](./0003.md). This facilitates generalized message sender attestation and endorsement, solving problems such as fake AI-generated content by allowing relevant parties or the entire world to check whether something has been endorsed by its purported originator.
 
-- **[BRC-4](./0004.md):** We incorporate by reference the extension to [BRC-1](./0001.md) as defined by [BRC-4](./004.md), providing for the consumption and utilization of arbitrary UTXO-based Bitcoin tokens as part of transactions. This facilitates the creation and transfer between users of tokenized assets without restrictions beyond those set by their respective output locking scripts.
+- **[BRC-4](./0004.md):** We incorporate by reference the extension to [BRC-1](./0001.md) as defined by [BRC-4](./0004.md), providing for the consumption and utilization of arbitrary UTXO-based Bitcoin tokens as part of transactions. This facilitates the creation and transfer between users of tokenized assets without restrictions beyond those set by their respective output locking scripts.
 
 - **[BRC-46](./0046.md):** We incorporate by reference the extension to [BRC-1](./0001.md) as defined by [BRC-46](./0046.md), providing for the tracking and management of Bitcoin UTXOs in baskets. This facilitates the storage and retrieval of single-party tokens and digital assets in the user's wallet while removing the need to rely on a single trusted application for asset management.
 

--- a/wallet/0065.md
+++ b/wallet/0065.md
@@ -12,15 +12,23 @@ The motivation behind BRC-65 is to enhance the functionality of the Bitcoin wall
 
 By defining a standard mechanism for labeling transactions and listing labeled transactions, BRC-65 promotes interoperability between wallets and applications. With this standardization, applications can expect consistent behavior across different wallets, making it easier for developers to create Bitcoin-powered applications without having to build custom wallet functionality. Furthermore, users can switch between wallets seamlessly without losing access to their labeled transactions.
 
+## Status Note
+
+BRC-65 remains the conceptual standard for wallet action labels, but its original BRC-56/BRC-1 message shapes have been superseded by [BRC-100](./0100.md). The singular `label` request field, `skip` pagination field, and [BRC-8](../transactions/0008.md) envelope response model are deprecated for current wallets.
+
+New implementations MUST use BRC-100 `createAction`, `internalizeAction`, and `listActions` behavior.
+
 ## Specification
 
-BRC-65 extends the functionality of BRC-56 by introducing the concept of transaction labels and the ability to list labeled transactions. This extension adds two new features to the wallet-to-application messaging layer: labeling transactions at the point of creation and retrieving labeled transactions.
+### Labels
 
-### Transaction Labels
+The `labels` field is an optional array on BRC-100 `createAction` and `internalizeAction` calls. Labels are application-defined strings used to organize wallet actions.
 
-The `labels` field is introduced as an optional parameter next to the `outputs` array and `description` of the BRC-1 Transaction Creation Request in BRC-56. This field allows applications to label transactions. Each label must be no longer than 300 characters and can only contain letters, numbers, and underscores.
+Current BRC-100 validation normalizes labels by trimming whitespace and lowercasing the value. A label must be between 1 and 300 UTF-8 bytes. The older restriction to letters, numbers, and underscores only is no longer current.
 
-The updated Transaction Creation Request with the `labels` field is as follows:
+Labels beginning with `p ` are reserved for installed or future label permission modules as defined by [BRC-111](./0111.md). Unsupported P-label schemes MUST be rejected rather than treated as normal labels.
+
+Example:
 
 ```json
 {
@@ -28,59 +36,68 @@ The updated Transaction Creation Request with the `labels` field is as follows:
   "labels": ["payment", "personal"],
   "outputs": [
     {
-      "script": "76a914b10f7d6c7fda3285e9b98297428ed814374cbd4088ac",
-      "satoshis": 3301
+      "lockingScript": "76a914b10f7d6c7fda3285e9b98297428ed814374cbd4088ac",
+      "satoshis": 3301,
+      "outputDescription": "Payment to John Galt"
     }
   ]
 }
 ```
 
-In this example, the application is creating a transaction with the labels "payment" and "personal". These labels can be used to categorize and organize the transaction in a way that is meaningful to the application.
-
 ### List Actions
 
-BRC-65 introduces the `listActions` message (the Actions List Request) to retrieve a list of Bitcoin transactions based on their labels. The Actions List Request message takes the following parameters:
+BRC-100 `listActions` retrieves wallet actions based on labels and optional inclusion flags:
 
-| Field   | Description                                                             |
-| ------- | ----------------------------------------------------------------------- |
-| `label` | The label to filter the transactions by.                                |
-| `skip`  | The number of transactions to skip before returning results (optional). |
-| `limit` | The maximum number of transactions to return (optional).                |
+| Field | Description |
+|-------|-------------|
+| `labels` | Array of labels to filter actions by |
+| `labelQueryMode` | `any` or `all`; defaults to `any` |
+| `includeLabels` | Include action labels in returned actions |
+| `includeInputs` | Include inputs in returned actions |
+| `includeInputSourceLockingScripts` | Include source locking scripts for inputs |
+| `includeInputUnlockingScripts` | Include unlocking scripts for inputs |
+| `includeOutputs` | Include outputs in returned actions |
+| `includeOutputLockingScripts` | Include output locking scripts |
+| `limit` | Maximum number of actions to return; current validation defaults to 10 |
+| `offset` | Offset into the result set; negative offsets count back from the end |
+| `seekPermission` | Whether the wallet may seek user permission if needed; defaults to true |
 
-The Actions List Request message retrieves Bitcoin transactions that have been labeled with the specified label. The `skip` parameter allows applications to retrieve a subset of transactions by skipping a certain number of transactions from the beginning of the list. The `limit` parameter defines the maximum number of transactions to return. If `skip` and `limit` are not provided, the request will return all transactions with the specified label.
-
-The Actions List Response comprises an array of BRC-8 Transaction Envelopes as defined in BRC-56, representing the labeled transactions, along with a `totalActions` field denoting the total number of transactions with the specified label.
-
-An example Actions List Request message with the label "payment" and a limit of 10 transactions is as follows:
+Example:
 
 ```json
 {
-  "label": "payment",
-  "limit": 10
+  "labels": ["payment"],
+  "labelQueryMode": "any",
+  "includeLabels": true,
+  "limit": 10,
+  "offset": 0
 }
 ```
 
-The corresponding Actions List Response would contain an array of BRC-8 Transaction Envelopes as well as the `totalActions` field:
+The response is a BRC-100 `ListActionsResult`:
 
 ```json
 {
-  "transactions": [
+  "totalActions": 42,
+  "actions": [
     {
-      "rawTx": "...",
-      "inputs": { ... },
-      "mapiResponses": { ... },
-      "txid": "..."
-    },
-    ...
-  ],
-  "totalActions": 42
+      "txid": "900b7e9ced44f8a7605bd4c1b7054b8fb958385998954d772820a8b81eabb56f",
+      "satoshis": 3301,
+      "status": "completed",
+      "isOutgoing": true,
+      "description": "Pay John Galt 3,301 satoshis",
+      "labels": ["payment", "personal"]
+    }
+  ]
 }
 ```
 
-In this example, the actions list response includes an array of BRC-8 Transaction Envelopes representing the labeled transactions with the label "payment". The `totalActions` field indicates that there are a total of 42 transactions with the "payment" label.
+Current action status values are defined by BRC-100 and include `completed`, `unprocessed`, `sending`, `unproven`, `unsigned`, `nosend`, `nonfinal`, and `failed`.
+
+### Permission Behavior
+
+Wallets may require user authorization before an originator applies or queries labels. Current wallet-toolbox behavior, including grouped label checks and P-label module delegation, is specified in [BRC-116](./0116.md) and [BRC-111](./0111.md).
 
 ## Implementations
 
-Implementations of this specification will need to extend the existing wallet software in order to support the labeling of transactions and the listing of labeled transactions. Wallets will need to ensure that they can create transactions with labeled outputs and store the labels for future retrieval. Applications will need to handle the labeling of transactions and make use of the Actions List Request to retrieve labeled transactions.
-
-Some existing implementations of BRC-56 may already support the labeling and listing of transactions, while others may need to update their software to include this additional functionality. The Babbage MetaNet Client, for example, has already implemented the Transaction Labels and List Actions functionality.
+This functionality is implemented by current `bsv-blockchain/ts-sdk` BRC-100 wallet interfaces and `bsv-blockchain/wallet-toolbox` storage and permission layers.

--- a/wallet/0066.md
+++ b/wallet/0066.md
@@ -10,6 +10,10 @@ This BRC extends [BRC-56](./0056.md) by adding the ability to remove specific ou
 
 Applications need the ability to remove specific outputs from a basket when they are no longer needed, without having to spend them. Furthermore, certificates may need to be deleted when they expire or are no longer relevant. This functionality allows for tokens and certificates to be managed more efficiently within a wallet, improving user experience and reducing clutter.
 
+## Status Note
+
+BRC-66 is historical. Current output and certificate relinquishment is specified by [BRC-100](./0100.md): use `relinquishOutput({ basket, output })` for basketed outputs and `relinquishCertificate({ type, serialNumber, certifier })` for certificates. Legacy `txid`/`vout` request shapes and BRC-56 extension framing are deprecated for new implementations.
+
 ## Specification
 
 This BRC introduces two new message types to the [BRC-56](./0056.md) messaging layer:

--- a/wallet/0073.md
+++ b/wallet/0073.md
@@ -4,105 +4,115 @@ Ty Everett (ty@projectbabbage.com)
 
 ## Abstract
 
-This specification outlines the architecture and structure of permissions granted to apps. It focuses on the grouping of permissions to provide a concise overview for users. The key permissions include Protocol Permissions, Spending Authorizations, Basket Access, and Certificate Field Access Grants.
+This specification defines the manifest declaration format for grouped wallet permissions. It allows an application to declare, in one place, the protocol access, spending authorization, basket access, and certificate disclosure capabilities it expects to request from the user.
+
+The current interoperable manifest namespace is `metanet.groupPermissions`. Wallets may continue to read the legacy `babbage.groupPermissions` namespace for backwards compatibility, but it is deprecated.
 
 ## Motivation
 
-As applications become more integrated with user data and cryptographic operations, the need for a clear and concise permission system has never been greater. This specification seeks to simplify user decisions by grouping permissions, ensuring transparency and user autonomy over their identities, their data and their digital assets.
+As applications become more integrated with user data and cryptographic operations, permission prompts can become fragmented and repetitive. Grouped permission declarations let wallets present a single, coherent prompt instead of a series of unrelated one-off requests, improving both transparency and user comprehension.
+
+## Status Note
+
+This document defines the **grouped-permission declaration shape**.
+
+The full runtime permission lifecycle, including manifest fetching, prompt routing, persistence, renewal, revocation, and interaction with counterparty trust (PACT), is authoritatively specified by [BRC-116](./0116.md). This document should therefore be read as the grouped-permission schema used by current BRC-100 wallet implementations, not as a complete permission-system specification by itself.
 
 ## Specification
 
-### Overview of Permission Types
+### Canonical Manifest Location
 
-There are four primary permission types that apps can be granted by users, each with its significance, function, and associated specifications:
+Applications SHOULD serve a W3C web-app manifest at:
 
-1. **Protocol Permissions (BRC-43)**: 
-   This permission grants an application the ability to utilize a user's keys to execute cryptographic operations (such as BRC-2 encryption or BRC-3 digital signatures).
+`https://{originator}/manifest.json`
 
-2. **Spending Authorizations (BRC-1)**:
-   As the name suggests, this allows apps to transact or spend a predefined number of satoshis over a specified time frame, within BRC-1 transactions.
+For local development, wallets MAY use:
 
-3. **Basket Access (BRC-46)**: 
-   This pertains to the app's capability to insert into and spend UTXO-based tokens from specific BRC-46 Output Baskets. The significance of this permission is to manage token operations within the app ecosystem. Each "basket" can be thought of as a container or grouping for tokens, and BRC-46 provides the framework for how apps can interact with these baskets, ensuring a structured approach to token management.
+`http://localhost/.../manifest.json`
 
-4. **Certificate Field Access Grants (BRC-52)**:
-   This is about identity verification. The permission allows an app to reveal specific fields from a BRC-52 identity certificate to designated verifiers. It's a crucial step in processes that require identity verification or authentication.
+Wallets MAY fetch this manifest proactively, or lazily when the first protected operation is attempted. Current wallet-toolbox behavior supports both patterns.
 
-### Group Permission Trigger Methodology
-   
-   - Applications initiate the permission request process via the `waitForAuthentication` function, which is part of the BRC-100 suite.
-   - Wallets determine the group permissions from the application's `manifest.json` file.
-   - The user receives a prompt detailing the permissions. They can choose to accept or deny each or all permissions. The wallet then applies their choices.
-   
-### Manifest File - `manifest.json`
+### Namespace
 
-   - The file is to be served over HTTPS and requested from the application by the wallet. HTTP is only accepted when running on `localhost` for development purposes.
-   - The existing `babbage` key is expanded to include the `groupPermissions` key.
-   - The `groupPermissions` key holds four subsequent keys representing the categories of permissions: `protocolPermissions`, `spendingAuthorization`, `basketAccess`, and `certificateAccess`.
+The canonical grouped-permission declaration lives under:
 
-### Definition for `groupPermissions` key in `manifest.json`
+`metanet.groupPermissions`
 
-The `groupPermissions` key is an object that encompasses various types of permissions, which the app might request from a user. This key contains four sub-keys: `protocolPermissions`, `spendingAuthorization`, `basketAccess`, and `certificateAccess`.
+Wallets SHOULD continue to recognize:
 
-1. `protocolPermissions` is an array of objects, where each object defines a specific Protocol Permission. Each object contains three fields: `protocolID` (a protocol ID array with two elements, the first a security level and the second a protocol string), `counterparty` (a string in hexadecimal format representing a public key, required only if the security level of the `protocolID` is `2`), and `description` (a short text explaining the purpose of this request).
+`babbage.groupPermissions`
 
-> NOTE: We do not support privileged key use in group permissions for security reasons. For the purpose of grouped permission requests, `privileged` is always `false`. By nature, every use of a privileged key must be requested on a one-off basis. Thus privileged operations can never be covered by a grouped permission scheme.
+for backwards compatibility, but applications SHOULD migrate to `metanet`.
 
-2. `spendingAuthorization` is an object that provides details about the satoshis an app is requesting authorization to spend. It has three fields: `amount` (a number indicating the amount in satoshis), `duration` (a number representing the time in seconds for the authorization's validity), and `description`.
+### `groupPermissions` Structure
 
-3. `basketAccess` is an array of objects, where each object denotes the access to a specific BRC-46 basket. The objects here have two fields: `basket` (the name of the BRC-46 basket) and `description`.
+The `groupPermissions` object may contain the following keys:
 
-4. `certificateAccess` is an array of objects that represent the different certificate types an app wants access to. Each object here consists of `type` (indicating the certificate type), `fields` (an array of strings naming the fields the app wants to reveal), `verifierPublicKey` (a string in hex format, representing the public key of the verifier), and `description`.
+- `description`
+- `protocolPermissions`
+- `spendingAuthorization`
+- `basketAccess`
+- `certificateAccess`
 
-With this structured approach, app developers can seamlessly integrate their permission requests within their `manifest.json`, and users can be assured of a clear understanding of the permissions they're granting.
+Grouped permissions do **not** cover privileged-key usage. Privileged operations remain one-off permission decisions in current interoperable wallet behavior.
 
-For the avoidance of doubt, the following sections provide tables that define each specific field, and example data structures.
+### Permission Types
 
-### Table 1: General Structure
+There are four grouped permission categories:
 
-| Key Name           | Value Type             | Description                                         |
-|--------------------|------------------------|-----------------------------------------------------|
-| `protocolPermissions`  | Array of Objects     | Contains Protocol Permissions requests.             |
-| `spendingAuthorization` | Object              | Contains Spending Authorization details.            |
-| `basketAccess`        | Array of Objects     | Contains Basket Access requests.                    |
-| `certificateAccess`   | Array of Objects     | Contains Certificate Field Access Grant requests.   |
+1. **Protocol permissions** for BRC-43 scoped cryptographic operations.
+2. **Spending authorization** for wallet spending on behalf of the originator.
+3. **Basket access** for BRC-46 basket usage.
+4. **Certificate access** for BRC-52 field revelation to a designated verifier.
 
-### Table 2: Protocol Permissions Object Structure
+### Protocol Permissions
 
-| Field Name       | Value Type | Description                                                  |
-|------------------|------------|--------------------------------------------------------------|
-| `protocolID`     | Array      | BRC-43 protocol ID array with two elements. First the security level between `0` and `2`, followed by the protocol string.  |
-| `counterparty`   | String (Hexadecimal) | Public key, 33-byte in hex format. Only required if `protocolID` security level is `2`.   |
-| `description`    | String     | Justification for the request, less than 50 characters.      |
+Each element of `protocolPermissions` is an object with:
 
-### Table 3: Spending Authorization Object Structure
+- `protocolID`: a BRC-43 protocol tuple `[securityLevel, protocolName]`
+- `counterparty`: required when the declaration is for a specific Level 2 counterparty
+- `description`: human-readable explanation for the user
 
-| Field Name       | Value Type         | Description                                                  |
-|------------------|--------------------|--------------------------------------------------------------|
-| `amount`         | Positive Number    | Satoshis being authorized for the app to spend.              |
-| `duration`       | Positive Number    | Time in seconds for the authorization's validity.            |
-| `description`    | String             | Justification for the request, less than 50 characters.      |
+Level 1 protocol declarations MAY omit `counterparty`.
 
-### Table 4: Basket Access Object Structure
+Level 2 declarations used in grouped permission requests SHOULD name the specific counterparty they are about.
 
-| Field Name       | Value Type         | Description                                                  |
-|------------------|--------------------|--------------------------------------------------------------|
-| `basket`         | String             | Name of the BRC-46 basket.                                   |
-| `description`    | String             | Justification for the request, less than 50 characters.      |
+### Spending Authorization
 
-### Table 5: Certificate Access Object Structure
+`spendingAuthorization` is an object with:
 
-| Field Name               | Value Type                   | Description                                                  |
-|--------------------------|-----------------------------|--------------------------------------------------------------|
-| `type`                   | String (base64)             | Certificate type field of a BRC-52 identity certificate.    |
-| `fields`                 | Array of Strings            | Array of field names being requested for revelation.         |
-| `verifierPublicKey`      | String (Hexadecimal)        | Public key of the verifier in 33-byte hex format.            |
-| `description`            | String                      | Justification for the request, less than 50 characters.      |
+- `amount`: the authorized monthly spend limit in satoshis
+- `description`: human-readable explanation for the user
+
+The older `duration` field is no longer part of current interoperable grouped-permission behavior and SHOULD be considered deprecated for new manifests.
+
+### Basket Access
+
+Each element of `basketAccess` is an object with:
+
+- `basket`: the BRC-46 basket name
+- `description`: human-readable explanation for the user
+
+### Certificate Access
+
+Each element of `certificateAccess` is an object with:
+
+- `type`: the BRC-52 certificate type
+- `fields`: the certificate fields requested for revelation
+- `verifierPublicKey`: the verifier's compressed public key
+- `description`: human-readable explanation for the user
+
+## Current Interoperability Notes
+
+- Wallets commonly fetch grouped permissions from `manifest.json` when the first protected operation is attempted, not only during `waitForAuthentication`.
+- `metanet.groupPermissions` is canonical.
+- `babbage.groupPermissions` is a deprecated backwards-compatibility fallback.
+- Grouped permissions and PACT are distinct; PACT is defined in [BRC-116](./0116.md).
 
 ## Examples
 
-1. **protocolPermissions Example**:
-   
+1. **`protocolPermissions`**
+
    ```json
    {
      "protocolID": [2, "Convo"],
@@ -111,18 +121,17 @@ For the avoidance of doubt, the following sections provide tables that define ea
    }
    ```
 
-2. **spendingAuthorization Example**:
-   
+2. **`spendingAuthorization`**
+
    ```json
    {
      "amount": 10000,
-     "duration": 3600,
      "description": "For in-app purchases."
    }
    ```
 
-3. **basketAccess Example**:
-   
+3. **`basketAccess`**
+
    ```json
    {
      "basket": "BRC-46 Gold",
@@ -130,8 +139,8 @@ For the avoidance of doubt, the following sections provide tables that define ea
    }
    ```
 
-4. **certificateAccess Example**:
-   
+4. **`certificateAccess`**
+
    ```json
    {
      "type": "...",
@@ -141,11 +150,15 @@ For the avoidance of doubt, the following sections provide tables that define ea
    }
    ```
 
-5. **Full manifest.json Example**:
-   
+5. **Full `manifest.json`**
+
    ```json
    {
-     "babbage": {
+     "name": "My App",
+     "short_name": "MyApp",
+     "display": "standalone",
+     "metanet": {
+       "schemaVersion": 1,
        "groupPermissions": {
          "protocolPermissions": [
            {
@@ -156,7 +169,6 @@ For the avoidance of doubt, the following sections provide tables that define ea
          ],
          "spendingAuthorization": {
            "amount": 10000,
-           "duration": 3600,
            "description": "For in-app purchases."
          },
          "basketAccess": [
@@ -174,10 +186,9 @@ For the avoidance of doubt, the following sections provide tables that define ea
            }
          ]
        }
-     }
+     },
+     "icons": []
    }
    ```
 
-App developers should prioritize user understanding and transparency when requesting permissions. The description field must be utilized effectively to convey the reason for the request, allowing users to make informed decisions.
-
-This approach ensures a streamlined and transparent process for apps to request and for users to grant permissions. It promotes a higher level of trust and clarity between applications and their users.
+Applications SHOULD provide clear descriptions that help the user understand why each grouped permission is being requested. Wallets SHOULD interpret these declarations using the lifecycle and enforcement rules in [BRC-116](./0116.md).

--- a/wallet/0100.md
+++ b/wallet/0100.md
@@ -222,7 +222,7 @@ The interface comprises numerous methods that cater to different functional area
 
 ### Transaction Operations:
 
-- **Creation**: The `createAction` method creates a new Action, which is effectively a Bitcoin transaction augmented with descriptive metadata and optional categorization (labels). This method can either fully construct and sign a transaction or return a "signableTransaction" reference if some inputs must be signed or processed later. The method always requires at least one input or one output to produce a valid transaction; otherwise, it must return an error. The minimum requirements is that at least one input or one output must be specified. If only `description` is provided and no inputs and no outputs are given, the wallet must return an error, since a transaction cannot be constructed. If `inputs` are provided, the wallet requires `inputBEEF` to supply context and validation data for these inputs. If both `inputBEEF` and a fully prepared set of `inputs` are provided, `inputBEEF` should provide SPV and contextual information about these inputs. The two are complementary: `inputs` define the UTXOs being consumed, and `inputBEEF` provides the transaction inclusion proofs or data needed for validation. Both must not conflict. If a conflict is detected, the wallet should return an error. Every input requires an `inputDescription`. This string documents why a particular UTXO was chosen or what it represents. This field is required to ensure proper user-level record-keeping and transparency. If `basket` is not provided for an output, that output is considered untracked by the wallet. It will not appear in `listOutputs`, and the wallet does not maintain any metadata about it. Baskets are used for grouping UTXOs for later retrieval, filtering, and permissioned operations.
+- **Creation**: The `createAction` method creates a new Action, which is effectively a Bitcoin transaction augmented with descriptive metadata and optional categorization (labels). This method can either fully construct and sign a transaction or return a `signableTransaction` reference if some inputs must be signed or processed later. In current interoperable implementations, `createAction` is also used for wallet-managed batching and chained-send workflows such as `noSend`, `sendWith`, and change remixing. Implementers MUST therefore not assume that every valid `createAction` call explicitly carries one or more inputs or outputs in the request body. If `inputs` are provided, `inputBEEF` supplies supporting SPV and contextual information for those inputs. Every explicit input requires an `inputDescription`. If `basket` is not provided for an output, that output is considered untracked by the wallet and will not appear in `listOutputs`.
 - **Signing**: `signAction` allows for signing and processing previously created transactions from the `createAction` method.
 - **Aborting**: `abortAction` facilitates the cancellation of transactions that have not yet been completed.
 - **Internalization**: `internalizeAction` enables wallets to accept and manage incoming transactions by parsing, tagging, and organizing outputs.
@@ -251,7 +251,7 @@ The interface comprises numerous methods that cater to different functional area
 ### Blockchain and Network Data:
 
 - **Blockchain Height**: `getHeight` retrieves the current height of the blockchain.
-- **Merkle Root Retrieval**: `getMerkleRootForHeight` retrieves the Merkle root at a specific block height.
+- **Block Header Retrieval**: `getHeader` retrieves the serialized block header at a specific block height.
 - **Network and Version Information**: `getNetwork` and `getVersion` retrieve information about the network (mainnet or testnet) and the wallet's version.
 
 ### Authentication:
@@ -283,6 +283,8 @@ To ensure consistency and prevent errors, the interface defines various data typ
 - `Base64String`: A string in standard base64 encoded format.
 - **Specialized Strings**: Defined for specific fields, including transactions, descriptions, version strings, certificate field names, etc.
 
+Current interoperable SDK validation measures string limits in **UTF-8 bytes**, not JavaScript character count. Historical type names in this document that end with `Characters` should therefore be interpreted as byte-length limits for interoperability purposes.
+
 ## Error Handling and Validation
 
 ### Errors are raised using a uniform structure containing:
@@ -298,10 +300,11 @@ When errors occur, they must be communicated and thrown such that they preserve 
 
 Wallets must apply all specified rules and logical validation procedures to all methods within the specification. For example, in the case of `createAction`, wallets should:
 
-- Verify that the required fields (`description` plus at least one input or one output) are present.
+- Verify that `description` is present.
+- Permit request shapes used for interoperable batching flows such as `noSend`, `sendWith`, or wallet-managed remix/change handling, even when no explicit inputs or outputs are supplied.
 - Check that if `inputs` are provided, the `inputDescription` field is also provided for each input.
 - Validate that if `inputBEEF` is provided, it corresponds logically to the `inputs`.
-- Ensure that labels, tags, and basket names comply with the defined format and size constraints.
+- Ensure that labels, tags, and basket names comply with the defined format and size constraints. Current interoperable SDK validation trims and lowercases these identifiers before enforcing length limits.
 - If any constraints are not met, or if conflicting parameters are detected (e.g., invalid `noSendChange usage`), the wallet should return a structured error as previously defined.
 
 ### Parameter Errors:
@@ -498,11 +501,19 @@ export type OriginatorDomainNameString = string
 
 /**
  * @typedef {string & { minLength: 5, maxLength: 50 }} DescriptionString5to50Characters
- * A string used for descriptions, with a length between 5 and 50 characters.
+ * A string used for short descriptions, such as `privilegedReason` values, with a length between 5 and 50 characters.
  * @remarks
  * TypeScript cannot enforce length constraints. Validate at runtime for length compliance.
  */
 export type DescriptionString5to50Characters = string
+
+/**
+ * @typedef {string & { minLength: 5, maxLength: 2000 }} ActionDescriptionString5to2000Characters
+ * A string used for action, input, output, and internalization descriptions, with a length between 5 and 2000 characters.
+ * @remarks
+ * Current interoperable `ts-sdk` validation accepts this wider range for transaction-facing descriptions.
+ */
+export type ActionDescriptionString5to2000Characters = string
 
 /**
  * @typedef {string & { maxLength: 300 }} BasketStringUnder300Characters
@@ -529,20 +540,20 @@ export type OutputTagStringUnder300Characters = string
 export type LabelStringUnder300Characters = string
 
 /**
- * @typedef {Byte[]} BEEF
- * An array of integers, each ranging from 0 to 255, indicating transaction data in BEEF(BRC-62) format.
+ * @typedef {Byte[] | Uint8Array} BEEF
+ * A byte array indicating transaction data in BEEF(BRC-62) format.
  * @remarks
- * Validate at runtime to ensure each element is within the specified range.
+ * Current interoperable implementations accept either a numeric byte array or a `Uint8Array`.
  */
-export type BEEF = Byte[]
+export type BEEF = Byte[] | Uint8Array
 
 /**
- * @typedef {Byte[]} AtomicBEEF
- * An array of integers, each ranging from 0 to 255, indicating transaction data in Atomic BEEF(BRC-95) format.
+ * @typedef {Byte[] | Uint8Array} AtomicBEEF
+ * A byte array indicating transaction data in Atomic BEEF(BRC-95) format.
  * @remarks
- * Validate at runtime to ensure each element is within the specified range.
+ * Current interoperable implementations accept either a numeric byte array or a `Uint8Array`.
  */
-export type AtomicBEEF = Byte[]
+export type AtomicBEEF = Byte[] | Uint8Array
 
 /**
  * @typedef {string & { minLength: 5, maxLength: 400 }} ProtocolString5To400Characters
@@ -621,18 +632,18 @@ export interface Wallet {
    * Creates a new Bitcoin transaction based on the provided inputs, outputs, labels, locks, and other options.
    *
    * @param {Object} args - The arguments required to create the transaction.
-   * @param {DescriptionString5to50Characters} args.description - A human-readable description of the action represented by this transaction.
+   * @param {ActionDescriptionString5to2000Characters} args.description - A human-readable description of the action represented by this transaction.
    * @param {BEEF} [args.inputBEEF] - BEEF data associated with the set of input transactions from which UTXOs will be consumed.
    * @param {Array<Object>} [args.inputs] - An optional array of input objects used in the transaction.
    * @param {OutpointString} args.inputs[].outpoint - The outpoint being consumed.
    * @param {HexString} args.inputs[].unlockingScript - The unlocking script needed to release the specified UTXO.
-   * @param {DescriptionString5to50Characters} args.inputs[].inputDescription - A description of this input for contextual understanding of what it consumes.
+   * @param {ActionDescriptionString5to2000Characters} args.inputs[].inputDescription - A description of this input for contextual understanding of what it consumes.
    * @param {PositiveIntegerOrZero} [args.inputs[].sequenceNumber] - An optional sequence number applied to the input.
    * @param {PositiveInteger} [args.inputs[].unlockingScriptLength] - Length of the unlocking script, in case it will be provided later using `signAction`.
    * @param {Array<Object>} [args.outputs] - An optional array of output objects for the transaction.
    * @param {HexString} args.outputs[].lockingScript - The locking script that dictates how the output can later be spent.
    * @param {SatoshiValue} args.outputs[].satoshis - Number of Satoshis that constitute this output.
-   * @param {DescriptionString5to50Characters} args.outputs[].outputDescription - Description of what this output represents.
+   * @param {ActionDescriptionString5to2000Characters} args.outputs[].outputDescription - Description of what this output represents.
    * @param {BasketStringUnder300Characters} [args.outputs[].basket] - Name of the basket where this UTXO will be held, if tracking is desired.
    * @param {string} [args.outputs[].customInstructions] - Custom instructions attached onto this UTXO, often utilized within application logic to provide necessary unlocking context or track token histories.
    * @param {OutputTagStringUnder300Characters[]} [args.outputs[].tags] - Tags assigned to the output for sorting or filtering.
@@ -654,19 +665,19 @@ export interface Wallet {
    */
   createAction: (
     args: {
-      description: DescriptionString5to50Characters
+      description: ActionDescriptionString5to2000Characters
       inputBEEF?: BEEF
       inputs?: Array<{
         outpoint: OutpointString
         unlockingScript?: HexString
         unlockingScriptLength?: PositiveInteger
-        inputDescription: DescriptionString5to50Characters
+        inputDescription: ActionDescriptionString5to2000Characters
         sequenceNumber?: PositiveIntegerOrZero
       }>
       outputs?: Array<{
         lockingScript: HexString
         satoshis: SatoshiValue
-        outputDescription: DescriptionString5to50Characters
+        outputDescription: ActionDescriptionString5to2000Characters
         basket?: BasketStringUnder300Characters
         customInstructions?: string
         tags?: OutputTagStringUnder300Characters[]
@@ -807,8 +818,9 @@ export interface Wallet {
         | 'unsigned'
         | 'nosend'
         | 'nonfinal'
+        | 'failed'
       isOutgoing: boolean
-      description: DescriptionString5to50Characters
+      description: ActionDescriptionString5to2000Characters
       labels?: LabelStringUnder300Characters[]
       version: PositiveIntegerOrZero
       lockTime: PositiveIntegerOrZero
@@ -817,7 +829,7 @@ export interface Wallet {
         sourceSatoshis: SatoshiValue
         sourceLockingScript?: HexString
         unlockingScript?: HexString
-        inputDescription: DescriptionString5to50Characters
+        inputDescription: ActionDescriptionString5to2000Characters
         sequenceNumber: PositiveIntegerOrZero
       }>
       outputs?: Array<{
@@ -825,7 +837,7 @@ export interface Wallet {
         satoshis: SatoshiValue
         lockingScript?: HexString
         spendable: boolean
-        outputDescription: DescriptionString5to50Characters
+        outputDescription: ActionDescriptionString5to2000Characters
         basket: BasketStringUnder300Characters
         tags: OutputTagStringUnder300Characters[]
         customInstructions?: string
@@ -849,7 +861,7 @@ export interface Wallet {
    * @param {BasketStringUnder300Characters} args.outputs[].insertionRemittance.basket - Basket in which to place the output (for insertions).
    * @param {string} [args.outputs[].insertionRemittance.customInstructions] - Optionally provided custom instructions attached to the output (for insertions).
    * @param {OutputTagStringUnder300Characters[]} [args.outputs[].insertionRemittance.tags] - Tags attached to the output (for insertions).
-   * @param {DescriptionString5to50Characters} args.description - Human-readable description of the transaction being internalized.
+   * @param {ActionDescriptionString5to2000Characters} args.description - Human-readable description of the transaction being internalized.
    * @param {LabelStringUnder300Characters[]} [args.labels] - Optional labels associated with this transaction.
    * @param {BooleanDefaultTrue} [args.seekPermission] — Whether to seek permission from the user for this operation if required. Default true, will return an error rather than proceed if set to false.
    * @param {OriginatorDomainNameString} [originator] - Fully-qualified domain name (FQDN) of the application that originated the request.
@@ -872,7 +884,7 @@ export interface Wallet {
           tags?: OutputTagStringUnder300Characters[]
         }
       }>
-      description: DescriptionString5to50Characters
+      description: ActionDescriptionString5to2000Characters
       labels?: LabelStringUnder300Characters[]
       seekPermission?: BooleanDefaultTrue
     },
@@ -2540,7 +2552,9 @@ Implementers should carefully follow the serialization and deserialization rules
 
 **Derivation Prefix/Suffix**: Values used during the internalization of payment outputs, as described within [BRC-29](../payments/0029.md) to generate different key pairs for each output across the same payment.
 
-**DescriptionString5to50Characters**: A string data type used for descriptions within the Wallet Interface, constrained to a length between 5 and 50 characters.
+**ActionDescriptionString5to2000Characters**: A string data type used for action descriptions, input descriptions, output descriptions, and internalization descriptions within the Wallet Interface, constrained to a length between 5 and 2000 characters in current interoperable implementations.
+
+**DescriptionString5to50Characters**: A string data type used for short descriptions such as `privilegedReason`, constrained to a length between 5 and 50 characters.
 
 **Digital Signature**: A cryptographic value generated using a private key that verifies the authenticity and integrity of data, as outlined in [BRC-3](../wallet/0003.md) with ECDSA.
 

--- a/wallet/0100.md
+++ b/wallet/0100.md
@@ -722,8 +722,6 @@ export interface Wallet {
    * @param {Base64String} args.reference - Reference number returned from the call to `createAction`.
    * @param {Object} [args.options] - Optional settings modifying transaction processing behavior.
    * @param {BooleanDefaultTrue} [args.options.acceptDelayedBroadcast] - Optional. If true, transaction will be sent to the network by a background process; use `noSend` and `sendWith` options to batch chained transactions. If false, transaction will be broadcast to the network and any errors returned in result; note that rapidly sent chained transactions may still fail due to network propagation delays.
-   * @param {'known'} [args.options.trustSelf] - Optional. If `known`, input transactions may omit supporting validity proof data for TXIDs known to this wallet or included in `knownTxids`.
-   * @param {TXIDHexString[]} [args.options.knownTxids] - Optional. When working with large chained transactions using `noSend` and `sendWith` options, include TXIDs of inputs that may be assumed to be valid even if not already known by this wallet.
    * @param {BooleanDefaultFalse} [args.options.returnTXIDOnly] - Optional. If true, only a TXID will be returned instead of a transaction.
    * @param {BooleanDefaultFalse} [args.options.noSend] - Optional. If true, the transaction will be constructed but not sent to the network. Supports the creation of chained batches of transactions using the `sendWith` option.
    * @param {Array<TXIDHexString>} [args.options.sendWith] - Optional. Sends a batch of actions previously created as `noSend` actions to the network; either synchronously if `acceptDelayedBroadcast` is true or by a background process.
@@ -852,7 +850,7 @@ export interface Wallet {
    * @param {BEEF} args.tx - Atomic BEEF-formatted transaction to internalize.
    * @param {Array<Object>} args.outputs - Metadata about outputs, processed differently based on payment or insertion types.
    * @param {PositiveIntegerOrZero} args.outputs[].outputIndex - Index of the output within the transaction.
-   * @param {'payment' | 'insert'} args.outputs[].protocol - Specifies whether the output is a payment (to be received into the wallet balance) or an insert operation (into a particular basket).
+   * @param {'wallet payment' | 'basket insertion'} args.outputs[].protocol - Specifies whether the output is a payment (to be received into the wallet balance) or an insert operation (into a particular basket).
    * @param {Object} [args.outputs[].paymentRemittance] - Remittance data, structured accordingly for the payment operation.
    * @param {Base64String} args.outputs[].paymentRemittance.derivationPrefix - Payment-level derivation prefix used by the sender for key derivation (for payments).
    * @param {Base64String} args.outputs[].paymentRemittance.derivationSuffix - Specific output-level derivation suffix used by the sender for key derivation (for payments).
@@ -1369,7 +1367,7 @@ export interface Wallet {
    * @param {PubKeyHex} args.identityKey - Identity key used to filter and discover certificates.
    * @param {PositiveIntegerDefault10Max10000} [args.limit] - Maximum number of certificates to return in the response.
    * @param {PositiveIntegerOrZero} [args.offset] - Skip this number of records before starting to provide results.
-   * @param {BooleanDefaultTrue} [args.seekPermission] — Whether to seek permission from the user for this operation if required. Default true, will return an error rather than proceed if set to false.
+   * @param {BooleanDefaultFalse} [args.seekPermission] — Whether to seek permission from the user for this operation if required. Current SDK validation defaults this discovery flag to false, returning an error rather than prompting unless set to true.
    * @param {OriginatorDomainNameString} [originator] - Fully-qualified domain name (FQDN) of the application that originated the request.
    * @returns {Promise<Object>} The promise resolves to the list of certificates discovered or an error object.
    */
@@ -1378,7 +1376,7 @@ export interface Wallet {
       identityKey: PubKeyHex
       limit?: PositiveIntegerDefault10Max10000
       offset?: PositiveIntegerOrZero
-      seekPermission?: BooleanDefaultTrue
+      seekPermission?: BooleanDefaultFalse
     },
     originator?: OriginatorDomainNameString
   ) => Promise<{
@@ -1412,7 +1410,7 @@ export interface Wallet {
    * @param {Record<CertificateFieldNameUnder50Characters, string>} args.attributes - The attributes used to discover the certificates.
    * @param {PositiveIntegerDefault10Max10000} [args.limit] - Optional limit on the number of results returned.
    * @param {PositiveIntegerOrZero} [args.offset] - Starts retrieval of results after the specified number of records.
-   * @param {BooleanDefaultTrue} [args.seekPermission] — Whether to seek permission from the user for this operation if required. Default true, will return an error rather than proceed if set to false.
+   * @param {BooleanDefaultFalse} [args.seekPermission] — Whether to seek permission from the user for this operation if required. Current SDK validation defaults this discovery flag to false, returning an error rather than prompting unless set to true.
    * @param {OriginatorDomainNameString} [originator] - Fully-qualified domain name (FQDN) of the application that originated the request.
    * @returns {Promise<Object>} The promise resolves to a list of matching certificates or an error object.
    */
@@ -1421,7 +1419,7 @@ export interface Wallet {
       attributes: Record<CertificateFieldNameUnder50Characters, string>
       limit?: PositiveIntegerDefault10Max10000
       offset?: PositiveIntegerOrZero
-      seekPermission?: BooleanDefaultTrue
+      seekPermission?: BooleanDefaultFalse
     },
     originator?: OriginatorDomainNameString
   ) => Promise<{
@@ -2342,7 +2340,7 @@ Each certificate in the `certificates` array is serialized as:
 | `identityKey`    | **Byte Array (33 bytes)** | The identity key to search for certificates.                     |
 | `limit`          | **VarInt**                | Maximum number of certificates to return, `-1` if not provided.  |
 | `offset`         | **VarInt**                | Number of certificates to skip, `-1` if not provided.            |
-| `seekPermission` | Int8                      | `1` for `true` (default), `0` for `false`, `-1` if not provided. |
+| `seekPermission` | Int8                      | `1` for `true`, `0` for `false`, `-1` if not provided; current SDK validation defaults omitted discovery permission flags to false. |
 
 ##### Return Values
 
@@ -2383,7 +2381,7 @@ Each certificate includes:
 | `attributes`     | **VarInt Length + Map** | Map of `fieldName` to `fieldValue` strings (UTF-8).              |
 | `limit`          | **VarInt**              | Maximum number of certificates to return, `-1` if not provided.  |
 | `offset`         | **VarInt**              | Number of certificates to skip, `-1` if not provided.            |
-| `seekPermission` | Int8                    | `1` for `true` (default), `0` for `false`, `-1` if not provided. |
+| `seekPermission` | Int8                    | `1` for `true`, `0` for `false`, `-1` if not provided; current SDK validation defaults omitted discovery permission flags to false. |
 
 ##### Return Values
 

--- a/wallet/0100.md
+++ b/wallet/0100.md
@@ -886,13 +886,12 @@ export interface Wallet {
    * @param {BasketStringUnder300Characters} args.basket - The associated basket name whose outputs should be listed.
    * @param {OutputTagStringUnder300Characters[]} [args.tags] - Filter outputs based on these tags.
    * @param {'all' | 'any'} [args.tagQueryMode] - Filter mode, defining whether all or any of the tags must match. By default, any tag can match.
-   * @param {'locking scripts' | 'entire transactions'} [args.include] - Whether to include locking scripts (with each output) or entire transactions (as aggregated BEEF, at the top level) in the result. By default, unless specified, neither are returned.
-   * @param {BooleanDefaultFalse} [args.includeEntireTransactions] - Whether to include the entire transaction(s) in the result.
+   * @param {'locking scripts' | 'entire transactions'} [args.include] - Whether to include locking scripts with each output or an aggregated top-level BEEF spanning the returned outputs. By default, unless specified, neither are returned.
    * @param {BooleanDefaultFalse} [args.includeCustomInstructions] - Whether custom instructions should be returned in the result.
    * @param {BooleanDefaultFalse} [args.includeTags] - Whether the tags associated with the output should be returned.
    * @param {BooleanDefaultFalse} [args.includeLabels] - Whether the labels associated with the transaction containing the output should be returned.
    * @param {PositiveIntegerDefault10Max10000} [args.limit] - Optional limit on the number of outputs to return.
-   * @param {PositiveIntegerOrZero} [args.offset] - Number of outputs to skip before starting to return results.
+   * @param {number} [args.offset] - If positive or zero: number of outputs to skip before returning results, oldest first. If negative: outputs are returned newest first and `-1` denotes the newest output.
    * @param {OriginatorDomainNameString} [originator] - Fully-qualified domain name (FQDN) of the application that originated the request.
    * @param {BooleanDefaultTrue} [args.seekPermission] — Whether to seek permission from the user for this operation if required. Default true, will return an error rather than proceed if set to false.
    * @returns {Promise<Object>} The promise returns an output listing or an error object.
@@ -907,7 +906,7 @@ export interface Wallet {
       includeTags?: BooleanDefaultFalse
       includeLabels?: BooleanDefaultFalse
       limit?: PositiveIntegerDefault10Max10000
-      offset?: PositiveIntegerOrZero
+      offset?: number
       seekPermission?: BooleanDefaultTrue
     },
     originator?: OriginatorDomainNameString
@@ -930,7 +929,7 @@ export interface Wallet {
    *
    * @param {Object} args - Arguments identifying the output in the basket.
    * @param {BasketStringUnder300Characters} args.basket - The associated basket name where the output should be removed.
-   * @param {OutpointString} args.outpoint - The output that should be removed from the basket.
+   * @param {OutpointString} args.output - The output that should be removed from the basket.
    * @param {OriginatorDomainNameString} [originator] - Fully-qualified domain name (FQDN) of the application that originated the request.
    * @returns {Promise<Object>} The promise returns an indication of successful removal or an error object.
    */
@@ -1754,7 +1753,6 @@ Same as in the `createAction` method, but only applicable fields:
 | ----------------- | ------------------------------------------ | ----------------------------------------------------------------------------- |
 | `txid`            | **Int8 Flag + Byte Array (32 bytes)**      | If present, `1` followed by 32-byte TXID. Else, `0`.                          |
 | `tx`              | **Int8 Flag + VarInt Length + Byte Array** | If present, `1` followed by transaction data (AtomicBEEF). Else, `0`.         |
-| `noSendChange`    | **VarInt Length + Array**                  | Array of outpoints (optional). If absent, `VarInt` `-1`.                      |
 | `sendWithResults` | **VarInt Length + Array**                  | Array of structures containing `txid` and `status`. If absent, `VarInt` `-1`. |
 
 #### 3. `abortAction`
@@ -1828,6 +1826,7 @@ For each action:
 - `5`: `'unsigned'`
 - `6`: `'nosend'`
 - `7`: `'nonfinal'`
+- `8`: `'failed'`
 
 **Input Object:**
 
@@ -1919,7 +1918,7 @@ For each output:
 | `includeTags`               | Int8                  | Same as above.                                                                      |
 | `includeLabels`             | Int8                  | Same as above.                                                                      |
 | `limit`                     | VarInt                | Maximum number of outputs to return. Use `-1` if not provided.                      |
-| `offset`                    | VarInt                | Number of outputs to skip. Use `-1` if not provided.                                |
+| `offset`                    | Signed integer        | If positive or zero, skips outputs oldest-first. If negative, counts from the newest output where `-1` denotes the newest output. |
 | `seekPermission`            | Int8                  | `1` for `true` (default), `0` for `false`, `-1` if not provided.                    |
 
 ##### Return Values
@@ -1930,6 +1929,7 @@ For each output:
 | Field          | Type   | Description                                          |
 | -------------- | ------ | ---------------------------------------------------- |
 | `totalOutputs` | VarInt | Total number of outputs matching the query.          |
+| `BEEF`         | Byte Array (optional) | Present when `include` is `'entire transactions'`; aggregated BEEF spanning the returned outputs. |
 | `outputs`      | Array  | Serialized array of output objects (details follow). |
 
 **Output Object:**
@@ -1941,7 +1941,6 @@ For each output:
 | `outpoint`           | Byte Array                 | Outpoint (TXID + output index).                 |
 | `satoshis`           | VarInt                     | Amount in satoshis.                             |
 | `lockingScript`      | VarInt Length + Byte Array | Locking script (if included).                   |
-| `tx`                 | VarInt Length + Byte Array | Transaction data (if included).                 |
 | `spendable`          | Int8                       | Always `1` (indicates the output is spendable). |
 | `customInstructions` | UTF-8 String               | Custom instructions (if included).              |
 | `tags`               | VarInt Length + Array      | Array of tags (if included).                    |

--- a/wallet/0116.md
+++ b/wallet/0116.md
@@ -145,11 +145,17 @@ The manifest serves three purposes:
 }
 ```
 
-All fields under `metanet` are optional except `schemaVersion`. An application that declares no `metanet.groupPermissions` will simply be prompted individually at runtime for each capability it uses. An application that declares no `metanet.counterpartyPermissions` will never trigger a PACT prompt - Level 2 protocol requests will fall through to individual or grouped permission prompts instead.
+All fields under `metanet` are optional. New manifests SHOULD include `schemaVersion`. An application that declares no `metanet.groupPermissions` will simply be prompted individually at runtime for each capability it uses. An application that declares no `metanet.counterpartyPermissions` will never trigger a PACT prompt - Level 2 protocol requests will fall through to individual or grouped permission prompts instead.
 
 #### Schema Version
 
-The `metanet.schemaVersion` field is a required integer that identifies the version of the Metanet permission schema. Wallets MUST check this field and handle unknown versions gracefully (e.g. by ignoring the `metanet` block or warning the user). The current version is `1`.
+The `metanet.schemaVersion` field identifies the version of the Metanet permission schema. New manifests SHOULD provide it, and the current version is `1`.
+
+For interoperability with current wallet-toolbox behavior:
+
+- Wallets SHOULD tolerate manifests that omit `schemaVersion`.
+- Wallets SHOULD continue to support the legacy `babbage` namespace as described in the Backwards Compatibility section.
+- Wallets SHOULD handle unknown or unsupported schema versions gracefully (for example by ignoring the unsupported fields or warning the user).
 
 #### Group Permissions Declaration
 
@@ -185,7 +191,14 @@ The `metanet.counterpartyPermissions` object declares PACT requirements - the Le
 | `description` | string? | Human-readable description |
 | `protocols` | array | Array of `{ protocolName, description }` - required peer-interaction protocols, interpreted as **Level 2 only** |
 
-The wallet MUST enforce that all declared `counterpartyPermissions.protocols` entries include a non-empty `protocolName`. These entries are interpreted as Level 2 protocol declarations.
+The wallet MUST interpret `counterpartyPermissions` entries as Level 2 protocol declarations.
+
+For interoperability with current wallet-toolbox behavior, a declaration MAY identify the protocol either by:
+
+- a non-empty `protocolName`, or
+- a `protocolID` equal to `[2, "<name>"]`.
+
+Entries that do not resolve to a Level 2 protocol declaration MUST be ignored.
 These declarations define required Level 2 protocols, while the concrete counterparty is supplied at request time. Effective permission scope remains per-originator + per-counterparty.
 
 Including `counterpartyPermissions` tells the wallet: "when this app encounters a new (untrusted) counterparty, request trust for this declared protocol set before allowing peer interaction to proceed." Without it, each Level 2 protocol permission is requested individually as it's used.

--- a/wallet/README.md
+++ b/wallet/README.md
@@ -2,6 +2,13 @@
 
 This directory contains standards for controlling, interfacing with and extending Bitcoin wallets.
 
+Current orientation:
+
+- [BRC-100](./0100.md) is the main wallet-to-application interface specification.
+- [BRC-116](./0116.md) authoritatively specifies permission lifecycle behavior and manifest handling for current wallets.
+- [BRC-73](./0073.md) should be read as the grouped-permission declaration shape used by current wallets, alongside BRC-116.
+- [BRC-98](./0098.md), [BRC-99](./0099.md), [BRC-111](./0111.md), [BRC-112](./0112.md), and [BRC-114](./0114.md) are compatibility-oriented extensions around permission and query behavior.
+
 BRC | Standard
 -----|------------------
 1    | [Transaction Creation](./0001.md)


### PR DESCRIPTION
## Summary

This PR is a broad documentation/specification refresh for the BRC repository. The main goal is to reduce confusion between older historical BRC text and the behavior that implementers actually need for present BSV wallet, overlay, certificate, outpoint, payment, and storage interoperability.

The unusual part of this PR is that several existing specs are rewritten or substantially replaced rather than supplemented by new BRC numbers. That is intentional: in the affected areas, keeping obsolete wire formats and vague historical descriptions as the main text would make the repository harder to use. The updated documents preserve historical context where needed, but move the normative or guidance text toward the behavior used by the BRC-100 wallet interface, BEEF/Atomic BEEF transaction transport, Wallet Toolbox storage/sync models, and the SDK overlay/KV/certificate primitives.

## Why this is necessary

Many older BRCs were written around pre-BRC-100 assumptions, including BRC-8 transaction envelopes, mAPI-era response structures, Authrite-specific transport assumptions, older wallet route names, DPP/Paymail flows, and broad placeholders such as generic `spendingInstructions`. Since then, the repository has accumulated newer specifications around BRC-62/BRC-95 BEEF, BRC-100 wallet APIs, BRC-103/BRC-104 peer authentication, BRC-105/BRC-118/BRC-121 HTTP payments, BRC-116 permissions, and Wallet Toolbox storage.

Without this refresh, implementers have to infer which specs are historical, which specs remain normative, and which old fields have been superseded. This PR makes that orientation explicit. It also fills previously placeholder or unused BRC numbers where implementations already existed but a stable BRC document did not.

## Repository-level navigation changes

- Updates the root `README.md` and `SUMMARY.md` so BRC-35, BRC-38, BRC-39, and BRC-40 are linked as real specs rather than unused or placeholder entries.
- Adds an "Interpreting the Repository" section explaining that the repo contains both active interoperability specifications and historical design context.
- Updates category README files so implementers can see the intended current orientation for wallets, payments, overlays, outpoints, scripts, and apps.
- Fixes small index issues such as the `EXAMPLE.md` link, the `apps/README.md` typo, the scripts BRC-20 pointer, and the Paymail BEEF title.

## Outpoints and wallet data portability

### BRC-36: Format for Bitcoin Outpoints

BRC-36 is rewritten from a broad UTXO storage object based on BRC-8 envelopes, raw transactions, mAPI responses, and proof fields into a narrower portable outpoint object:

- `outpoint`
- `satoshis`
- optional `lockingScript`
- required Atomic BEEF `tx`

The rewrite clarifies that BRC-36 is about portable output facts, not wallet-internal state. Basket assignment, tags, custom metadata, spendability flags, and wallet storage bookkeeping are moved out of BRC-36 scope.

### BRC-37: Basket and Custom Instructions Extension

BRC-37 is rewritten from a generic `spendingInstructions` concept into a small BRC-36 extension for:

- `basket`
- optional `customInstructions`

The goal is to preserve the useful wallet basket/custom-instruction pattern without implying a universal spending-instruction schema. Basket-specific semantics remain defined by the basket or higher-level protocol.

### BRC-38: User Wallet Data Format

Adds a full plaintext export format for single-user Wallet Toolbox data. It defines:

- a canonical JSON document form
- export metadata
- table closure for user-scoped wallet data
- byte/string conversion rules
- decoded JSON handling for fields that are stored as JSON strings
- sorting rules for canonical serialization
- import and privacy requirements

This creates a stable single-user portability artifact for backups, migration, recovery, and data-access/export use cases.

### BRC-39: User Wallet Data Format Encryption Extension

Adds the encrypted wrapper for BRC-38 exports. It defines:

- conventional file name `wallet.brc39`
- binary `WDAT` envelope
- Argon2id password KDF profile
- AES-256-GCM content encryption
- password normalization
- header validation
- import/export procedures

This deliberately avoids `wallet.dat` to prevent confusion with historical wallet file names.

### BRC-40: User Wallet Data Synchronization

Adds the chunked, resumable wallet storage synchronization model used by Wallet Toolbox-style storage providers. It standardizes:

- producer/consumer roles
- per-entity offsets
- inclusive `since` semantics
- entity ordering
- durable sync state
- remote-to-local ID mapping
- completion detection
- authentication/authorization expectations

This gives storage backends a shared sync model without requiring proprietary adapters.

## Overlay and KV-store updates

### BRC-35: Layered Key-Value Store for Wallets and Overlay Services

Adds a complete KVStore BRC for behavior that previously existed mostly in SDK code and tests. It defines two profiles:

- Global KVStore: public overlay-tracked PushDrop KV tokens using `ls_kvstore` and `tm_kvstore`.
- Local KVStore: wallet-local basket/tag-backed KV persistence using existing BRC-100 wallet methods.

The spec covers token lifecycle, tuple identity, PushDrop field ordering, signature payload rules, controller semantics, lookup query structure, history expectations, local encrypted/plaintext profiles, duplicate-state collapse, corrupted-state handling, and what is SDK convenience versus normative protocol surface.

### BRC-22 and BRC-24

Updates overlay submission and lookup specs away from older Authrite/BRC-8 JSON assumptions and toward the BEEF-based overlay framing used by SHIP/SLAP-style implementations:

- `/submit` accepts BEEF bytes with `X-Topics`.
- submission responses return per-topic admittance instructions.
- `/lookup` accepts `{ service, query }`.
- lookup responses use `output-list` answers with BEEF-backed output data.
- older provider/BRC-36 hydrated response framing is marked historical/deprecated for new implementations.

### Other overlay specs

Adds status and compatibility notes across BRC-23, BRC-25, BRC-26, BRC-64, BRC-88, and BRC-101 to align terminology around topic managers, lookup services, retained history, SHIP/SLAP conventions, local-development URLs, and extension boundaries.

## Certificate and peer-to-peer updates

### BRC-52: Identity Certificates

Substantially rewrites BRC-52 as the authoritative certificate primitive spec for BRC-100, BRC-103, and BRC-104 behavior. It covers:

- core certificate JSON fields
- canonical binary certificate serialization
- signature preimage rules
- certifier signature parameters
- certificate field encryption
- master keyrings
- verifier keyrings
- revocation outpoints
- direct acquisition and issuance acquisition
- selective revelation/prove flows
- storage and security considerations

The implementation basis is described in terms of SDK/Wallet Toolbox behavior without pinning quickly-stale commits or package versions.

### BRC-31, BRC-33, BRC-103, and BRC-104

Adds status/orientation edits around Authrite-era behavior and newer peer authentication/HTTP transport expectations. The intent is to keep historical context while making clear which newer specs define the active authentication model.

## Payment updates

### BRC-29

Updates BRC-29 from a BRC-8 transaction-envelope payment message toward BRC-100 construction/internalization and BEEF/Atomic BEEF transport. It adds:

- BRC-100 payment construction guidance
- `createAction` output guidance
- `customInstructions` remittance guidance
- Atomic BEEF transport framing
- `internalizeAction` example using `wallet payment`
- a clearly marked legacy JSON envelope section

### DPP, Paymail, PacketPay, and 402 payment orientation

Adds status notes to BRC-27, BRC-28, BRC-41, BRC-54, BRC-55, BRC-70, BRC-105, and BRC-121 to separate older or external payment protocols from the current BRC-100/BRC-29/BRC-105/BRC-118/BRC-121 payment flow used by newer wallet integrations.

The payments README now gives maintainers and implementers a high-level map:

- BRC-105 is the main BSV-native HTTP monetization framework in this repo.
- BRC-118 extends BRC-105 with multipart transport.
- BRC-120 points to the frozen external x402 v1.0 specification.
- BRC-121 defines a smaller BSV-specific 402 payment profile.
- HTTP 402 remains a reserved RFC 9110 status code that these BRCs layer ecosystem conventions on top of.

## Wallet interface and permission updates

### BRC-5, BRC-56, and legacy substrates

Updates older wallet communication specs to mark pre-BRC-100 localhost routes and legacy abstract method names as historical. The updated text points implementers toward BRC-100 method names and current HTTP/window/XDM-style substrates without implying `/v1` legacy routes are required.

### BRC-46 and BRC-65

Rewrites/updates wallet basket and label behavior to reflect BRC-100 output basket and action label semantics:

- basket names as wallet-managed output sets
- lowercasing/normalization guidance
- BRC-100 `listOutputs` interaction
- output tags versus transaction labels
- reserved `p ` namespaces
- deprecated older query fields and response models

### BRC-73 and BRC-116

Clarifies grouped-permission manifests and permission lifecycle behavior:

- `metanet.groupPermissions` is the canonical namespace.
- `babbage.groupPermissions` remains a backwards-compatibility fallback.
- BRC-116 is the authority for runtime permission lifecycle, manifest handling, renewal, revocation, PACT, and permission-token behavior.
- `schemaVersion` and counterparty permission declarations are made tolerant enough for Wallet Toolbox interoperability.

### BRC-100

Updates BRC-100 details to better match the wallet interface behavior implementers see:

- action/input/output/internalization descriptions use the wider transaction-facing description range
- BEEF/Atomic BEEF may be byte arrays or `Uint8Array`
- `createAction` can be used for no-send, chained-send, batching, and change-remixing flows
- `internalizeAction` protocol strings are `wallet payment` and `basket insertion`
- `listOutputs.include = 'entire transactions'` returns an aggregated top-level BEEF
- `listOutputs.offset` supports negative newest-first semantics
- `relinquishOutput` uses `output`
- certificate discovery defaults are clarified
- `failed` is added as an action status
- obsolete `trustSelf`, `knownTxids`, per-output transaction return, and `noSendChange` binary field assumptions are removed or narrowed

## Transaction spec notes

Adds status notes to BRC-8, BRC-9, and BRC-76 so implementers understand how those historical transaction formats relate to newer BEEF/SPV and graph-aware sync behavior. This is not meant to erase historical specs; it is meant to stop implementers from treating older envelopes as the active wallet transport surface where newer BRCs supersede them.

## Scope and non-goals

This PR does not introduce executable code. It does not change any implementation packages directly. It also does not attempt to make every historical BRC active or fully modern. The focus is documentation accuracy, repository navigation, and reducing implementation ambiguity.

Where older specs remain useful for legacy interoperability, the PR generally keeps them and adds status notes. Where older text was actively misleading for current implementers, the PR replaces or rewrites it so the canonical document is easier to follow.

## Review notes for maintainers

Areas that deserve especially careful maintainer review:

- Whether BRC-36 should require Atomic BEEF for portable outpoint exchange.
- Whether BRC-37 is scoped correctly around basket/custom-instruction metadata.
- Whether BRC-38/BRC-39/BRC-40 are acceptable as replacements for prior placeholder wallet data/export/sync entries.
- Whether BRC-35 captures the intended boundary between SDK convenience and protocol-level KVStore behavior.
- Whether BRC-52 should be the authoritative certificate primitive spec for BRC-100/BRC-103/BRC-104.
- Whether the payment README orientation correctly describes BRC-105, BRC-118, BRC-120, and BRC-121 without overstating deprecation of still-useful external protocols.
- Whether BRC-100 wording should be treated as correction of the existing spec or split into later compatibility notes.

## Validation

- `git diff --check` passes.
- Verified local Markdown links in changed Markdown files resolve.
- Reviewed the branch against `master` and addressed follow-up review findings about stale implementation anchors and the ambiguous `wallet.dat` filename.

No automated test suite was run because this PR changes documentation/specification Markdown only.