### PR TITLE
BRC-126: Multicast NACK-based Retransmission Protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ BRC | Standard
 123  | [Basket Identifier Namespace Framework](./wallet/0123.md)
 124  | [Multicast Transaction Frame Format](./transactions/0124.md)
 125  | [PeerPay URI Scheme for BRC-29 Payments](./payments/0125.md)
+126  | [Multicast Transaction NACK Retransmission Protocol](./transactions/0126.md)
 
 ## License
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -61,6 +61,7 @@
 * [BEEF V2 Txid Only Extension](./transactions/0096.md)
 * [SubTree Unified Merkle Path (STUMP) Format](./transactions/0119.md)
 * [Multicast Transaction Frame Format](./transactions/0124.md)
+* [Multicast Transaction NACK Retransmission Protocol](./transactions/0126.md)
 
 ## Scripts
 

--- a/transactions/0126.md
+++ b/transactions/0126.md
@@ -272,7 +272,7 @@ E3E1F3E8                                  // Network Magic
 10                                        // MsgType = NACK
 00                                        // LookupType = by PrevSeq
 1A2B3C4D5E6F7A8B                          // LookupSeq = PrevSeq of missing frame
-0000000000000000                          // Reserved
+0000000000000000                          // ChainID = 0 (orphan gap, not yet chain-attributed)
 ```
 
 ### MISS Response (16 bytes)

--- a/transactions/0126.md
+++ b/transactions/0126.md
@@ -1,0 +1,345 @@
+# BRC-126: BSV Multicast NACK Retransmission Protocol
+
+Jeff Harris (jeff@lightweb.net)
+
+## Abstract
+
+This BRC specifies the NACK-based retransmission and endpoint discovery protocol for the BSV multicast transaction distribution pipeline. It defines four UDP datagram formats — ADVERT, NACK, MISS, and ACK — along with tier/preference-based endpoint selection, an escalation state machine, and configurable retransmit modes. The protocol operates on top of the BRC-124 data-plane and enables reliable gap recovery without requiring connection state at the ingress or listener tiers.
+
+## Copyright
+
+This BRC is licensed under the Open BSV License.
+
+## Motivation
+
+The BRC-124 data-plane delivers BSV transactions over IPv6 multicast with best-effort semantics. Network congestion, interface buffer overflows, and MLD snooping transitions can cause individual frames to be lost. Because BRC-124 frames carry a `PrevSeq`/`CurSeq` XXH64 hash chain stamped by the ingress proxy, listeners can detect exactly which frame is missing without a central sequence authority.
+
+This BRC adds the reliability layer that allows listeners to recover those gaps:
+
+1. **Gap detection** — listeners identify missing frames via hash-chain breaks (`PrevSeq ≠ lastCurSeq`).
+2. **NACK dispatch** — listeners send a 24-byte NACK datagram to a retry endpoint requesting the missing frame by its hash-chain identifier.
+3. **ACK/MISS responses** — every NACK receives a deterministic 16-byte response; ACK confirms retransmit dispatched, MISS triggers immediate escalation.
+4. **Endpoint discovery** — retry endpoints periodically multicast a 56-byte ADVERT beacon; listeners maintain a dynamic registry sorted by tier and preference, with no manual configuration required in well-connected deployments.
+5. **Flood prevention** — deduplication and fill-suppression mechanisms prevent retransmit storms at scale.
+
+## Specification
+
+### Common Message Preamble
+
+All BRC-126 datagrams begin with a 7-byte preamble:
+
+| Offset | Size | Field         | Description                              |
+| ------ | ---- | ------------- | ---------------------------------------- |
+| 0      | 4    | Network Magic | `0xE3E1F3E8` (BSV mainnet P2P magic)     |
+| 4      | 2    | Protocol Ver  | `0x02BF` (703, BSV large-block baseline) |
+| 6      | 1    | MsgType       | Identifies the message type (see below)  |
+
+The `MsgType` byte at offset 6 is in the same position as `FrameVersion` in BRC-124 data frames. Values `0x10`–`0x2F` are reserved for BRC-126 control messages and are distinct from the data-frame version codes (`0x01`, `0x02`).
+
+### MsgType Values
+
+| MsgType | Name   | Size | Direction                     |
+| ------- | ------ | ---- | ----------------------------- |
+| `0x10`  | NACK   | 24 B | Listener → Retry endpoint     |
+| `0x11`  | MISS   | 16 B | Retry endpoint → Listener     |
+| `0x12`  | ACK    | 16 B | Retry endpoint → Listener     |
+| `0x20`  | ADVERT | 56 B | Retry endpoint → Beacon group |
+
+---
+
+### ADVERT Wire Format (`MsgType 0x20`) — 56 bytes
+
+Sent periodically by retry endpoints to the beacon multicast group. Listeners use it to build and maintain their endpoint registry.
+
+| Offset | Size | Field          | Description                                                   |
+| ------ | ---- | -------------- | ------------------------------------------------------------- |
+| 0      | 4    | Network Magic  | `0xE3E1F3E8`                                                  |
+| 4      | 2    | Protocol Ver   | `0x02BF`                                                      |
+| 6      | 1    | MsgType        | `0x20` (ADVERT)                                               |
+| 7      | 1    | Scope          | `0x05` = site-local, `0x08` = org, `0x0E` = global            |
+| 8      | 16   | NACKAddr       | IPv6 unicast address listeners use for NACK requests          |
+| 24     | 2    | NACKPort       | UDP port for NACK requests (default `9300`)                   |
+| 26     | 1    | Tier           | Operator-assigned proximity tier; `0` = source-adjacent       |
+| 27     | 1    | Preference     | Within-tier priority; higher = more preferred (default `128`) |
+| 28     | 2    | BeaconInterval | Beacon send interval in seconds; listeners TTL = `3 × this`   |
+| 30     | 2    | Flags          | Capability bitmask (see below)                                |
+| 32     | 4    | InstanceID     | CRC32c of hostname; matches metrics `instance` label          |
+| 36     | 4    | Reserved       | Must be `0x00000000`                                          |
+| 40     | 16   | Reserved       | Must be all zeros; reserved for future capability bitmap      |
+
+#### ADVERT Flags Bitmask
+
+| Bit    | Name                | Meaning                                                    |
+| ------ | ------------------- | ---------------------------------------------------------- |
+| `0x01` | _(reserved)_        | Unused; must be zero                                       |
+| `0x02` | HasParent           | Endpoint forwards cache-miss NACKs to an upstream endpoint |
+| `0x04` | Draining            | Entering shutdown; listeners should stop routing new NACKs |
+| `0x08` | UnicastRetransmit   | Supports unicast frame delivery to the NACK source         |
+| `0x10` | MulticastRetransmit | Retransmits via multicast to the original shard group      |
+
+**HasParent:** When set, the endpoint maintains a connection to a parent (higher-tier) endpoint and forwards NACKs on local cache miss. Listeners need only know their local tier; inter-tier forwarding is handled transparently.
+
+**Beacon group addresses** are derived from the shard address scheme using the reserved control-plane index `0xFFFFFD`:
+
+| Scope           | Beacon Group (no middle bytes) |
+| --------------- | ------------------------------ |
+| Site (`0x05`)   | `FF05::FF:FFFD`                |
+| Org (`0x08`)    | `FF08::FF:FFFD`                |
+| Global (`0x0E`) | `FF0E::FF:FFFD`                |
+
+When `-mc-base-addr` middle bytes are configured, those bytes are interleaved at positions 2–12 of the IPv6 address identically to data-plane shard groups.
+
+---
+
+### NACK Wire Format (`MsgType 0x10`) — 24 bytes
+
+Sent by a listener to a retry endpoint when a gap is detected. Requests a specific frame by its BRC-124 `CurSeq` value (backward lookup) or by its `PrevSeq` value (forward lookup).
+
+| Offset | Size | Field      | Description                                                                |
+| ------ | ---- | ---------- | -------------------------------------------------------------------------- |
+| 0      | 4    | Magic      | `0xE3E1F3E8`                                                               |
+| 4      | 2    | ProtoVer   | `0x02BF`                                                                   |
+| 6      | 1    | MsgType    | `0x10` (NACK)                                                              |
+| 7      | 1    | LookupType | `0x00` = by PrevSeq (forward lookup); `0x01` = by CurSeq (backward lookup) |
+| 8      | 8    | LookupSeq  | XXH64 value identifying the missing frame                                  |
+| 16     | 8    | Reserved   | Must be `0x0000000000000000`                                               |
+
+**LookupType semantics:**
+
+| LookupType | Cache Key Used             | Use Case                                          |
+| ---------- | -------------------------- | ------------------------------------------------- |
+| `0x00`     | `PrevSeq` of missing frame | Forward lookup: "I have frame N; what is N+1?"    |
+| `0x01`     | `CurSeq` of missing frame  | Backward lookup: "I have frame N+2; what is N+1?" |
+
+The listener opens a per-request ephemeral UDP socket (`[::]:0`), sends the NACK, and waits up to 300 ms for a single response (`MISS` or `ACK`).
+
+---
+
+### MISS Response (`MsgType 0x11`) — 16 bytes
+
+Sent unicast to the NACK source when the requested frame is not in the endpoint's cache. On receipt, the listener advances immediately to the next endpoint (no backoff delay).
+
+| Offset | Size | Field    | Description                         |
+| ------ | ---- | -------- | ----------------------------------- |
+| 0      | 4    | Magic    | `0xE3E1F3E8`                        |
+| 4      | 2    | ProtoVer | `0x02BF`                            |
+| 6      | 1    | MsgType  | `0x11` (MISS)                       |
+| 7      | 1    | Flags    | Reserved; must be `0x00`            |
+| 8      | 8    | CurSeq   | Always `0x0000000000000000` on MISS |
+
+---
+
+### ACK Response (`MsgType 0x12`) — 16 bytes
+
+Sent unicast to the NACK source when the frame was found and retransmit dispatched. On receipt, the listener cancels the gap entry immediately.
+
+| Offset | Size | Field    | Description                                        |
+| ------ | ---- | -------- | -------------------------------------------------- |
+| 0      | 4    | Magic    | `0xE3E1F3E8`                                       |
+| 4      | 2    | ProtoVer | `0x02BF`                                           |
+| 6      | 1    | MsgType  | `0x12` (ACK)                                       |
+| 7      | 1    | Flags    | `0x01` = multicast sent; `0x02` = unicast sent     |
+| 8      | 8    | CurSeq   | `CurSeq` of the retransmitted frame (from BRC-124) |
+
+The listener uses the `CurSeq` echo to confirm the gap entry matches before cancelling it.
+
+---
+
+### Tier / Preference Model
+
+Retry endpoints are organised into tiers representing proximity to the transaction source, and assigned a preference within each tier.
+
+| Tier   | Meaning                                            |
+| ------ | -------------------------------------------------- |
+| `0`    | Same AS as `bitcoin-shard-proxy` (source-adjacent) |
+| `1`    | One AS boundary from source                        |
+| `N`    | N AS hops from source                              |
+| `0xFF` | Static seed (no beacon received; lowest priority)  |
+
+Endpoints discovered via ADVERT carry their operator-assigned `Tier` (0–254) and `Preference` (0–255). Endpoints registered via static configuration seed the registry at `Tier=0xFF, Preference=0`.
+
+Listeners sort the endpoint registry by `(Tier ASC, Preference DESC)`. NACK dispatch always selects the head of the sorted list; on MISS or timeout, the listener advances to the next position.
+
+#### Escalation State Machine
+
+```text
+  ┌──────────┐
+  │ PENDING  │  gap registered; hold-off jitter applied
+  └────┬─────┘
+       │ timer fires
+       ▼
+  ┌────────────────┐
+  │ NACKED(Tier-K) │  NACK sent to current (tier, preference) endpoint
+  └───┬────┬───┬───┘
+      │    │   │
+      │    │   └── Timeout ──► exponential backoff; retry next sweep
+      │    │
+      │    └── MISS ──► advance to next endpoint at same tier (Preference DESC);
+      │                 if tier exhausted, escalate to Tier K+1;
+      │                 retry IMMEDIATELY (no backoff on MISS)
+      │
+      └── ACK ──► gap entry cancelled; done
+
+  Any state ──► FILLED (multicast repair arrived via data plane)
+               gap entry cancelled; in-flight NACK socket times out harmlessly
+```
+
+- **ACK received:** Cancel gap entry. No further NACKs sent for this gap.
+- **MISS received:** Advance to next endpoint at same tier by Preference; if tier exhausted, move to next tier; retry immediately.
+- **Timeout:** Apply exponential backoff (capped at `nack-backoff-max`); retry on next sweeper tick.
+- **Multicast fill:** The data-plane receive goroutine calls `Tracker.Fill()` independently; gap cancelled regardless of NACK state.
+
+---
+
+### Beacon Scopes
+
+An endpoint instance beacons to **exactly one** group, set via `-beacon-scope`. Three scopes are defined:
+
+| Scope  | Flag value | Beacon group    | Use case                                            |
+| ------ | ---------- | --------------- | --------------------------------------------------- |
+| Site   | `site`     | `FF05::FF:FFFD` | Intra-site discovery; all listeners join at startup |
+| Org    | `org`      | `FF08::FF:FFFD` | Organisation-wide discovery for multi-site AS       |
+| Global | `global`   | `FF0E::FF:FFFD` | Inter-AS discovery via MP-BGP MVPN / MSDP           |
+
+To cover multiple scopes, run separate endpoint instances each configured with a different `-beacon-scope` value. Each scope can use independent `Tier` and `Preference` tuning.
+
+Listeners compute TTL as `3 × BeaconInterval`. An endpoint not heard for that duration is evicted from the registry. Static seeds (`-retry-endpoints`) are never evicted.
+
+---
+
+### Configurable Retransmit Modes
+
+Retransmit behavior is controlled by flags on the retry endpoint:
+
+| Flag                    | Default | Effect                                             |
+| ----------------------- | ------- | -------------------------------------------------- |
+| `-retransmit-multicast` | `true`  | Retransmit frame to original multicast shard group |
+| `-retransmit-unicast`   | `false` | Retransmit frame unicast to NACK source            |
+| `-suppress-miss`        | `false` | Do not send MISS response on cache miss            |
+| `-suppress-ack`         | `false` | Do not send ACK response on cache hit              |
+
+**Deployment profiles:**
+
+- **On-fabric (default):** `-retransmit-multicast=true` — all listeners on the fabric receive the retransmit simultaneously.
+- **Edge / unicast:** `-retransmit-unicast=true -retransmit-multicast=false` — for listeners not on the multicast fabric.
+- **High-volume:** `-suppress-ack=true` — reduces per-frame ACK traffic; MISS responses are preserved for escalation correctness.
+
+---
+
+### Flood Prevention
+
+| Mechanism               | Component                | Effect                                                              |
+| ----------------------- | ------------------------ | ------------------------------------------------------------------- |
+| Dedup window (60 s)     | Retry endpoint           | Only one endpoint per site retransmits any given frame              |
+| `SequenceIDRetransmit`  | Retry endpoint → ingress | Retransmitted frames are tagged; ingress drops from recaching       |
+| `Tracker.Fill()`        | Listener                 | Multicast repair cancels all pending NACKs for a gap                |
+| Jitter hold-off         | Listener                 | Randomised delay before first NACK suppresses correlated duplicates |
+| Exponential backoff     | Listener                 | Reduces NACK rate on persistent or repeated gaps                    |
+| `MaxRetries` + `GapTTL` | Listener                 | Gap entries evicted after retry exhaustion or absolute deadline     |
+
+---
+
+## Examples
+
+### ADVERT Datagram (56 bytes)
+
+A site-scope endpoint at `fd20::24`, port 9300, Tier 0, Preference 128, 60-second interval, multicast retransmit enabled:
+
+```text
+E3E1F3E8                                  // Network Magic
+02BF                                      // Protocol Version
+20                                        // MsgType = ADVERT
+05                                        // Scope = site-local
+FD200000000000000000000000000024          // NACKAddr = fd20::24
+2454                                      // NACKPort = 9300
+00                                        // Tier = 0
+80                                        // Preference = 128
+003C                                      // BeaconInterval = 60 s
+0010                                      // Flags = MulticastRetransmit
+A1B2C3D4                                  // InstanceID (CRC32c of hostname)
+00000000                                  // Reserved
+00000000000000000000000000000000          // Reserved (16 bytes)
+```
+
+### NACK Datagram (24 bytes)
+
+Forward lookup (by PrevSeq) for a missing frame with PrevSeq `0x1A2B3C4D5E6F7A8B`:
+
+```text
+E3E1F3E8                                  // Network Magic
+02BF                                      // Protocol Version
+10                                        // MsgType = NACK
+00                                        // LookupType = by PrevSeq
+1A2B3C4D5E6F7A8B                          // LookupSeq = PrevSeq of missing frame
+0000000000000000                          // Reserved
+```
+
+### MISS Response (16 bytes)
+
+```text
+E3E1F3E8                                  // Network Magic
+02BF                                      // Protocol Version
+11                                        // MsgType = MISS
+00                                        // Flags
+0000000000000000                          // CurSeq = 0 (cache miss)
+```
+
+### ACK Response (16 bytes)
+
+Frame found and retransmitted via multicast:
+
+```text
+E3E1F3E8                                  // Network Magic
+02BF                                      // Protocol Version
+12                                        // MsgType = ACK
+01                                        // Flags = multicast_sent
+1A2B3C4D5E6F7A8C                          // CurSeq of retransmitted frame
+```
+
+---
+
+## References
+
+- [BRC-12: Raw Transaction Format](./0012.md) — Payload format for transaction data within BRC-124 frames
+- [BRC-124: Multicast Transaction Frame Format](./0124.md) — Data-plane frame format; defines `PrevSeq`, `CurSeq`, `SubtreeID`, and the XXH64 hash chain stamped by the ingress proxy
+- [bitcoin-shard-common](https://github.com/lightwebinc/bitcoin-shard-common) — Reference implementation of frame and shard primitives (Go)
+
+---
+
+## Constants Reference
+
+```text
+| Name                   | Value      | Hex          | Description                          |
+|------------------------|------------|--------------|--------------------------------------|
+| `MagicBSV`             | 3823236072 | `0xE3E1F3E8` | BSV mainnet P2P magic                |
+| `ProtoVer`             | 703        | `0x02BF`     | Protocol version                     |
+| `MsgTypeNACK`          | 16         | `0x10`       | NACK request                         |
+| `MsgTypeMISS`          | 17         | `0x11`       | MISS response                        |
+| `MsgTypeACK`           | 18         | `0x12`       | ACK response                         |
+| `MsgTypeADVERT`        | 32         | `0x20`       | Endpoint advertisement beacon        |
+| `ScopesSite`           | 5          | `0x05`       | Site-local beacon scope              |
+| `ScopeOrg`             | 8          | `0x08`       | Organisation beacon scope            |
+| `ScopeGlobal`          | 14         | `0x0E`       | Global beacon scope                  |
+| `LookupByPrevSeq`      | 0          | `0x00`       | NACK forward lookup key type         |
+| `LookupByCurSeq`       | 1          | `0x01`       | NACK backward lookup key type        |
+| `FlagMulticastSent`    | 1          | `0x01`       | ACK flag: multicast retransmit sent  |
+| `FlagUnicastSent`      | 2          | `0x02`       | ACK flag: unicast retransmit sent    |
+| `FlagHasParent`        | 2          | `0x02`       | ADVERT flag: upstream endpoint set   |
+| `FlagDraining`         | 4          | `0x04`       | ADVERT flag: endpoint is draining    |
+| `FlagUnicastRetransmit`| 8          | `0x08`       | ADVERT flag: unicast retransmit      |
+| `FlagMcastRetransmit`  | 16         | `0x10`       | ADVERT flag: multicast retransmit    |
+| `CtrlGroupBeacon`      | 16777213   | `0xFFFFFD`   | Control-plane beacon group index     |
+| `DefaultNACKPort`      | 9300       | `0x2454`     | Default NACK/ADVERT UDP port         |
+| `DefaultBeaconInterval`| 60         | —            | Default ADVERT send interval (s)     |
+| `DefaultCacheTTL`      | 60         | —            | Default frame cache TTL (s)          |
+| `TierStaticSeed`       | 255        | `0xFF`       | Tier assigned to static seed endpoints |
+```
+
+---
+
+## Implementations
+
+- **Retry endpoint:** [bitcoin-retry-endpoint](https://github.com/lightwebinc/bitcoin-retry-endpoint) — NACK server (`server/server.go`), ADVERT sender (`beacon/beacon.go`), frame cache (`cache/`), rate limiting (`ratelimit/`)
+- **Listener:** [bitcoin-shard-listener](https://github.com/lightwebinc/bitcoin-shard-listener) — NACK wire encode/decode (`nack/wire.go`), gap tracker (`nack/nack.go`), ADVERT decode + endpoint registry (`discovery/`)
+- **Common:** [bitcoin-shard-common](https://github.com/lightwebinc/bitcoin-shard-common) — Frame decode (`frame/frame.go`), shard group derivation (`shard/shard.go`), control group address helper (`shard/control.go`)
+- **Proxy:** [bitcoin-shard-proxy](https://github.com/lightwebinc/bitcoin-shard-proxy) — PrevSeq/CurSeq stamping (`forwarder/forwarder.go`)

--- a/transactions/0126.md
+++ b/transactions/0126.md
@@ -102,7 +102,7 @@ Sent by a listener to a retry endpoint when a gap is detected. Requests a specif
 | 6      | 1    | MsgType    | `0x10` (NACK)                                                              |
 | 7      | 1    | LookupType | `0x00` = by PrevSeq (forward lookup); `0x01` = by CurSeq (backward lookup) |
 | 8      | 8    | LookupSeq  | XXH64 value identifying the missing frame                                  |
-| 16     | 8    | Reserved   | Must be `0x0000000000000000`                                               |
+| 16     | 8    | ChainID    | Initial `CurSeq` of the hash-chain; `0x0` = gap not yet chain-attributed   |
 
 **LookupType semantics:**
 

--- a/transactions/0126.md
+++ b/transactions/0126.md
@@ -63,7 +63,7 @@ Sent periodically by retry endpoints to the beacon multicast group. Listeners us
 | 27     | 1    | Preference     | Within-tier priority; higher = more preferred (default `128`) |
 | 28     | 2    | BeaconInterval | Beacon send interval in seconds; listeners TTL = `3 × this`   |
 | 30     | 2    | Flags          | Capability bitmask (see below)                                |
-| 32     | 4    | InstanceID     | CRC32c of hostname; matches metrics `instance` label          |
+| 32     | 4    | InstanceID     | CRC32c of hostname; stable across restarts                   |
 | 36     | 4    | Reserved       | Must be `0x00000000`                                          |
 | 40     | 16   | Reserved       | Must be all zeros; reserved for future capability bitmap      |
 
@@ -193,13 +193,15 @@ Listeners sort the endpoint registry by `(Tier ASC, Preference DESC)`. NACK disp
 
 ### Beacon Scopes
 
-An endpoint instance beacons to **exactly one** group, set via `-beacon-scope`. Three scopes are defined:
+Three scope bytes are defined for the ADVERT wire format. The reference implementation's `-beacon-scope` flag accepts `site`, `global`, or `both` (sends to site + global simultaneously):
 
-| Scope  | Flag value | Beacon group    | Use case                                            |
-| ------ | ---------- | --------------- | --------------------------------------------------- |
-| Site   | `site`     | `FF05::FF:FFFD` | Intra-site discovery; all listeners join at startup |
-| Org    | `org`      | `FF08::FF:FFFD` | Organisation-wide discovery for multi-site AS       |
-| Global | `global`   | `FF0E::FF:FFFD` | Inter-AS discovery via MP-BGP MVPN / MSDP           |
+| Scope           | Scope byte | Beacon group    | Use case                                            |
+| --------------- | ---------- | --------------- | --------------------------------------------------- |
+| Site (`0x05`)   | `0x05`     | `FF05::FF:FFFD` | Intra-site discovery; all listeners join at startup |
+| Org (`0x08`)    | `0x08`     | `FF08::FF:FFFD` | Organisation-wide discovery for multi-site AS       |
+| Global (`0x0E`) | `0x0E`     | `FF0E::FF:FFFD` | Inter-AS discovery via MP-BGP MVPN / MSDP           |
+
+Scope byte `0xFF` is used in ADVERT datagrams when the sender intends to cover both site and global simultaneously (sends two ADVERTs). Listeners parse the scope byte from each individual datagram.
 
 To cover multiple scopes, run separate endpoint instances each configured with a different `-beacon-scope` value. Each scope can use independent `Tier` and `Preference` tuning.
 
@@ -228,14 +230,13 @@ Retransmit behavior is controlled by flags on the retry endpoint:
 
 ### Flood Prevention
 
-| Mechanism               | Component                | Effect                                                              |
-| ----------------------- | ------------------------ | ------------------------------------------------------------------- |
-| Dedup window (60 s)     | Retry endpoint           | Only one endpoint per site retransmits any given frame              |
-| `SequenceIDRetransmit`  | Retry endpoint → ingress | Retransmitted frames are tagged; ingress drops from recaching       |
-| `Tracker.Fill()`        | Listener                 | Multicast repair cancels all pending NACKs for a gap                |
-| Jitter hold-off         | Listener                 | Randomised delay before first NACK suppresses correlated duplicates |
-| Exponential backoff     | Listener                 | Reduces NACK rate on persistent or repeated gaps                    |
-| `MaxRetries` + `GapTTL` | Listener                 | Gap entries evicted after retry exhaustion or absolute deadline     |
+| Mechanism               | Component      | Effect                                                              |
+| ----------------------- | -------------- | ------------------------------------------------------------------- |
+| Cache TTL (60 s)        | Retry endpoint | Frames expire naturally; bounds retransmit window                   |
+| `Tracker.Fill()`        | Listener       | Multicast repair cancels all pending NACKs for a gap                |
+| Jitter hold-off         | Listener       | Randomised delay before first NACK suppresses correlated duplicates |
+| Exponential backoff     | Listener       | Reduces NACK rate on persistent or repeated gaps                    |
+| `MaxRetries` + `GapTTL` | Listener       | Gap entries evicted after retry exhaustion or absolute deadline     |
 
 ---
 

--- a/transactions/0126.md
+++ b/transactions/0126.md
@@ -12,12 +12,12 @@ This BRC is licensed under the Open BSV License.
 
 ## Motivation
 
-The BRC-124 data-plane delivers BSV transactions over IPv6 multicast with best-effort semantics. Network congestion, interface buffer overflows, and MLD snooping transitions can cause individual frames to be lost. Because BRC-124 frames carry a `PrevSeq`/`CurSeq` XXH64 hash chain stamped by the ingress proxy, listeners can detect exactly which frame is missing without a central sequence authority.
+The BRC-124 data-plane delivers BSV transactions over IPv6 multicast with best-effort semantics. Network congestion, interface buffer overflows, and MLD snooping transitions can cause individual frames to be lost. Because BRC-124 frames carry a monotonic `Sequence Number` stamped by the sender, listeners can detect exactly which frame is missing without a central sequence authority.
 
 This BRC adds the reliability layer that allows listeners to recover those gaps:
 
-1. **Gap detection** — listeners identify missing frames via hash-chain breaks (`PrevSeq ≠ lastCurSeq`).
-2. **NACK dispatch** — listeners send a 24-byte NACK datagram to a retry endpoint requesting the missing frame by its hash-chain identifier.
+1. **Gap detection** — listeners identify missing frames when a frame's `Sequence Number` advances by more than 1 from the last-seen value for a given `(Sender ID, Sequence ID)` flow.
+2. **NACK dispatch** — listeners send a 56-byte NACK datagram to a retry endpoint identifying the missing frame by its sender flow and sequence number.
 3. **ACK/MISS responses** — every NACK receives a deterministic 16-byte response; ACK confirms retransmit dispatched, MISS triggers immediate escalation.
 4. **Endpoint discovery** — retry endpoints periodically multicast a 56-byte ADVERT beacon; listeners maintain a dynamic registry sorted by tier and preference, with no manual configuration required in well-connected deployments.
 5. **Flood prevention** — deduplication and fill-suppression mechanisms prevent retransmit storms at scale.
@@ -40,7 +40,7 @@ The `MsgType` byte at offset 6 is in the same position as `FrameVersion` in BRC-
 
 | MsgType | Name   | Size | Direction                     |
 | ------- | ------ | ---- | ----------------------------- |
-| `0x10`  | NACK   | 24 B | Listener → Retry endpoint     |
+| `0x10`  | NACK   | 56 B | Listener → Retry endpoint     |
 | `0x11`  | MISS   | 16 B | Retry endpoint → Listener     |
 | `0x12`  | ACK    | 16 B | Retry endpoint → Listener     |
 | `0x20`  | ADVERT | 56 B | Retry endpoint → Beacon group |
@@ -91,27 +91,27 @@ When `-mc-base-addr` middle bytes are configured, those bytes are interleaved at
 
 ---
 
-### NACK Wire Format (`MsgType 0x10`) — 24 bytes
+### NACK Wire Format (`MsgType 0x10`) — 56 bytes
 
-Sent by a listener to a retry endpoint when a gap is detected. Requests a specific frame by its BRC-124 `CurSeq` value (backward lookup) or by its `PrevSeq` value (forward lookup).
+Sent by a listener to a retry endpoint when a gap is detected. Identifies the missing frame by sender flow (`Sender ID` + `Sequence ID`) and sequence number range. For current single-frame retrieval, `Start Sequence Number == End Sequence Number`; range requests are reserved for future use.
 
-| Offset | Size | Field      | Description                                                                |
-| ------ | ---- | ---------- | -------------------------------------------------------------------------- |
-| 0      | 4    | Magic      | `0xE3E1F3E8`                                                               |
-| 4      | 2    | ProtoVer   | `0x02BF`                                                                   |
-| 6      | 1    | MsgType    | `0x10` (NACK)                                                              |
-| 7      | 1    | LookupType | `0x00` = by PrevSeq (forward lookup); `0x01` = by CurSeq (backward lookup) |
-| 8      | 8    | LookupSeq  | XXH64 value identifying the missing frame                                  |
-| 16     | 8    | ChainID    | Initial `CurSeq` of the hash-chain; `0x0` = gap not yet chain-attributed   |
-
-**LookupType semantics:**
-
-| LookupType | Cache Key Used             | Use Case                                          |
-| ---------- | -------------------------- | ------------------------------------------------- |
-| `0x00`     | `PrevSeq` of missing frame | Forward lookup: "I have frame N; what is N+1?"    |
-| `0x01`     | `CurSeq` of missing frame  | Backward lookup: "I have frame N+2; what is N+1?" |
+| Offset | Size | Field                | Description                                                             |
+| ------ | ---- | -------------------- | ----------------------------------------------------------------------- |
+| 0      | 4    | Magic                | `0xE3E1F3E8`                                                            |
+| 4      | 2    | ProtoVer             | `0x02BF`                                                                |
+| 6      | 1    | MsgType              | `0x10` (NACK)                                                           |
+| 7      | 1    | Flags                | Reserved; must be `0x00`                                                |
+| 8      | 4    | Sender ID            | CRC32c of source IPv6; from BRC-124 frame bytes 40–43                   |
+| 12     | 4    | Sequence ID          | Flow identifier; from BRC-124 frame bytes 44–47                         |
+| 16     | 4    | Start Sequence Number| First missing sequence number (inclusive)                               |
+| 20     | 4    | End Sequence Number  | Last missing sequence number (inclusive); equals Start for single-frame |
+| 24     | 32   | Subtree ID           | 32-byte batch identifier; from BRC-124 frame bytes 56–87; zeros = unset |
 
 The listener opens a per-request ephemeral UDP socket (`[::]:0`), sends the NACK, and waits up to 300 ms for a single response (`MISS` or `ACK`).
+
+> **Sender ID + Sequence ID** together identify the flow whose frame is missing. The retry endpoint uses `Sender ID` as a per-flow rate-limiting key (NACK storm cap). A `Sender ID` of `0` bypasses the per-flow check.
+
+> **Start / End Sequence Number** specify the missing range. The retry endpoint looks up the frame using the cache key `(Sender ID, Sequence ID, Start Sequence Number)`.
 
 ---
 
@@ -125,7 +125,8 @@ Sent unicast to the NACK source when the requested frame is not in the endpoint'
 | 4      | 2    | ProtoVer | `0x02BF`                            |
 | 6      | 1    | MsgType  | `0x11` (MISS)                       |
 | 7      | 1    | Flags    | Reserved; must be `0x00`            |
-| 8      | 8    | CurSeq   | Always `0x0000000000000000` on MISS |
+| 8      | 4    | Sequence Number | Always `0x00000000` on MISS        |
+| 12     | 4    | Reserved        | Must be `0x00000000`               |
 
 ---
 
@@ -139,9 +140,10 @@ Sent unicast to the NACK source when the frame was found and retransmit dispatch
 | 4      | 2    | ProtoVer | `0x02BF`                                           |
 | 6      | 1    | MsgType  | `0x12` (ACK)                                       |
 | 7      | 1    | Flags    | `0x01` = multicast sent; `0x02` = unicast sent     |
-| 8      | 8    | CurSeq   | `CurSeq` of the retransmitted frame (from BRC-124) |
+| 8      | 4    | Sequence Number | `Sequence Number` of the retransmitted frame (from BRC-124 bytes 48–51) |
+| 12     | 4    | Reserved        | Must be `0x00000000`                                                    |
 
-The listener uses the `CurSeq` echo to confirm the gap entry matches before cancelling it.
+The listener uses the `Sequence Number` echo to confirm the gap entry matches before cancelling it.
 
 ---
 
@@ -262,17 +264,20 @@ A1B2C3D4                                  // InstanceID (CRC32c of hostname)
 00000000000000000000000000000000          // Reserved (16 bytes)
 ```
 
