### PR TITLE
BRC-129: IPv6 Multicast Group Address Assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ BRC | Standard
 123  | [Basket Identifier Namespace Framework](./wallet/0123.md)
 124  | [Multicast Transaction Frame Format](./transactions/0124.md)
 125  | [PeerPay URI Scheme for BRC-29 Payments](./payments/0125.md)
+129  | [IPv6 Multicast Group Address Assignments](./transactions/0129.md)
 
 ## License
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -127,6 +127,7 @@
 * [Message Signature Creation and Verification](./peer-to-peer/0077.md)
 * [Serialization Format for Portable Encrypted Messages](./peer-to-peer/0078.md)
 * [Defining a Scalable IPv6 Multicast Protocol for Blockchain Transaction Broadcast and Update Delivery](./peer-to-peer/0082.md)
+* [IPv6 Multicast Group Address Assignments](./peer-to-peer/0129.md)
 * [Proven Identity Key Exchange (PIKE)](./peer-to-peer/0085.md)
 * [Peer-to-Peer Mutual Authentication and Certificate Exchange Protocol](./peer-to-peer/0103.md)
 * [HTTP Transport for BRC-103 Mutual Authentication](./peer-to-peer/0104.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -61,6 +61,7 @@
 * [BEEF V2 Txid Only Extension](./transactions/0096.md)
 * [SubTree Unified Merkle Path (STUMP) Format](./transactions/0119.md)
 * [Multicast Transaction Frame Format](./transactions/0124.md)
+* [IPv6 Multicast Group Address Assignments](./transactions/0129.md)
 
 ## Scripts
 
@@ -127,7 +128,6 @@
 * [Message Signature Creation and Verification](./peer-to-peer/0077.md)
 * [Serialization Format for Portable Encrypted Messages](./peer-to-peer/0078.md)
 * [Defining a Scalable IPv6 Multicast Protocol for Blockchain Transaction Broadcast and Update Delivery](./peer-to-peer/0082.md)
-* [IPv6 Multicast Group Address Assignments](./peer-to-peer/0129.md)
 * [Proven Identity Key Exchange (PIKE)](./peer-to-peer/0085.md)
 * [Peer-to-Peer Mutual Authentication and Certificate Exchange Protocol](./peer-to-peer/0103.md)
 * [HTTP Transport for BRC-103 Mutual Authentication](./peer-to-peer/0104.md)

--- a/peer-to-peer/0129.md
+++ b/peer-to-peer/0129.md
@@ -1,0 +1,134 @@
+# BRC-129: IPv6 Multicast Group Address Assignments
+
+Jeff Harris (jeff@lightweb.net)
+
+## Abstract
+
+This BRC specifies the IPv6 multicast group address scheme for the BSV transaction sharding pipeline. It defines how the 16-bit shard index space is allocated across data-plane shard groups and control-plane service groups, how addresses are derived from the IANA Bitcoin multicast allocation, and the canonical addresses for beacon discovery, subtree announcement, and the block control channel.
+
+## Copyright
+
+This BRC is licensed under the Open BSV License.
+
+## Motivation
+
+[BRC-82](./0082.md) establishes the scalable IPv6 multicast protocol for BSV transaction distribution. [BRC-124](../transactions/0124.md) defines the wire frame format. Both reference a set of multicast group addresses without specifying a canonical address scheme. As the multicast infrastructure is deployed across multiple scopes (site-local, organisation-local, and global) and across independent operator networks, a shared addressing convention is needed so that:
+
+1. Any deployment with `shardBits ≤ 15` produces data-plane group indices that are orthogonal to control-plane groups.
+2. Control-plane services — beacon discovery, subtree announcements, and block control — use stable, well-known addresses operators can pre-configure in firewalls and routing policy.
+3. Operators running private or test networks can use an alternative group-id to isolate their multicast address space without modifying any other aspect of the protocol.
+
+## Specification
+
+### IANA Allocation
+
+IANA allocates IPv6 multicast group addresses on the **96-bit boundary**: the top 96 bits (bytes `[0:12]`) identify the IANA-assigned group, leaving the bottom 32 bits (bytes `[12:16]`) for sub-allocation by the assignee.
+
+The IANA Bitcoin multicast allocation is `FF0X::B` (group-id `0x000B`). This BRC splits the bottom 32 bits of that allocation into two 16-bit subfields:
+
+- **Bytes `[12:14]`** — IANA group-id (default `0x000B`)
+- **Bytes `[14:16]`** — shard index (16-bit, application-assigned)
+
+```text
+Byte:   0  1    2  3  4  5  6  7  8  9 10 11   12 13   14 15
+        [scope] [-------- IANA boundary zero -------]  [GID] [IDX]
+        FF 05    00 00 00 00 00 00 00 00 00 00         00 0B  XX XX
+```
+
+Conformant deployments MUST use group-id `0x000B`. Operators MAY override the group-id (see [Group-ID Override](#group-id-override)) for testing or private deployments. Deployments using different group-ids operate in entirely disjoint multicast address spaces.
+
+### Address Derivation
+
+Every multicast group address in the BSV shard pipeline is derived from three components:
+
+1. **Scope prefix** (`MCPrefix`, 2 bytes) — the first two bytes of the IPv6 address. Common values: `FF05` (site-local), `FF08` (organisation-local), `FF0E` (global).
+2. **IANA group-id** (`MCGroupID`, 2 bytes) — occupies bytes `[12:14]`. Default: `0x000B`.
+3. **Shard group index** (`IDX`, 2 bytes) — occupies bytes `[14:16]`.
+
+The full 128-bit address is assembled as:
+
+```text
+[MCPrefix][0x00 × 10][MCGroupID][IDX]
+```
+
+For example, with scope `FF05`, group-id `0x000B`, and shard index `0x0003`:
+
+```text
+FF05:0000:0000:0000:0000:0000:000B:0003
+```
+
+Compressed form: `FF05::B:3`
+
+### Data-Plane Shard Groups
+
+Shard group indices MUST occupy the range `0x0000`–`0x0FFF` (4,096 indices). The maximum permitted value is `shardBits = 12` (4,096 groups), which keeps all shard indices within this range. Indices at or above `0x1000` MUST NOT be used as shard group indices.
+
+The group index for a transaction is derived deterministically from its TxID:
+
+```
+groupIndex = binary.BigEndian.Uint32(txid[0:4]) >> (32 - shardBits)
+```
+
+Implementations MUST use only the low 16 bits of `groupIndex` when assembling the multicast address.
+
+### Free Space and Specialty Transmission Domains
+
+Indices `0x1000`–`0xF7FF` (56,832 indices) are unassigned and reserved for future use. This range accommodates future expansion of the shard group space, as well as specialty transmission domains for purpose-specific multicast services that are not general-purpose transaction sharding. No current protocol assigns addresses in this range. Implementations MUST NOT join or transmit to addresses in this range unless explicitly specified by a future BRC.
+
+### Control-Plane Reserved Indices
+
+Network service groups occupy `0xF800`–`0xFFFF` (2,048 indices). Current protocol assignments are allocated from the top of this range; the remainder is reserved for future network services. Implementations MUST NOT use unassigned indices within this range. The defined assignments MUST be supported at the scopes indicated; additional scopes are permitted where operationally necessary.
+
+| Index    | Purpose                              | Scope    | Full address (default group-id)                     | Compressed       |
+| -------- | ------------------------------------ | -------- | --------------------------------------------------- | ---------------- |
+| `0xFFFB` | Subtree Announcements (site)         | `FF05`   | `FF05:0000:0000:0000:0000:0000:000B:FFFB`           | `FF05::B:FFFB`   |
+| `0xFFFB` | Subtree Announcements (org)          | `FF08`   | `FF08:0000:0000:0000:0000:0000:000B:FFFB`           | `FF08::B:FFFB`   |
+| `0xFFFB` | Subtree Announcements (global)       | `FF0E`   | `FF0E:0000:0000:0000:0000:0000:000B:FFFB`           | `FF0E::B:FFFB`   |
+| `0xFFFC` | Subtree Group Announcements (site)   | `FF05`   | `FF05:0000:0000:0000:0000:0000:000B:FFFC`           | `FF05::B:FFFC`   |
+| `0xFFFC` | Subtree Group Announcements (org)    | `FF08`   | `FF08:0000:0000:0000:0000:0000:000B:FFFC`           | `FF08::B:FFFC`   |
+| `0xFFFC` | Subtree Group Announcements (global) | `FF0E`   | `FF0E:0000:0000:0000:0000:0000:000B:FFFC`           | `FF0E::B:FFFC`   |
+| `0xFFFD` | Beacon (site)                        | `FF05`   | `FF05:0000:0000:0000:0000:0000:000B:FFFD`           | `FF05::B:FFFD`   |
+| `0xFFFD` | Beacon (org)                         | `FF08`   | `FF08:0000:0000:0000:0000:0000:000B:FFFD`           | `FF08::B:FFFD`   |
+| `0xFFFD` | Beacon (global)                      | `FF0E`   | `FF0E:0000:0000:0000:0000:0000:000B:FFFD`           | `FF0E::B:FFFD`   |
+| `0xFFFE` | Block Control channel                | `FF0E`   | `FF0E:0000:0000:0000:0000:0000:000B:FFFE`           | `FF0E::B:FFFE`   |
+| `0xFFFF` | _(reserved)_                         | —        | reserved                                            | do not use       |
+
+### Group-ID Override
+
+The 16-bit IANA group-id field (bytes `[12:14]`) is configurable via the `-mc-group-id` flag (environment variable `MC_GROUP_ID`). The default is `0x000B` (IANA Bitcoin allocation).
+
+```
+-mc-group-id 0x000B    # default (IANA Bitcoin)
+-mc-group-id 0xCAFE    # private deployment / lab
+```
+
+All group addresses — both shard and control-plane — inherit the same group-id. Deployments using different group-ids are entirely isolated at the multicast layer with no protocol changes required.
+
+### Beacon Groups
+
+Beacon groups (`0xFFFD`) carry ADVERT messages that enable listeners to discover retry endpoint addresses without manual configuration. Each beacon-enabled service instance advertises to exactly one scope group, selected via `-beacon-scope`. Deployments requiring coverage across multiple scopes run separate service instances per scope. The beacon protocol is specified in [BRC-126](https://github.com/lightwebinc/bitcoin-multicast/blob/main/docs/brc-126-retransmission-protocol.md).
+
+### Subtree Announcements
+
+Subtree Announcement groups (`0xFFFB`) carry signed announcements of a subtree's transaction IDs and their ordering within the subtree's Merkle structure. The subtree ID is the Merkle root hash of the announced set. Listeners subscribe to this group to discover transaction batches for downstream filtering. The subtree announcement protocol is specified in [BRC-127](https://github.com/lightwebinc/bitcoin-multicast/blob/main/docs/brc-127-subtree-announce.md).
+
+### Subtree Group Announcements
+
+Subtree Group Announcement groups (`0xFFFC`) carry announcements of new subtree inclusions in a logical group of subtrees. This enables listeners to discover related transaction groupings and configure automated filtering for special-interest downstream networks. Like beacon and subtree announcement groups, multiple scopes are supported.
+
+### Block Control Channel
+
+`FF0E::B:FFFE` (index `0xFFFE`, global scope only) is a mandatory channel distributing block headers, block templates, coinbase transactions, chained-transaction anchors, and other producer data of interest to all network participants. All conformant network participants MUST join this group.
+
+## References
+
+- [BRC-82: Defining a Scalable IPv6 Multicast Protocol for Blockchain Transaction Broadcast and Update Delivery](./0082.md) — Overall multicast protocol architecture
+- [BRC-124: Multicast Transaction Frame Format](../transactions/0124.md) — Wire format for data-plane frames
+- [BRC-119: SubTree Unified Merkle Path (STUMP) Format](../transactions/0119.md) — Subtree ID concept referenced by the subtree announcement groups
+- [BRC-126: NACK Retransmission Protocol](https://github.com/lightwebinc/bitcoin-multicast/blob/main/docs/brc-126-retransmission-protocol.md) — ADVERT beacon wire format and endpoint discovery
+- [BRC-127: Subtree Group Announcement Protocol](https://github.com/lightwebinc/bitcoin-multicast/blob/main/docs/brc-127-subtree-announce.md) — Subtree announcement wire format and listener integration
+
+## Implementations
+
+- **Go**: [bitcoin-shard-common/shard](https://github.com/lightwebinc/bitcoin-shard-common/tree/main/shard) — `Engine.Addr(groupIndex, port)` (data-plane addresses), `ControlGroupAddr(scopePrefix, groupID, index)` (control-plane addresses), `DefaultGroupID = 0x000B`, constants `CtrlGroupSubtreeAnnounce`, `CtrlGroupSubtreeGroupAnnounce`, `CtrlGroupBeacon`, `CtrlGroupControl`
+- **Services**: [bitcoin-shard-proxy](https://github.com/lightwebinc/bitcoin-shard-proxy), [bitcoin-shard-listener](https://github.com/lightwebinc/bitcoin-shard-listener), [bitcoin-retry-endpoint](https://github.com/lightwebinc/bitcoin-retry-endpoint), [bitcoin-multicast](https://github.com/lightwebinc/bitcoin-multicast)

--- a/transactions/0129.md
+++ b/transactions/0129.md
@@ -12,7 +12,7 @@ This BRC is licensed under the Open BSV License.
 
 ## Motivation
 
-[BRC-82](./0082.md) establishes the scalable IPv6 multicast protocol for BSV transaction distribution. [BRC-124](../transactions/0124.md) defines the wire frame format. Both reference a set of multicast group addresses without specifying a canonical address scheme. As the multicast infrastructure is deployed across multiple scopes (site-local, organisation-local, and global) and across independent operator networks, a shared addressing convention is needed so that:
+[BRC-82](../peer-to-peer/0082.md) details a design for a scalable IPv6 multicast protocol for BSV transaction distribution. [BRC-124](./0124.md) defines a multicast transmission wire frame format. Both reference a set of multicast group addresses without specifying a canonical address scheme. As the multicast infrastructure is deployed across multiple scopes (site-local, organisation-local, and global) and across independent operator networks, a shared addressing convention is needed so that:
 
 1. Any deployment with `shardBits ≤ 15` produces data-plane group indices that are orthogonal to control-plane groups.
 2. Control-plane services — beacon discovery, subtree announcements, and block control — use stable, well-known addresses operators can pre-configure in firewalls and routing policy.
@@ -122,9 +122,9 @@ Subtree Group Announcement groups (`0xFFFC`) carry announcements of new subtree 
 
 ## References
 
-- [BRC-82: Defining a Scalable IPv6 Multicast Protocol for Blockchain Transaction Broadcast and Update Delivery](./0082.md) — Overall multicast protocol architecture
-- [BRC-124: Multicast Transaction Frame Format](../transactions/0124.md) — Wire format for data-plane frames
-- [BRC-119: SubTree Unified Merkle Path (STUMP) Format](../transactions/0119.md) — Subtree ID concept referenced by the subtree announcement groups
+- [BRC-82: Defining a Scalable IPv6 Multicast Protocol for Blockchain Transaction Broadcast and Update Delivery](../peer-to-peer/0082.md) — Overall multicast protocol architecture
+- [BRC-124: Multicast Transaction Frame Format](./0124.md) — Wire format for data-plane frames
+- [BRC-119: SubTree Unified Merkle Path (STUMP) Format](./0119.md) — Subtree ID concept referenced by the subtree announcement groups
 - [BRC-126: NACK Retransmission Protocol](https://github.com/lightwebinc/bitcoin-multicast/blob/main/docs/brc-126-retransmission-protocol.md) — ADVERT beacon wire format and endpoint discovery
 - [BRC-127: Subtree Group Announcement Protocol](https://github.com/lightwebinc/bitcoin-multicast/blob/main/docs/brc-127-subtree-announce.md) — Subtree announcement wire format and listener integration
 

--- a/transactions/README.md
+++ b/transactions/README.md
@@ -23,3 +23,4 @@ BRC | Standard
 96   | [BEEF V2 Txid Only Extension](./0096.md)
 119  | [SubTree Unified Merkle Path (STUMP) Format](./0119.md)
 124  | [Multicast Transaction Frame Format](./0124.md)
+129  | [IPv6 Multicast Group Address Assignments](./0129.md)


### PR DESCRIPTION
### This pull request:

Proposes a new standard by creating a new markdown file in the appropriate directory and requests discussion and assignment of a BRC number

### Summary

## BRC-129: IPv6 Multicast Group Address Assignments

This BRC specifies the canonical IPv6 multicast group address scheme for the BSV transaction sharding pipeline. It defines the 16-bit index space allocation:

- Shard groups: 0x0000–0x0FFF (4,096 groups, shardBits ≤ 12)
- Free space: 0x1000–0xF7FF (56,832 indices) — reserved for future expansion and specialty transmission domains
- Network services: 0xF800–0xFFFF (2,048 indices) — control-plane services (beacons, subtree announcements, block control) allocated from the top

Addresses are derived from the IANA Bitcoin SV Node multicast allocation FF0X::B (group-id 0x000B), with configurable group-id override for private deployments.

