### PR TITLE
BRC-126: Multicast NACK Retransmission Protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,6 @@ We look forward to your contributions and helping to create a world where transa
 
 Read more about areas of interest on [OpenStandards.cash](https://openstandards.cash)
 
-## Current implementation map
-
-The standards in this repository are vendor-neutral. Current BSV Association reference implementations include:
-
-- `@bsv/sdk` for TypeScript SDK primitives, transactions, identities, overlays, storage, and the BRC-100 `WalletClient` interface.
-- `@bsv/wallet-toolbox` for BRC-100 wallet storage, services, signing, monitoring, and wallet implementation tooling.
-- BSV Desktop and BSV Browser as BSV Association reference wallet/browser applications for the BRC-100 interface.
-- Overlay service implementations in `bsv-blockchain/overlay-services`, `bsv-blockchain/overlay-express`, and related overlay example repositories.
-
-Vendor distributions can implement the same standards with their own branding and hosted service defaults. Examples include Babbage's Metanet Desktop / Metanet Explorer as well as the Hudos Browser built by Matt Archbold.
-
 ## Structure
 
 The BRCs repository is organized into directories, each representing a different category of proposal. Categories may include, but are not limited to:
@@ -179,6 +168,7 @@ BRC | Standard
 119  | [SubTree Unified Merkle Path (STUMP) Format](./transactions/0119.md)
 120  | [x402 Stateless Settlement-Gated HTTP Protocol](./payments/0120.md)
 121  | [Simple 402 Payments](./payments/0121.md)
+122  | [Raw Multicast Transaction Format](./transactions/0122.md)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ BRC | Standard
 123  | [Basket Identifier Namespace Framework](./wallet/0123.md)
 124  | [Multicast Transaction Frame Format](./transactions/0124.md)
 125  | [PeerPay URI Scheme for BRC-29 Payments](./payments/0125.md)
+126  | [BSV Multicast NACK Retransmission Protocol](./transactions/0126.md)
 
 ## License
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -61,6 +61,7 @@
 * [BEEF V2 Txid Only Extension](./transactions/0096.md)
 * [SubTree Unified Merkle Path (STUMP) Format](./transactions/0119.md)
 * [Multicast Transaction Frame Format](./transactions/0124.md)
+* [BSV Multicast NACK Retransmission Protocol](./transactions/0126.md)
 
 ## Scripts
 

--- a/transactions/0122.md
+++ b/transactions/0122.md
@@ -1,0 +1,228 @@
+# BRC-122: BSV Multicast Transaction Frame Format
+
+Jeff Harris (jeff@lightweb.net)
+
+## Abstract
+
+This BRC specifies the wire format for transporting BSV transactions over IPv6 multicast and TCP/UDP unicast. The format extends the legacy BRC-12 frame with additional fields for sequence tracking, subtree identification, and sender attribution. All fields are 8-byte aligned for efficient memory access on 64-bit architectures.
+
+## Copyright
+
+This BRC is licensed under the Open BSV License.
+
+## Motivation
+
+As BSV transaction throughput scales to billions of transactions per second, efficient distribution infrastructure becomes critical. IPv6 multicast provides a scalable one-to-many transport mechanism, but globally scalable transaction distribution requires:
+
+1. **Deterministic sharding** — routing transactions to specific multicast groups based on transaction ID
+2. **Sequence tracking** — detecting and recovering from frame loss via NACK-based retransmission
+3. **Subtree identification** — filtering batches of related transactions at the network layer
+4. **Sender attribution** — identifying the original sender for per-sender gap tracking
+
+This frame format addresses these requirements while maintaining compatibility with the existing BRC-12 transaction payload format. It uses a 92-byte header that provides the metadata necessary for high-throughput multicast distribution with best-effort reliability, complementing the legacy 44-byte header defined in BRC-12.
+
+## Specification
+
+### Frame Structure Overview
+
+A frame consists of a 92-byte header followed by a variable-length payload containing a BRC-12 raw transaction. All multi-byte integers are big-endian. Fields at offsets 8, 48, 56, and 88 are 8-byte aligned; other fields maintain 4-byte alignment or natural alignment.
+
+### Header Format (92 bytes)
+
+```text
+| Offset | Size | Alignment | Field                 | Description                                    |
+|--------|------|-----------|-----------------------|------------------------------------------------|
+| 0      | 4    | —         | Network Magic         | `0xE3E1F3E8` (BSV mainnet P2P magic)           |
+| 4      | 2    | —         | Protocol Version      | `0x02BF` (703, BSV large-block baseline)       |
+| 6      | 1    | —         | Frame Version         | `0x02`                                         |
+| 7      | 1    | —         | Reserved              | Must be `0x00`                                 |
+| 8      | 32   | 8-byte    | Transaction ID        | Raw 256-bit TXID (internal byte order)         |
+| 40     | 4    | 8-byte    | Sender ID             | CRC32c of source IPv6 address; `0` = unset     |
+| 44     | 4    | —         | Sequence ID           | Random temporal flow identifier; `0` = unset   |
+| 48     | 4    | 8-byte    | Sequence Number       | Monotonic sender counter; `0` = unset          |
+| 52     | 4    | —         | Reserved              | Must be `0x00`                                 |
+| 56     | 32   | 8-byte    | Subtree ID            | 32-byte batch identifier; zeros = unset        |
+| 88     | 4    | 8-byte    | Payload Length        | `uint32` BE                                    |
+| 92     | *    | —         | Payload               | BRC-12 raw transaction bytes                   |
+```
+
+### Field Definitions
+
+#### Network Magic (bytes 0–3)
+
+The value `0xE3E1F3E8` (BSV mainnet P2P network magic). This enables standard BSV firewall rules and network monitoring tools to correctly classify shard frames. Frames with incorrect magic are rejected.
+
+#### Protocol Version (bytes 4–5)
+
+The value `0x02BF` (703 in decimal), representing the BSV node protocol version that introduced the large-block policy. This field is informational; receivers do not validate it.
+
+#### Frame Version (byte 6)
+
+The value `0x02` for frames following this specification. The legacy format defined in BRC-12 uses `0x01` (see Compatibility section). Any other value causes the frame to be rejected.
+
+#### Reserved (byte 7)
+
+Must be `0x00`. Reserved for future protocol extensions.
+
+#### Transaction ID (bytes 8–39)
+
+The 32-byte transaction hash in internal byte order (as used in BSV P2P protocol), **not** the reversed display order used by block explorers.
+
+#### Sender ID (bytes 40–43)
+
+A 32-bit CRC32c checksum of the source IPv6 address, computed using the Castagnoli polynomial (0x1EDC6F41). The checksum enables per-sender gap tracking and retransmission request routing while minimizing header overhead.
+
+**Computation:**
+```
+senderID = CRC32c(ipv6AddressBytes)
+```
+
+Where `ipv6AddressBytes` is the 16-byte IPv6 address in `net.IP.To16()` format:
+- Native IPv6 sources: the 16-byte IPv6 address
+- IPv4 sources: IPv4-mapped IPv6 address (`::ffff:a.b.c.d`)
+
+This field is stamped in-place by senders, ingress proxies, or retry endpoints before forwarding. A value of `0` indicates the field is unset.
+
+**Collision Risk:** With 4 bytes (32 bits), the probability of collision among *n* senders is approximately *n²/2³³*. Given BSV's mining economics (10-minute block interval, difficulty retargeting), the network supports at most ~1,000 concurrent miners, with 12–20 core transaction processor nodes handling the majority of traffic. At 1,000 senders, collision probability is ~0.01% (1 in 10,000); at 100 senders, it is negligible (~0.0001%). Operators should use per-sender Sequence ID spaces to further disambiguate transaction flows.
+
+#### Sequence ID (bytes 44–47)
+
+A 32-bit unsigned integer (big-endian) containing a random temporal flow identifier assigned by the sender. Combined with Sender ID and Sequence Number, it uniquely identifies a sequenced flow for retransmission requests. Senders reset this value periodically (e.g., every ~4 million frames or ~10 minutes). All-zero bytes indicate the field is unset.
+
+#### Sequence Number (bytes 48–51)
+
+A 32-bit unsigned integer (big-endian) containing a monotonic counter assigned by the sender. Increments by 1 for each frame in a flow, wrapping at 2³²−1 (4,294,967,295). Used by receivers to detect gaps and trigger NACK-based retransmission. A value of `0` indicates the field is unset.
+
+#### Reserved/Padding (bytes 52–55)
+
+Must be `0x00000000`. Reserved for future protocol extensions. Provides 8-byte alignment for Subtree ID field.
+
+#### Subtree ID (bytes 56–87)
+
+A 32-byte opaque batch identifier. A subtree is an ordered set of related transactions sharing a common batch context. This field enables downstream subscribers to filter frames by batch at the application layer. All-zero bytes indicate the field is unset.
+
+#### Payload Length (bytes 88–91)
+
+A 32-bit unsigned integer (big-endian) specifying the number of payload bytes immediately following the header. It is up to the application to determine the maximum allowed payload size.
+
+#### Payload (byte 92 onward)
+
+Raw serialized BSV transaction in BRC-12 format: version (4 bytes LE) + input vector + output vector + locktime (4 bytes LE). No additional envelope wraps the transaction.
+
+### Alignment Verification
+
+```text
+| Field                 | Offset | Offset % 8 |
+|-----------------------|--------|------------|
+| Transaction ID        | 8      | 0 ✓        |
+| Sender ID             | 40     | 0 ✓        |
+| Sequence ID           | 44     | 4          |
+| Sequence Number       | 48     | 0 ✓        |
+| (Reserved/Padding)    | 52     | 4          |
+| Subtree ID            | 56     | 0 ✓        |
+| Payload Length        | 88     | 0 ✓        |
+```
+
+### Compatibility with BRC-12 Legacy Format
+
+Legacy BRC-12 frames (Frame Version `0x01`) use a 44-byte header with no sequence or subtree fields:
+
+```text
+| Offset | Size | Field                           |
+|--------|------|---------------------------------|
+| 0      | 4    | Network Magic                   |
+| 4      | 2    | Protocol Version                |
+| 6      | 1    | Frame Version (`0x01` = legacy) |
+| 7      | 1    | Reserved                        |
+| 8      | 32   | Transaction ID                  |
+| 40     | 4    | Payload Length                  |
+| 44     | *    | Payload                         |
+```
+
+### TCP Transport
+
+When transported over TCP, frames are concatenated end-to-end with no additional envelope. The reader:
+
+1. Reads 44 bytes (sufficient for legacy header or BRC-122 header start)
+2. Inspects byte 6 (Frame Version)
+   - **Version 0x01 (legacy):** header complete; read `PayLen` at bytes 40–43
+   - **Version 0x02 (BRC-122):** read 48 more bytes; read `PayLen` at bytes 88–91
+3. Reads exactly `PayLen` bytes
+4. Processes the complete frame
+
+### Error Handling
+
+```text
+| Condition                | UDP Behavior  | TCP Behavior      |
+|--------------------------|---------------|-------------------|
+| Bad magic                | Silent drop   | Connection closed |
+| Unknown frame version    | Silent drop   | Connection closed |
+| Payload length too large | Silent drop   | Connection closed |
+| Truncated datagram       | Silent drop   | Connection closed |
+```
+
+## Examples
+
+### BRC-122 Frame Hex Dump
+
+A frame following this specification carrying a 200-byte transaction:
+
+```text
+// Header (92 bytes)
+E3E1F3E8                                                          // Network Magic
+02BF                                                              // Protocol Version
+02                                                                // Frame Version
+00                                                                // Reserved
+11c6900eee6e68d191cd25034a5f872ed29e3b69273906a10e021f39ed866471  // TXID
+A1B2C3D4                                                          // Sender ID (CRC32c of IPv6)
+00000001                                                          // Sequence ID (flow identifier)
+000004D2                                                          // Sequence Number (1234)
+00000000                                                          // Reserved/Padding
+baadf498a00ca5a44d1c4d9d103b49017f53cd8cb2a70a9c67fc884ecdd622b5  // Subtree ID
+000000C8                                                          // Payload Length (200)
+
+// Payload (200 bytes of BRC-12 transaction data)
+0200000001...00000000
+```
+
+### Legacy Frame Hex Dump
+
+The same transaction in legacy (BRC-12) format:
+
+```text
+// Header (44 bytes)
+E3E1F3E8                                                          // Network Magic
+02BF                                                              // Protocol Version
+01                                                                // Frame Version (0x01 = legacy)
+00                                                                // Reserved
+11c6900eee6e68d191cd25034a5f872ed29e3b69273906a10e021f39ed866471  // TXID
+000000C8                                                          // Payload Length (200)
+
+// Payload (200 bytes)
+0200000001...00000000
+```
+
+## References
+
+- [BRC-12: Raw Transaction Format](./0012.md) — Payload format for transaction data
+- [BRC-74: BSV Unified Merkle Path (BUMP) Format](./0074.md) — Merkle proof format used for transaction verification
+- [BRC-119: SubTree Unified Merkle Path (STUMP) Format](./0119.md) — Defines the Subtree ID concept referenced in this frame format
+- [bitcoin-shard-common](https://github.com/lightwebinc/bitcoin-shard-common) — Reference implementation (Go)
+
+## Constants Reference
+
+```text
+| Name               | Value      | Hex          | Description                   |
+|--------------------|------------|--------------|-------------------------------|
+| `MagicBSV`         | 3811983336 | `0xE3E1F3E8` | BSV mainnet P2P magic         |
+| `ProtoVer`         | 703        | `0x02BF`     | Protocol version              |
+| `FrameVerLegacy`   | 1          | `0x01`       | Legacy BRC-12 frame version   |
+| `FrameVerBRC122`   | 2          | `0x02`       | Current BRC-122 frame version |
+| `HeaderSizeLegacy` | 44         | `0x2C`       | Legacy header size in bytes   |
+| `HeaderSize`       | 92         | `0x5C`       | BRC-122 header size in bytes  |
+```
+
+## Implementations
+
+- **Go**: [bitcoin-shard-common/frame](https://github.com/lightwebinc/bitcoin-shard-common/tree/main/frame) — `Encode()`, `Decode()`, wire constants
+- **Services**: [bitcoin-shard-proxy](https://github.com/lightwebinc/bitcoin-shard-proxy), [bitcoin-shard-listener](https://github.com/lightwebinc/bitcoin-shard-listener) — Network multicast infrastructure

--- a/transactions/0126.md
+++ b/transactions/0126.md
@@ -1,0 +1,345 @@
+# BRC-126: BSV Multicast NACK Retransmission Protocol
+
+Jeff Harris (jeff@lightweb.net)
+
+## Abstract
+
+This BRC specifies the NACK-based retransmission and endpoint discovery protocol for the BSV multicast transaction distribution pipeline. It defines four UDP datagram formats — ADVERT, NACK, MISS, and ACK — along with tier/preference-based endpoint selection, an escalation state machine, and configurable retransmit modes. The protocol operates on top of the BRC-124 data-plane and enables reliable gap recovery without requiring connection state at the ingress or listener tiers.
+
+## Copyright
+
+This BRC is licensed under the Open BSV License.
+
+## Motivation
+
+The BRC-124 data-plane delivers BSV transactions over IPv6 multicast with best-effort semantics. Network congestion, interface buffer overflows, and MLD snooping transitions can cause individual frames to be lost. Because BRC-124 frames carry a `PrevSeq`/`CurSeq` XXH64 hash chain stamped by the ingress proxy, listeners can detect exactly which frame is missing without a central sequence authority.
+
+This BRC adds the reliability layer that allows listeners to recover those gaps:
+
+1. **Gap detection** — listeners identify missing frames via hash-chain breaks (`PrevSeq ≠ lastCurSeq`).
+2. **NACK dispatch** — listeners send a 24-byte NACK datagram to a retry endpoint requesting the missing frame by its hash-chain identifier.
+3. **ACK/MISS responses** — every NACK receives a deterministic 16-byte response; ACK confirms retransmit dispatched, MISS triggers immediate escalation.
+4. **Endpoint discovery** — retry endpoints periodically multicast a 56-byte ADVERT beacon; listeners maintain a dynamic registry sorted by tier and preference, with no manual configuration required in well-connected deployments.
+5. **Flood prevention** — deduplication and fill-suppression mechanisms prevent retransmit storms at scale.
+
+## Specification
+
+### Common Message Preamble
+
+All BRC-126 datagrams begin with a 7-byte preamble:
+
+| Offset | Size | Field         | Description                              |
+| ------ | ---- | ------------- | ---------------------------------------- |
+| 0      | 4    | Network Magic | `0xE3E1F3E8` (BSV mainnet P2P magic)     |
+| 4      | 2    | Protocol Ver  | `0x02BF` (703, BSV large-block baseline) |
+| 6      | 1    | MsgType       | Identifies the message type (see below)  |
+
+The `MsgType` byte at offset 6 is in the same position as `FrameVersion` in BRC-124 data frames. Values `0x10`–`0x2F` are reserved for BRC-126 control messages and are distinct from the data-frame version codes (`0x01`, `0x02`).
+
+### MsgType Values
+
+| MsgType | Name   | Size | Direction                     |
+| ------- | ------ | ---- | ----------------------------- |
+| `0x10`  | NACK   | 24 B | Listener → Retry endpoint     |
+| `0x11`  | MISS   | 16 B | Retry endpoint → Listener     |
+| `0x12`  | ACK    | 16 B | Retry endpoint → Listener     |
+| `0x20`  | ADVERT | 56 B | Retry endpoint → Beacon group |
+
+---
+
+### ADVERT Wire Format (`MsgType 0x20`) — 56 bytes
+
+Sent periodically by retry endpoints to the beacon multicast group. Listeners use it to build and maintain their endpoint registry.
+
+| Offset | Size | Field          | Description                                                   |
+| ------ | ---- | -------------- | ------------------------------------------------------------- |
+| 0      | 4    | Network Magic  | `0xE3E1F3E8`                                                  |
+| 4      | 2    | Protocol Ver   | `0x02BF`                                                      |
+| 6      | 1    | MsgType        | `0x20` (ADVERT)                                               |
+| 7      | 1    | Scope          | `0x05` = site-local, `0x08` = org, `0x0E` = global            |
+| 8      | 16   | NACKAddr       | IPv6 unicast address listeners use for NACK requests          |
+| 24     | 2    | NACKPort       | UDP port for NACK requests (default `9300`)                   |
+| 26     | 1    | Tier           | Operator-assigned proximity tier; `0` = source-adjacent       |
+| 27     | 1    | Preference     | Within-tier priority; higher = more preferred (default `128`) |
+| 28     | 2    | BeaconInterval | Beacon send interval in seconds; listeners TTL = `3 × this`   |
+| 30     | 2    | Flags          | Capability bitmask (see below)                                |
+| 32     | 4    | InstanceID     | CRC32c of hostname; matches metrics `instance` label          |
+| 36     | 4    | Reserved       | Must be `0x00000000`                                          |
+| 40     | 16   | Reserved       | Must be all zeros; reserved for future capability bitmap      |
+
+#### ADVERT Flags Bitmask
+
+| Bit    | Name                | Meaning                                                    |
+| ------ | ------------------- | ---------------------------------------------------------- |
+| `0x01` | _(reserved)_        | Unused; must be zero                                       |
+| `0x02` | HasParent           | Endpoint forwards cache-miss NACKs to an upstream endpoint |
+| `0x04` | Draining            | Entering shutdown; listeners should stop routing new NACKs |
+| `0x08` | UnicastRetransmit   | Supports unicast frame delivery to the NACK source         |
+| `0x10` | MulticastRetransmit | Retransmits via multicast to the original shard group      |
+
+**HasParent:** When set, the endpoint maintains a connection to a parent (higher-tier) endpoint and forwards NACKs on local cache miss. Listeners need only know their local tier; inter-tier forwarding is handled transparently.
+
+**Beacon group addresses** are derived from the shard address scheme using the reserved control-plane index `0xFFFFFD`:
+
+| Scope           | Beacon Group (no middle bytes) |
+| --------------- | ------------------------------ |
+| Site (`0x05`)   | `FF05::FF:FFFD`                |
+| Org (`0x08`)    | `FF08::FF:FFFD`                |
+| Global (`0x0E`) | `FF0E::FF:FFFD`                |
+
+When `-mc-base-addr` middle bytes are configured, those bytes are interleaved at positions 2–12 of the IPv6 address identically to data-plane shard groups.
+
+---
+
+### NACK Wire Format (`MsgType 0x10`) — 24 bytes
+
+Sent by a listener to a retry endpoint when a gap is detected. Requests a specific frame by its BRC-124 `CurSeq` value (backward lookup) or by its `PrevSeq` value (forward lookup).
+
+| Offset | Size | Field      | Description                                                                |
+| ------ | ---- | ---------- | -------------------------------------------------------------------------- |
+| 0      | 4    | Magic      | `0xE3E1F3E8`                                                               |
+| 4      | 2    | ProtoVer   | `0x02BF`                                                                   |
+| 6      | 1    | MsgType    | `0x10` (NACK)                                                              |
+| 7      | 1    | LookupType | `0x00` = by PrevSeq (forward lookup); `0x01` = by CurSeq (backward lookup) |
+| 8      | 8    | LookupSeq  | XXH64 value identifying the missing frame                                  |
+| 16     | 8    | Reserved   | Must be `0x0000000000000000`                                               |
+
+**LookupType semantics:**
+
+| LookupType | Cache Key Used             | Use Case                                          |
+| ---------- | -------------------------- | ------------------------------------------------- |
+| `0x00`     | `PrevSeq` of missing frame | Forward lookup: "I have frame N; what is N+1?"    |
+| `0x01`     | `CurSeq` of missing frame  | Backward lookup: "I have frame N+2; what is N+1?" |
+
+The listener opens a per-request ephemeral UDP socket (`[::]:0`), sends the NACK, and waits up to 300 ms for a single response (`MISS` or `ACK`).
+
+---
+
+### MISS Response (`MsgType 0x11`) — 16 bytes
+
+Sent unicast to the NACK source when the requested frame is not in the endpoint's cache. On receipt, the listener advances immediately to the next endpoint (no backoff delay).
+
+| Offset | Size | Field    | Description                         |
+| ------ | ---- | -------- | ----------------------------------- |
+| 0      | 4    | Magic    | `0xE3E1F3E8`                        |
+| 4      | 2    | ProtoVer | `0x02BF`                            |
+| 6      | 1    | MsgType  | `0x11` (MISS)                       |
+| 7      | 1    | Flags    | Reserved; must be `0x00`            |
+| 8      | 8    | CurSeq   | Always `0x0000000000000000` on MISS |
+
+---
+
+### ACK Response (`MsgType 0x12`) — 16 bytes
+
+Sent unicast to the NACK source when the frame was found and retransmit dispatched. On receipt, the listener cancels the gap entry immediately.
+
+| Offset | Size | Field    | Description                                        |
+| ------ | ---- | -------- | -------------------------------------------------- |
+| 0      | 4    | Magic    | `0xE3E1F3E8`                                       |
+| 4      | 2    | ProtoVer | `0x02BF`                                           |
+| 6      | 1    | MsgType  | `0x12` (ACK)                                       |
+| 7      | 1    | Flags    | `0x01` = multicast sent; `0x02` = unicast sent     |
+| 8      | 8    | CurSeq   | `CurSeq` of the retransmitted frame (from BRC-124) |
+
+The listener uses the `CurSeq` echo to confirm the gap entry matches before cancelling it.
+
+---
+
+### Tier / Preference Model
+
+Retry endpoints are organised into tiers representing proximity to the transaction source, and assigned a preference within each tier.
+
+| Tier   | Meaning                                            |
+| ------ | -------------------------------------------------- |
+| `0`    | Same AS as `bitcoin-shard-proxy` (source-adjacent) |
+| `1`    | One AS boundary from source                        |
+| `N`    | N AS hops from source                              |
+| `0xFF` | Static seed (no beacon received; lowest priority)  |
+
+Endpoints discovered via ADVERT carry their operator-assigned `Tier` (0–254) and `Preference` (0–255). Endpoints registered via static configuration seed the registry at `Tier=0xFF, Preference=0`.
+
+Listeners sort the endpoint registry by `(Tier ASC, Preference DESC)`. NACK dispatch always selects the head of the sorted list; on MISS or timeout, the listener advances to the next position.
+
+#### Escalation State Machine
+
+```text
+  ┌──────────┐
+  │ PENDING  │  gap registered; hold-off jitter applied
+  └────┬─────┘
+       │ timer fires
+       ▼
+  ┌────────────────┐
+  │ NACKED(Tier-K) │  NACK sent to current (tier, preference) endpoint
+  └───┬────┬───┬───┘
+      │    │   │
+      │    │   └── Timeout ──► exponential backoff; retry next sweep
+      │    │
+      │    └── MISS ──► advance to next endpoint at same tier (Preference DESC);
+      │                 if tier exhausted, escalate to Tier K+1;
+      │                 retry IMMEDIATELY (no backoff on MISS)
+      │
+      └── ACK ──► gap entry cancelled; done
+
+  Any state ──► FILLED (multicast repair arrived via data plane)
+               gap entry cancelled; in-flight NACK socket times out harmlessly
+```
+
+- **ACK received:** Cancel gap entry. No further NACKs sent for this gap.
+- **MISS received:** Advance to next endpoint at same tier by Preference; if tier exhausted, move to next tier; retry immediately.
+- **Timeout:** Apply exponential backoff (capped at `nack-backoff-max`); retry on next sweeper tick.
+- **Multicast fill:** The data-plane receive goroutine calls `Tracker.Fill()` independently; gap cancelled regardless of NACK state.
+
+---
+
+### Beacon Scopes
+
+An endpoint instance beacons to **exactly one** group, set via `-beacon-scope`. Three scopes are defined:
+
+| Scope  | Flag value | Beacon group    | Use case                                            |
+| ------ | ---------- | --------------- | --------------------------------------------------- |
+| Site   | `site`     | `FF05::FF:FFFD` | Intra-site discovery; all listeners join at startup |
+| Org    | `org`      | `FF08::FF:FFFD` | Organisation-wide discovery for multi-site AS       |
+| Global | `global`   | `FF0E::FF:FFFD` | Inter-AS discovery via MP-BGP MVPN / MSDP           |
+
+To cover multiple scopes, run separate endpoint instances each configured with a different `-beacon-scope` value. Each scope can use independent `Tier` and `Preference` tuning.
+
+Listeners compute TTL as `3 × BeaconInterval`. An endpoint not heard for that duration is evicted from the registry. Static seeds (`-retry-endpoints`) are never evicted.
+
+---
+
+### Configurable Retransmit Modes
+
+Retransmit behavior is controlled by flags on the retry endpoint:
+
+| Flag                    | Default | Effect                                             |
+| ----------------------- | ------- | -------------------------------------------------- |
+| `-retransmit-multicast` | `true`  | Retransmit frame to original multicast shard group |
+| `-retransmit-unicast`   | `false` | Retransmit frame unicast to NACK source            |
+| `-suppress-miss`        | `false` | Do not send MISS response on cache miss            |
+| `-suppress-ack`         | `false` | Do not send ACK response on cache hit              |
+
+**Deployment profiles:**
+
+- **On-fabric (default):** `-retransmit-multicast=true` — all listeners on the fabric receive the retransmit simultaneously.
+- **Edge / unicast:** `-retransmit-unicast=true -retransmit-multicast=false` — for listeners not on the multicast fabric.
+- **High-volume:** `-suppress-ack=true` — reduces per-frame ACK traffic; MISS responses are preserved for escalation correctness.
+
+---
+
+### Flood Prevention
+
+| Mechanism               | Component                | Effect                                                              |
+| ----------------------- | ------------------------ | ------------------------------------------------------------------- |
+| Dedup window (60 s)     | Retry endpoint           | Only one endpoint per site retransmits any given frame              |
+| `SequenceIDRetransmit`  | Retry endpoint → ingress | Retransmitted frames are tagged; ingress drops from recaching       |
+| `Tracker.Fill()`        | Listener                 | Multicast repair cancels all pending NACKs for a gap                |
+| Jitter hold-off         | Listener                 | Randomised delay before first NACK suppresses correlated duplicates |
+| Exponential backoff     | Listener                 | Reduces NACK rate on persistent or repeated gaps                    |
+| `MaxRetries` + `GapTTL` | Listener                 | Gap entries evicted after retry exhaustion or absolute deadline     |
+
+---
+
+## Examples
+
+### ADVERT Datagram (56 bytes)
+
+A site-scope endpoint at `fd20::24`, port 9300, Tier 0, Preference 128, 60-second interval, multicast retransmit enabled:
+
+```text
+E3E1F3E8                                  // Network Magic
+02BF                                      // Protocol Version
+20                                        // MsgType = ADVERT
+05                                        // Scope = site-local
+FD200000000000000000000000000024          // NACKAddr = fd20::24
+2454                                      // NACKPort = 9300
+00                                        // Tier = 0
+80                                        // Preference = 128
+003C                                      // BeaconInterval = 60 s
+0010                                      // Flags = MulticastRetransmit
+A1B2C3D4                                  // InstanceID (CRC32c of hostname)
+00000000                                  // Reserved
+00000000000000000000000000000000          // Reserved (16 bytes)
+```
+
+### NACK Datagram (24 bytes)
+
+Forward lookup (by PrevSeq) for a missing frame with PrevSeq `0x1A2B3C4D5E6F7A8B`:
+
+```text
+E3E1F3E8                                  // Network Magic
+02BF                                      // Protocol Version
+10                                        // MsgType = NACK
+00                                        // LookupType = by PrevSeq
+1A2B3C4D5E6F7A8B                          // LookupSeq = PrevSeq of missing frame
+0000000000000000                          // Reserved
+```
+
+### MISS Response (16 bytes)
+
+```text
+E3E1F3E8                                  // Network Magic
+02BF                                      // Protocol Version
+11                                        // MsgType = MISS
+00                                        // Flags
+0000000000000000                          // CurSeq = 0 (cache miss)
+```
+
+### ACK Response (16 bytes)
+
+Frame found and retransmitted via multicast:
+
+```text
+E3E1F3E8                                  // Network Magic
+02BF                                      // Protocol Version
+12                                        // MsgType = ACK
+01                                        // Flags = multicast_sent
+1A2B3C4D5E6F7A8C                          // CurSeq of retransmitted frame
+```
+
+---
+
+## References
+
+- [BRC-12: Raw Transaction Format](./0012.md) — Payload format for transaction data within BRC-124 frames
+- [BRC-124: Multicast Transaction Frame Format](./0124.md) — Data-plane frame format; defines `PrevSeq`, `CurSeq`, `SubtreeID`, and the XXH64 hash chain stamped by the ingress proxy
+- [bitcoin-shard-common](https://github.com/lightwebinc/bitcoin-shard-common) — Reference implementation of frame and shard primitives (Go)
+
+---
+
+## Constants Reference
+
+```text
+| Name                   | Value      | Hex          | Description                          |
+|------------------------|------------|--------------|--------------------------------------|
+| `MagicBSV`             | 3823236072 | `0xE3E1F3E8` | BSV mainnet P2P magic                |
+| `ProtoVer`             | 703        | `0x02BF`     | Protocol version                     |
+| `MsgTypeNACK`          | 16         | `0x10`       | NACK request                         |
+| `MsgTypeMISS`          | 17         | `0x11`       | MISS response                        |
+| `MsgTypeACK`           | 18         | `0x12`       | ACK response                         |
+| `MsgTypeADVERT`        | 32         | `0x20`       | Endpoint advertisement beacon        |
+| `ScopesSite`           | 5          | `0x05`       | Site-local beacon scope              |
+| `ScopeOrg`             | 8          | `0x08`       | Organisation beacon scope            |
+| `ScopeGlobal`          | 14         | `0x0E`       | Global beacon scope                  |
+| `LookupByPrevSeq`      | 0          | `0x00`       | NACK forward lookup key type         |
+| `LookupByCurSeq`       | 1          | `0x01`       | NACK backward lookup key type        |
+| `FlagMulticastSent`    | 1          | `0x01`       | ACK flag: multicast retransmit sent  |
+| `FlagUnicastSent`      | 2          | `0x02`       | ACK flag: unicast retransmit sent    |
+| `FlagHasParent`        | 2          | `0x02`       | ADVERT flag: upstream endpoint set   |
+| `FlagDraining`         | 4          | `0x04`       | ADVERT flag: endpoint is draining    |
+| `FlagUnicastRetransmit`| 8          | `0x08`       | ADVERT flag: unicast retransmit      |
+| `FlagMcastRetransmit`  | 16         | `0x10`       | ADVERT flag: multicast retransmit    |
+| `CtrlGroupBeacon`      | 16777213   | `0xFFFFFD`   | Control-plane beacon group index     |
+| `DefaultNACKPort`      | 9300       | `0x2454`     | Default NACK/ADVERT UDP port         |
+| `DefaultBeaconInterval`| 60         | —            | Default ADVERT send interval (s)     |
+| `DefaultCacheTTL`      | 60         | —            | Default frame cache TTL (s)          |
+| `TierStaticSeed`       | 255        | `0xFF`       | Tier assigned to static seed endpoints |
+```
+
+---
+
+## Implementations
+
+- **Retry endpoint:** [bitcoin-retry-endpoint](https://github.com/lightwebinc/bitcoin-retry-endpoint) — NACK server (`server/server.go`), ADVERT sender (`beacon/beacon.go`), frame cache (`cache/`), rate limiting (`ratelimit/`)
+- **Listener:** [bitcoin-shard-listener](https://github.com/lightwebinc/bitcoin-shard-listener) — NACK wire encode/decode (`nack/wire.go`), gap tracker (`nack/nack.go`), ADVERT decode + endpoint registry (`discovery/`)
+- **Common:** [bitcoin-shard-common](https://github.com/lightwebinc/bitcoin-shard-common) — Frame decode (`frame/frame.go`), shard group derivation (`shard/shard.go`), control group address helper (`shard/control.go`)
+- **Proxy:** [bitcoin-shard-proxy](https://github.com/lightwebinc/bitcoin-shard-proxy) — PrevSeq/CurSeq stamping (`forwarder/forwarder.go`)


### PR DESCRIPTION
### This pull request:

Proposes a new standard by creating a new markdown file in the appropriate directory and requests discussion and assignment of a BRC number

### Summary

Adds a new BRC specifying a NACK-based retransmission and endpoint discovery protocol for the BSV multicast transaction distribution pipeline.

### What it defines

- Four UDP datagram formats: ADVERT (56 B), NACK (24 B), MISS (16 B), ACK (16 B)
- Tier/preference endpoint selection with an escalation state machine
- Beacon-based discovery via site/org/global multicast scopes
- Configurable retransmit modes (multicast, unicast, suppress-ack/miss)
- Flood prevention mechanisms (dedup window, jitter hold-off, exponential backoff, fill-suppression)

### Relationship to other BRCs

- Builds on BRC-124 (Multicast Transaction Frame Format) — uses the PrevSeq/CurSeq XXH64 hash chain for gap detection
- References BRC-12 for payload format

### Implementations

- [bitcoin-retry-endpoint](https://github.com/lightwebinc/bitcoin-retry-endpoint) — NACK server + ADVERT sender + frame cache
- [bitcoin-shard-listener](https://github.com/lightwebinc/bitcoin-shard-listener) — gap tracker + NACK dispatch + beacon registry
- [bitcoin-shard-common](https://github.com/lightwebinc/bitcoin-shard-common) — frame decode + control group address helpers
- [bitcoin-shard-proxy](https://github.com/lightwebinc/bitcoin-shard-proxy) — PrevSeq/CurSeq stamping