-### NACK Datagram (24 bytes)
+### NACK Datagram (56 bytes)
 
-Forward lookup (by PrevSeq) for a missing frame with PrevSeq `0x1A2B3C4D5E6F7A8B`:
+Single-frame retrieval: missing frame for sender `0xA1B2C3D4`, flow `0x00000001`, sequence number `1235`:
 
 ```text
 E3E1F3E8                                  // Network Magic
 02BF                                      // Protocol Version
 10                                        // MsgType = NACK
-00                                        // LookupType = by PrevSeq
-1A2B3C4D5E6F7A8B                          // LookupSeq = PrevSeq of missing frame
-0000000000000000                          // ChainID = 0 (orphan gap, not yet chain-attributed)
+00                                        // Flags (reserved)
+A1B2C3D4                                  // Sender ID (CRC32c of source IPv6)
+00000001                                  // Sequence ID (flow identifier)
+000004D3                                  // Start Sequence Number = 1235
+000004D3                                  // End Sequence Number = 1235 (single frame)
+baadf498a00ca5a44d1c4d9d103b49017f53cd8cb2a70a9c67fc884ecdd622b5  // Subtree ID
 ```
 
 ### MISS Response (16 bytes)
@@ -282,7 +287,8 @@ E3E1F3E8                                  // Network Magic
 02BF                                      // Protocol Version
 11                                        // MsgType = MISS
 00                                        // Flags
