### PR TITLE
BRC-12 wire format details

### DIFF
--- a/transactions/0012.md
+++ b/transactions/0012.md
@@ -40,3 +40,70 @@ The script fields in the input and output objects are interpreted as bytecode fo
 
 The transaction hash (referred to as the "TXID") is calculated by taking the double-SHA256 hash of the entire transaction. This hash is used as a unique identifier for the transaction on the Bitcoin network.
 
+## Wire Frame Format
+
+Raw transactions are transported over the network inside a frame envelope. The frame consists of a fixed-size header followed by the raw transaction payload described above. All multi-byte integers in the header are big-endian.
+
+### Frame Header (44 bytes)
+
+```text
+| Offset | Size | Field            | Value / Notes                                    |
+|--------|------|------------------|--------------------------------------------------|
+| 0      | 4    | Network Magic    | `0xE3E1F3E8` (BSV mainnet P2P magic)            |
+| 4      | 2    | Protocol Version | `0x02BF` (703, BSV large-block baseline)        |
+| 6      | 1    | Frame Version    | `0x01` (BRC-12 legacy)                          |
+| 7      | 1    | Reserved         | Must be `0x00`                                  |
+| 8      | 32   | Transaction ID   | Raw 256-bit TXID in internal byte order         |
+| 40     | 4    | Payload Length   | `uint32` BE; byte count of payload that follows |
+| 44     | *    | Payload          | Raw serialized transaction (this specification) |
+```
+
+Total header size: **44 bytes**.
+
+### Field Definitions
+
+#### Network Magic (bytes 0–3)
+
+The value `0xE3E1F3E8`, the BSV mainnet P2P network magic. This allows standard BSV firewall rules and network monitoring tools to classify frames correctly. Receivers must reject frames with any other value.
+
+#### Protocol Version (bytes 4–5)
+
+The value `0x02BF` (703 decimal), the BSV node protocol version that introduced the large-block policy. This field is informational; receivers do not validate it.
+
+#### Frame Version (byte 6)
+
+The value `0x01` for frames following this specification. Receivers must reject frames with unknown version bytes.
+
+#### Reserved (byte 7)
+
+Must be `0x00`. Reserved for future protocol extensions.
+
+#### Transaction ID (bytes 8–39)
+
+The 32-byte transaction hash in **internal byte order** as used in the BSV P2P protocol. This is the byte-reversed form of the display TXID shown by block explorers.
+
+#### Payload Length (bytes 40–43)
+
+A 32-bit unsigned integer (big-endian) specifying the number of bytes in the payload immediately following the header.
+
+#### Payload (byte 44 onward)
+
+The raw serialized BSV transaction as defined in the Specification section above.
+
+### Example Frame Hex Dump
+
+A BRC-12 frame carrying a 200-byte transaction:
+
+```text
+// Header (44 bytes)
+E3E1F3E8                                                          // Network Magic
+02BF                                                              // Protocol Version
+01                                                                // Frame Version (0x01 = BRC-12)
+00                                                                // Reserved
+11c6900eee6e68d191cd25034a5f872ed29e3b69273906a10e021f39ed866471  // Transaction ID
+000000C8                                                          // Payload Length (200)
+
+// Payload (200 bytes of raw transaction data)
+0200000001...00000000
+```
+

--- a/transactions/0012.md
+++ b/transactions/0012.md
@@ -46,17 +46,15 @@ Raw transactions are transported over the network inside a frame envelope. The f
 
 ### Frame Header (44 bytes)
 
-```text
-| Offset | Size | Field            | Value / Notes                                    |
-|--------|------|------------------|--------------------------------------------------|
+| Offset | Size | Field            | Value / Notes                                   |
+| ------ | ---- | ---------------- | ----------------------------------------------- |
 | 0      | 4    | Network Magic    | `0xE3E1F3E8` (BSV mainnet P2P magic)            |
 | 4      | 2    | Protocol Version | `0x02BF` (703, BSV large-block baseline)        |
 | 6      | 1    | Frame Version    | `0x01` (BRC-12 legacy)                          |
 | 7      | 1    | Reserved         | Must be `0x00`                                  |
 | 8      | 32   | Transaction ID   | Raw 256-bit TXID in internal byte order         |
 | 40     | 4    | Payload Length   | `uint32` BE; byte count of payload that follows |
-| 44     | *    | Payload          | Raw serialized transaction (this specification) |
-```
+| 44     | \*   | Payload          | Raw serialized transaction (this specification) |
 
 Total header size: **44 bytes**.
 
@@ -106,4 +104,3 @@ E3E1F3E8                                                          // Network Mag
 // Payload (200 bytes of raw transaction data)
 0200000001...00000000
 ```
-


### PR DESCRIPTION
### This pull request:

Amends or corrects an existing standard, without the need for creating a new one

### Summary

This PR adds missing details about the wire format, or network header used to carry BRC-12 transaction payload data. It does not change the previous spec, but adds additional detail as used by node software and other applications.