-0000000000000000                          // CurSeq = 0 (cache miss)
+00000000                                  // Sequence Number = 0 (cache miss)
+00000000                                  // Reserved
 ```
 
 ### ACK Response (16 bytes)
@@ -294,7 +300,8 @@ E3E1F3E8                                  // Network Magic
 02BF                                      // Protocol Version
 12                                        // MsgType = ACK
 01                                        // Flags = multicast_sent
-1A2B3C4D5E6F7A8C                          // CurSeq of retransmitted frame
+000004D3                                  // Sequence Number of retransmitted frame (1235)
+00000000                                  // Reserved
 ```
 
 ---
@@ -302,7 +309,7 @@ E3E1F3E8                                  // Network Magic
 ## References
 
 - [BRC-12: Raw Transaction Format](./0012.md) — Payload format for transaction data within BRC-124 frames
-- [BRC-124: Multicast Transaction Frame Format](./0124.md) — Data-plane frame format; defines `PrevSeq`, `CurSeq`, `SubtreeID`, and the XXH64 hash chain stamped by the ingress proxy
+- [BRC-124: Multicast Transaction Frame Format](./0124.md) — Data-plane frame format; defines `Sender ID`, `Sequence ID`, `Sequence Number`, and `Subtree ID` stamped by the sender
 - [bitcoin-shard-common](https://github.com/lightwebinc/bitcoin-shard-common) — Reference implementation of frame and shard primitives (Go)
 
 ---
@@ -321,8 +328,7 @@ E3E1F3E8                                  // Network Magic
 | `ScopesSite`           | 5          | `0x05`       | Site-local beacon scope              |
 | `ScopeOrg`             | 8          | `0x08`       | Organisation beacon scope            |
 | `ScopeGlobal`          | 14         | `0x0E`       | Global beacon scope                  |
-| `LookupByPrevSeq`      | 0          | `0x00`       | NACK forward lookup key type         |
-| `LookupByCurSeq`       | 1          | `0x01`       | NACK backward lookup key type        |
+| `NACKSize`             | 56         | `0x38`       | NACK datagram size in bytes          |
 | `FlagMulticastSent`    | 1          | `0x01`       | ACK flag: multicast retransmit sent  |
 | `FlagUnicastSent`      | 2          | `0x02`       | ACK flag: unicast retransmit sent    |
 | `FlagHasParent`        | 2          | `0x02`       | ADVERT flag: upstream endpoint set   |
@@ -343,4 +349,4 @@ E3E1F3E8                                  // Network Magic
 - **Retry endpoint:** [bitcoin-retry-endpoint](https://github.com/lightwebinc/bitcoin-retry-endpoint) — NACK server (`server/server.go`), ADVERT sender (`beacon/beacon.go`), frame cache (`cache/`), rate limiting (`ratelimit/`)
 - **Listener:** [bitcoin-shard-listener](https://github.com/lightwebinc/bitcoin-shard-listener) — NACK wire encode/decode (`nack/wire.go`), gap tracker (`nack/nack.go`), ADVERT decode + endpoint registry (`discovery/`)
 - **Common:** [bitcoin-shard-common](https://github.com/lightwebinc/bitcoin-shard-common) — Frame decode (`frame/frame.go`), shard group derivation (`shard/shard.go`), control group address helper (`shard/control.go`)
-- **Proxy:** [bitcoin-shard-proxy](https://github.com/lightwebinc/bitcoin-shard-proxy) — PrevSeq/CurSeq stamping (`forwarder/forwarder.go`)
+- **Proxy:** [bitcoin-shard-proxy](https://github.com/lightwebinc/bitcoin-shard-proxy) — Sender ID / Sequence Number stamping (`forwarder/forwarder.go`)

--- a/transactions/0126.md
+++ b/transactions/0126.md
@@ -12,12 +12,12 @@ This BRC is licensed under the Open BSV License.
 
 ## Motivation
 
-The BRC-124 data-plane delivers BSV transactions over IPv6 multicast with best-effort semantics. Network congestion, interface buffer overflows, and MLD snooping transitions can cause individual frames to be lost. Because BRC-124 frames carry a monotonic `Sequence Number` stamped by the sender, listeners can detect exactly which frame is missing without a central sequence authority.
+The BRC-124 data-plane delivers BSV transactions over IPv6 multicast with best-effort semantics. Network congestion, interface buffer overflows, and MLD snooping transitions can cause individual frames to be lost. Because BRC-124 frames carry a stable per-flow `HashKey` and a monotonic `SeqNum` stamped by the ingress proxy, listeners can detect exactly which frame is missing without a central sequence authority.
 
 This BRC adds the reliability layer that allows listeners to recover those gaps:
 
-1. **Gap detection** — listeners identify missing frames when a frame's `Sequence Number` advances by more than 1 from the last-seen value for a given `(Sender ID, Sequence ID)` flow.
-2. **NACK dispatch** — listeners send a 56-byte NACK datagram to a retry endpoint identifying the missing frame by its sender flow and sequence number.
+1. **Gap detection** — listeners identify missing frames when a frame's `SeqNum` advances by more than 1 from the last-seen value for a given `HashKey` flow.
+2. **NACK dispatch** — listeners send a 64-byte NACK datagram to a retry endpoint identifying the missing frame by its flow (`HashKey`) and sequence number.
 3. **ACK/MISS responses** — every NACK receives a deterministic 16-byte response; ACK confirms retransmit dispatched, MISS triggers immediate escalation.
 4. **Endpoint discovery** — retry endpoints periodically multicast a 56-byte ADVERT beacon; listeners maintain a dynamic registry sorted by tier and preference, with no manual configuration required in well-connected deployments.
 5. **Flood prevention** — deduplication and fill-suppression mechanisms prevent retransmit storms at scale.
@@ -40,7 +40,7 @@ The `MsgType` byte at offset 6 is in the same position as `FrameVersion` in BRC-
 
 | MsgType | Name   | Size | Direction                     |
 | ------- | ------ | ---- | ----------------------------- |
-| `0x10`  | NACK   | 56 B | Listener → Retry endpoint     |
+| `0x10`  | NACK   | 64 B | Listener → Retry endpoint     |
 | `0x11`  | MISS   | 16 B | Retry endpoint → Listener     |
 | `0x12`  | ACK    | 16 B | Retry endpoint → Listener     |
 | `0x20`  | ADVERT | 56 B | Retry endpoint → Beacon group |
@@ -91,27 +91,28 @@ When `-mc-base-addr` middle bytes are configured, those bytes are interleaved at
 
 ---
 
-### NACK Wire Format (`MsgType 0x10`) — 56 bytes
+### NACK Wire Format (`MsgType 0x10`) — 64 bytes
 
-Sent by a listener to a retry endpoint when a gap is detected. Identifies the missing frame by sender flow (`Sender ID` + `Sequence ID`) and sequence number range. For current single-frame retrieval, `Start Sequence Number == End Sequence Number`; range requests are reserved for future use.
+Sent by a listener to a retry endpoint when a gap is detected. Identifies the missing frame by its flow (`HashKey`) and sequence number range. For current single-frame retrieval, `StartSeq == EndSeq`; range requests (`StartSeq < EndSeq`) are reserved for future use.
 
-| Offset | Size | Field                | Description                                                             |
-| ------ | ---- | -------------------- | ----------------------------------------------------------------------- |
-| 0      | 4    | Magic                | `0xE3E1F3E8`                                                            |
-| 4      | 2    | ProtoVer             | `0x02BF`                                                                |
-| 6      | 1    | MsgType              | `0x10` (NACK)                                                           |
-| 7      | 1    | Flags                | Reserved; must be `0x00`                                                |
-| 8      | 4    | Sender ID            | CRC32c of source IPv6; from BRC-124 frame bytes 40–43                   |
-| 12     | 4    | Sequence ID          | Flow identifier; from BRC-124 frame bytes 44–47                         |
-| 16     | 4    | Start Sequence Number| First missing sequence number (inclusive)                               |
-| 20     | 4    | End Sequence Number  | Last missing sequence number (inclusive); equals Start for single-frame |
-| 24     | 32   | Subtree ID           | 32-byte batch identifier; from BRC-124 frame bytes 56–87; zeros = unset |
+| Offset | Size | Field     | Description                                                                     |
+| ------ | ---- | --------- | ------------------------------------------------------------------------------- |
+| 0      | 4    | Magic     | `0xE3E1F3E8`                                                                    |
+| 4      | 2    | ProtoVer  | `0x02BF`                                                                        |
+| 6      | 1    | MsgType   | `0x10` (NACK)                                                                   |
+| 7      | 1    | Flags     | Reserved; must be `0x00`                                                        |
+| 8      | 8    | HashKey   | Stable per-flow XXH64 identifier; from BRC-124 frame bytes 40–47               |
+| 16     | 8    | StartSeq  | First missing `SeqNum` (inclusive)                                              |
+| 24     | 8    | EndSeq    | Last missing `SeqNum` (inclusive); equals `StartSeq` for single-frame retrieval |
+| 32     | 32   | SubtreeID | 32-byte batch identifier; from BRC-124 frame bytes 56–87; zeros = unset        |
 
 The listener opens a per-request ephemeral UDP socket (`[::]:0`), sends the NACK, and waits up to 300 ms for a single response (`MISS` or `ACK`).
 
-> **Sender ID + Sequence ID** together identify the flow whose frame is missing. The retry endpoint uses `Sender ID` as a per-flow rate-limiting key (NACK storm cap). A `Sender ID` of `0` bypasses the per-flow check.
+> **HashKey** (offset 8) is the `HashKey` field from the BRC-124 frame, computed as `XXH64(senderIPv6 ∥ groupIdx ∥ subtreeID)`. It uniquely identifies the flow. The retry endpoint uses `HashKey` as a per-flow rate-limiting key (NACK storm cap). A value of `0` bypasses the per-flow check.
 
-> **Start / End Sequence Number** specify the missing range. The retry endpoint looks up the frame using the cache key `(Sender ID, Sequence ID, Start Sequence Number)`.
+> **StartSeq / EndSeq** (offsets 16/24) specify the range of missing sequence numbers. For current single-frame retrieval, `StartSeq == EndSeq`. The retry endpoint looks up the frame using the 16-byte cache key `HashKey ∥ StartSeq`.
+
+> **SubtreeID** (offset 32) is carried for informational purposes; the cache key is `HashKey ∥ SeqNum` and does not require SubtreeID for disambiguation.
 
 ---
 
@@ -125,8 +126,7 @@ Sent unicast to the NACK source when the requested frame is not in the endpoint'
 | 4      | 2    | ProtoVer | `0x02BF`                            |
 | 6      | 1    | MsgType  | `0x11` (MISS)                       |
 | 7      | 1    | Flags    | Reserved; must be `0x00`            |
-| 8      | 4    | Sequence Number | Always `0x00000000` on MISS        |
-| 12     | 4    | Reserved        | Must be `0x00000000`               |
+| 8      | 8    | SeqNum   | Always `0` on MISS                  |
 
 ---
 
@@ -140,10 +140,9 @@ Sent unicast to the NACK source when the frame was found and retransmit dispatch
 | 4      | 2    | ProtoVer | `0x02BF`                                           |
 | 6      | 1    | MsgType  | `0x12` (ACK)                                       |
 | 7      | 1    | Flags    | `0x01` = multicast sent; `0x02` = unicast sent     |
-| 8      | 4    | Sequence Number | `Sequence Number` of the retransmitted frame (from BRC-124 bytes 48–51) |
-| 12     | 4    | Reserved        | Must be `0x00000000`                                                    |
+| 8      | 8    | SeqNum   | `SeqNum` of the retransmitted frame (from BRC-124 bytes 48–55) |
 
-The listener uses the `Sequence Number` echo to confirm the gap entry matches before cancelling it.
+The listener uses the `SeqNum` echo to confirm the gap entry matches before cancelling it.
 
 ---
 
@@ -264,20 +263,19 @@ A1B2C3D4                                  // InstanceID (CRC32c of hostname)
 00000000000000000000000000000000          // Reserved (16 bytes)
 ```
 
-### NACK Datagram (56 bytes)
+### NACK Datagram (64 bytes)
 
-Single-frame retrieval: missing frame for sender `0xA1B2C3D4`, flow `0x00000001`, sequence number `1235`:
+Single-frame retrieval: missing frame for flow `HashKey=0xA1B2C3D400000001`, `SeqNum=1235`:
 
 ```text
 E3E1F3E8                                  // Network Magic
 02BF                                      // Protocol Version
 10                                        // MsgType = NACK
 00                                        // Flags (reserved)
-A1B2C3D4                                  // Sender ID (CRC32c of source IPv6)
-00000001                                  // Sequence ID (flow identifier)
-000004D3                                  // Start Sequence Number = 1235
-000004D3                                  // End Sequence Number = 1235 (single frame)
-baadf498a00ca5a44d1c4d9d103b49017f53cd8cb2a70a9c67fc884ecdd622b5  // Subtree ID
+A1B2C3D400000001                          // HashKey (XXH64 of sender+group+subtree)
+00000000000004D3                          // StartSeq = 1235
+00000000000004D3                          // EndSeq = 1235 (single frame)
+baadf498a00ca5a44d1c4d9d103b49017f53cd8cb2a70a9c67fc884ecdd622b5  // SubtreeID
 ```
 
 ### MISS Response (16 bytes)
@@ -287,8 +285,7 @@ E3E1F3E8                                  // Network Magic
 02BF                                      // Protocol Version
 11                                        // MsgType = MISS
 00                                        // Flags
-00000000                                  // Sequence Number = 0 (cache miss)
-00000000                                  // Reserved
+0000000000000000                          // SeqNum = 0 (cache miss)
 ```
 
 ### ACK Response (16 bytes)
@@ -300,8 +297,7 @@ E3E1F3E8                                  // Network Magic
 02BF                                      // Protocol Version
 12                                        // MsgType = ACK
 01                                        // Flags = multicast_sent
-000004D3                                  // Sequence Number of retransmitted frame (1235)
-00000000                                  // Reserved
+00000000000004D3                          // SeqNum of retransmitted frame (1235)
 ```
 
 ---
@@ -309,7 +305,7 @@ E3E1F3E8                                  // Network Magic
 ## References
 
 - [BRC-12: Raw Transaction Format](./0012.md) — Payload format for transaction data within BRC-124 frames
-- [BRC-124: Multicast Transaction Frame Format](./0124.md) — Data-plane frame format; defines `Sender ID`, `Sequence ID`, `Sequence Number`, and `Subtree ID` stamped by the sender
+- [BRC-124: Multicast Transaction Frame Format](./0124.md) — Data-plane frame format; defines `HashKey`, `SeqNum`, and `Subtree ID` stamped by the proxy
 - [bitcoin-shard-common](https://github.com/lightwebinc/bitcoin-shard-common) — Reference implementation of frame and shard primitives (Go)
 
 ---
@@ -328,7 +324,7 @@ E3E1F3E8                                  // Network Magic
 | `ScopesSite`           | 5          | `0x05`       | Site-local beacon scope              |
 | `ScopeOrg`             | 8          | `0x08`       | Organisation beacon scope            |
 | `ScopeGlobal`          | 14         | `0x0E`       | Global beacon scope                  |
-| `NACKSize`             | 56         | `0x38`       | NACK datagram size in bytes          |
+| `NACKSize`             | 64         | `0x40`       | NACK datagram size in bytes          |
 | `FlagMulticastSent`    | 1          | `0x01`       | ACK flag: multicast retransmit sent  |
 | `FlagUnicastSent`      | 2          | `0x02`       | ACK flag: unicast retransmit sent    |
 | `FlagHasParent`        | 2          | `0x02`       | ADVERT flag: upstream endpoint set   |
@@ -349,4 +345,4 @@ E3E1F3E8                                  // Network Magic
 - **Retry endpoint:** [bitcoin-retry-endpoint](https://github.com/lightwebinc/bitcoin-retry-endpoint) — NACK server (`server/server.go`), ADVERT sender (`beacon/beacon.go`), frame cache (`cache/`), rate limiting (`ratelimit/`)
 - **Listener:** [bitcoin-shard-listener](https://github.com/lightwebinc/bitcoin-shard-listener) — NACK wire encode/decode (`nack/wire.go`), gap tracker (`nack/nack.go`), ADVERT decode + endpoint registry (`discovery/`)
 - **Common:** [bitcoin-shard-common](https://github.com/lightwebinc/bitcoin-shard-common) — Frame decode (`frame/frame.go`), shard group derivation (`shard/shard.go`), control group address helper (`shard/control.go`)
-- **Proxy:** [bitcoin-shard-proxy](https://github.com/lightwebinc/bitcoin-shard-proxy) — Sender ID / Sequence Number stamping (`forwarder/forwarder.go`)
+- **Proxy:** [bitcoin-shard-proxy](https://github.com/lightwebinc/bitcoin-shard-proxy) — HashKey / SeqNum stamping (`forwarder/forwarder.go`)

--- a/transactions/README.md
+++ b/transactions/README.md
@@ -23,3 +23,4 @@ BRC | Standard
 96   | [BEEF V2 Txid Only Extension](./0096.md)
 119  | [SubTree Unified Merkle Path (STUMP) Format](./0119.md)
 124  | [Multicast Transaction Frame Format](./0124.md)
+126  | [Multicast Transaction NACK Retransmission Protocol](./0126.md)


### PR DESCRIPTION
### This pull request:

Proposes a new standard by creating a new markdown file in the appropriate directory and requests discussion and assignment of a BRC number

### Summary

## BRC-126: Multicast NACK-based Retransmission Protocol

Adds a new BRC specifying the NACK-based retransmission and endpoint discovery protocol for the BSV multicast transaction distribution pipeline.

### What it defines

- Four UDP datagram formats: ADVERT (56 B), NACK (24 B), MISS (16 B), ACK (16 B)
- Tier/preference endpoint selection with an escalation state machine
- Beacon-based discovery via site/org/global multicast scopes
- Configurable retransmit modes (multicast, unicast, suppress-ack/miss)
- Flood prevention mechanisms (dedup window, jitter hold-off, exponential backoff, fill-suppression)

### Relationship to other BRCs

- Builds on BRC-124 (Multicast Transaction Frame Format) — uses the PrevSeq/CurSeq XXH64 hash chain for gap detection
- References BRC-12 for payload format

