### PR TITLE
BRC-132: Multicast Subtree Data Frame Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ BRC | Standard
 123  | [Basket Identifier Namespace Framework](./wallet/0123.md)
 124  | [Multicast Transaction Frame Format](./transactions/0124.md)
 125  | [PeerPay URI Scheme for BRC-29 Payments](./payments/0125.md)
+132  | [Subtree Data Multicast Protocol](./transactions/0132.md)
 
 ## License
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -61,6 +61,7 @@
 * [BEEF V2 Txid Only Extension](./transactions/0096.md)
 * [SubTree Unified Merkle Path (STUMP) Format](./transactions/0119.md)
 * [Multicast Transaction Frame Format](./transactions/0124.md)
+* [Subtree Data Multicast Protocol](./transactions/0132.md)
 
 ## Scripts
 

--- a/transactions/0132.md
+++ b/transactions/0132.md
@@ -38,7 +38,7 @@ Subtree data frames are sent to the `CtrlGroupSubtreeAnnounce` group (index
 `0xFFFB`):
 
 | Index  | Scope  | Compressed Address | Constant                 |
-| ------ | ------ | ------------------ | ------------------------ |
+|--------|--------|--------------------|--------------------------|
 | 0xFFFB | site   | FF05::B:FFFB       | CtrlGroupSubtreeAnnounce |
 | 0xFFFB | org    | FF08::B:FFFB       | CtrlGroupSubtreeAnnounce |
 | 0xFFFB | global | FF0E::B:FFFB       | CtrlGroupSubtreeAnnounce |
@@ -54,18 +54,18 @@ components that inspect Magic, HashKey, or SeqNum read correct values at the
 same offsets. The header is read using the same 44+48 two-step protocol as
 BRC-124 and BRC-131.
 
-| Offset | Size | Align | Field         | Value / Notes                                          |
-| ------ | ---- | ----- | ------------- | ------------------------------------------------------ |
-| 0      | 4    | —     | Network Magic | `0xE3E1F3E8` (BSV mainnet P2P magic)                   |
-| 4      | 2    | —     | Protocol Ver  | `0x02BF` (703, BSV large-block baseline)               |
-| 6      | 1    | —     | Frame Version | `0x05` — BRC-132 subtree data                          |
-| 7      | 1    | —     | MsgType       | `0x01` = HashesOnly, `0x02` = FullNodes                |
-| 8      | 32   | 8B    | SubtreeID     | SHA-256 Merkle root of the subtree (content ID)        |
-| 40     | 8    | 8B    | HashKey       | `XXH64(senderIPv6 ∥ 0xFFFB ∥ SubtreeID)`; proxy-stamped |
+| Offset | Size | Align | Field         | Value / Notes                                            |
+|--------|------|-------|---------------|----------------------------------------------------------|
+| 0      | 4    | —     | Network Magic | `0xE3E1F3E8` (BSV mainnet P2P magic)                     |
+| 4      | 2    | —     | Protocol Ver  | `0x02BF` (703, BSV large-block baseline)                 |
+| 6      | 1    | —     | Frame Version | `0x05` — BRC-132 subtree data                            |
+| 7      | 1    | —     | MsgType       | `0x01` = HashesOnly, `0x02` = FullNodes                  |
+| 8      | 32   | 8B    | SubtreeID     | SHA-256 Merkle root of the subtree (content ID)          |
+| 40     | 8    | 8B    | HashKey       | `XXH64(senderIPv6 ∥ 0xFFFB ∥ SubtreeID)`; proxy-stamped  |
 | 48     | 8    | 8B    | SeqNum        | Monotonic counter per (sender, SubtreeID); proxy-stamped |
-| 56     | 32   | 8B    | LayoutPad32   | All zeros; retained for uniform `HeaderSize = 92`      |
-| 88     | 4    | 8B    | PayloadLen    | Payload size in bytes (uint32 BE)                      |
-| 92     | *    | —     | Payload       | MsgType-specific subtree data (see §Payload Format)    |
+| 56     | 32   | 8B    | LayoutPad32   | All zeros; retained for uniform `HeaderSize = 92`        |
+| 88     | 4    | 8B    | PayloadLen    | Payload size in bytes (uint32 BE)                        |
+| 92     | *    | —     | Payload       | MsgType-specific subtree data (see §Payload Format)      |
 
 **Key distinctions from BRC-124:**
 
@@ -81,7 +81,7 @@ BRC-124 and BRC-131.
 ### MsgType Values
 
 | MsgType | Constant               | Node Size | Description                             |
-| ------- | ---------------------- | --------- | --------------------------------------- |
+|---------|------------------------|-----------|-----------------------------------------|
 | `0x01`  | `SubtreeMsgHashesOnly` | 32 bytes  | TxHashes only (network transfer format) |
 | `0x02`  | `SubtreeMsgFullNodes`  | 48 bytes  | TxHash + Fee + Size per node            |
 
@@ -95,7 +95,7 @@ and a conflict set.
 #### Common Prefix (24 bytes)
 
 | Offset | Size | Field          | Description                                     |
-| ------ | ---- | -------------- | ----------------------------------------------- |
+|--------|------|----------------|-------------------------------------------------|
 | 0      | 8    | TotalFees      | Aggregate fee sum for the subtree (uint64 BE)   |
 | 8      | 8    | TotalSizeBytes | Aggregate serialised tx size (uint64 BE, bytes) |
 | 16     | 8    | NodeCount      | Number of transaction nodes (uint64 BE)         |
@@ -103,7 +103,7 @@ and a conflict set.
 #### MsgType 0x01 — HashesOnly
 
 | Offset       | Size   | Field                     |
-| ------------ | ------ | ------------------------- |
+|--------------|--------|---------------------------|
 | 24           | 32 × N | TxHashes                  |
 | 24 + 32N     | 8      | ConflictCount (uint64 BE) |
 | 24 + 32N + 8 | 32 × M | ConflictHashes            |
@@ -112,11 +112,11 @@ Maximum size at 1M nodes, 0 conflicts: 24 + 32 × 1,048,576 + 8 ≈ **32 MB**.
 
 #### MsgType 0x02 — FullNodes
 
-| Offset       | Size   | Field                                             |
-| ------------ | ------ | ------------------------------------------------- |
+| Offset       | Size   | Field                                            |
+|--------------|--------|--------------------------------------------------|
 | 24           | 48 × N | Nodes: TxHash (32B) ∥ Fee (8B BE) ∥ Size (8B BE) |
-| 24 + 48N     | 8      | ConflictCount (uint64 BE)                         |
-| 24 + 48N + 8 | 32 × M | ConflictHashes                                    |
+| 24 + 48N     | 8      | ConflictCount (uint64 BE)                        |
+| 24 + 48N + 8 | 32 × M | ConflictHashes                                   |
 
 Maximum size at 1M nodes, 0 conflicts: 24 + 48 × 1,048,576 + 8 ≈ **48 MB**.
 
@@ -139,7 +139,7 @@ using BRC-130:
 Fragment counts at MTU 9000 (fragDataSize = 8848 bytes):
 
 | Subtree size                  | Fragments |
-| ----------------------------- | --------- |
+|-------------------------------|-----------|
 | ~32 MB (HashesOnly, 1M nodes) | ~3,793    |
 | ~48 MB (FullNodes, 1M nodes)  | ~5,689    |
 
@@ -177,28 +177,28 @@ After reassembly, optional Merkle-root recomputation verifies the SubtreeID:
 
 ### Error Handling
 
-| Condition                      | Action                                        |
-| ------------------------------ | --------------------------------------------- |
-| `raw[6] != 0x05`               | Not BRC-132; handled by other decoders        |
-| Bad magic                      | Silent drop                                   |
-| Unknown MsgType                | Drop; `ErrBadSubtreeMsg`                      |
-| PayloadLen exceeds buffer      | Drop; `io.ErrUnexpectedEOF`                   |
-| Datagram shorter than 92 bytes | Drop; `ErrTooShort`                           |
-| `SeqNum == 0`                  | Frame not proxy-stamped; listener discards    |
+| Condition                      | Action                                         |
+|--------------------------------|------------------------------------------------|
+| `raw[6] != 0x05`               | Not BRC-132; handled by other decoders         |
+| Bad magic                      | Silent drop                                    |
+| Unknown MsgType                | Drop; `ErrBadSubtreeMsg`                       |
+| PayloadLen exceeds buffer      | Drop; `io.ErrUnexpectedEOF`                    |
+| Datagram shorter than 92 bytes | Drop; `ErrTooShort`                            |
+| `SeqNum == 0`                  | Frame not proxy-stamped; listener discards     |
 | Merkle mismatch (optional)     | Drop; `bsl_reassembly_merkle_mismatch_total++` |
 
 ## Constants Reference
 
-| Name                         | Value | Hex    | Description                                 |
-| ---------------------------- | ----- | ------ | ------------------------------------------- |
-| `FrameVerV5`                 | 5     | `0x05` | BRC-132 subtree data frame version          |
-| `SubtreeMsgHashesOnly`       | 1     | `0x01` | MsgType: TxHashes only (32B per node)       |
-| `SubtreeMsgFullNodes`        | 2     | `0x02` | MsgType: TxHash + Fee + Size (48B per node) |
-| `CtrlGroupSubtreeAnnounce`   | 65531 | `0xFFFB` | Subtree data multicast group index        |
-| `HeaderSize`                 | 92    | `0x5C` | BRC-132 header size (identical to BRC-124)  |
-| `SubtreeDataPayloadHeaderSize` | 24  | `0x18` | Fixed metadata prefix size                  |
-| `SubtreeNodeHashSize`        | 32    | `0x20` | Node size in HashesOnly payload             |
-| `SubtreeNodeFullSize`        | 48    | `0x30` | Node size in FullNodes payload              |
+| Name                           | Value | Hex      | Description                                 |
+|--------------------------------|-------|----------|---------------------------------------------|
+| `FrameVerV5`                   | 5     | `0x05`   | BRC-132 subtree data frame version          |
+| `SubtreeMsgHashesOnly`         | 1     | `0x01`   | MsgType: TxHashes only (32B per node)       |
+| `SubtreeMsgFullNodes`          | 2     | `0x02`   | MsgType: TxHash + Fee + Size (48B per node) |
+| `CtrlGroupSubtreeAnnounce`     | 65531 | `0xFFFB` | Subtree data multicast group index          |
+| `HeaderSize`                   | 92    | `0x5C`   | BRC-132 header size (identical to BRC-124)  |
+| `SubtreeDataPayloadHeaderSize` | 24    | `0x18`   | Fixed metadata prefix size                  |
+| `SubtreeNodeHashSize`          | 32    | `0x20`   | Node size in HashesOnly payload             |
+| `SubtreeNodeFullSize`          | 48    | `0x30`   | Node size in FullNodes payload              |
 
 ## References
 

--- a/transactions/0132.md
+++ b/transactions/0132.md
@@ -37,13 +37,11 @@ contains.
 Subtree data frames are sent to the `CtrlGroupSubtreeAnnounce` group (index
 `0xFFFB`):
 
-```text
-| Index  | Scope  | Compressed Address | Constant                   |
-|--------|--------|--------------------|----------------------------|
-| 0xFFFB | site   | FF05::B:FFFB       | CtrlGroupSubtreeAnnounce   |
-| 0xFFFB | org    | FF08::B:FFFB       | CtrlGroupSubtreeAnnounce   |
-| 0xFFFB | global | FF0E::B:FFFB       | CtrlGroupSubtreeAnnounce   |
-```
+| Index  | Scope  | Compressed Address | Constant                 |
+| ------ | ------ | ------------------ | ------------------------ |
+| 0xFFFB | site   | FF05::B:FFFB       | CtrlGroupSubtreeAnnounce |
+| 0xFFFB | org    | FF08::B:FFFB       | CtrlGroupSubtreeAnnounce |
+| 0xFFFB | global | FF0E::B:FFFB       | CtrlGroupSubtreeAnnounce |
 
 Scope selection follows the `CtrlGroupBeacon` pattern defined in BRC-129.
 Operators select one or more scopes via the `-announce-scope` flag on listening
@@ -56,20 +54,18 @@ components that inspect Magic, HashKey, or SeqNum read correct values at the
 same offsets. The header is read using the same 44+48 two-step protocol as
 BRC-124 and BRC-131.
 
-```text
-| Offset | Size | Align | Field         | Value / Notes                                         |
-|--------|------|-------|---------------|-------------------------------------------------------|
-| 0      | 4    | —     | Network Magic | 0xE3E1F3E8 (BSV mainnet P2P magic)                    |
-| 4      | 2    | —     | Protocol Ver  | 0x02BF (703, BSV large-block baseline)                |
-| 6      | 1    | —     | Frame Version | 0x05 — BRC-132 subtree data                           |
-| 7      | 1    | —     | MsgType       | 0x01 = HashesOnly, 0x02 = FullNodes                   |
-| 8      | 32   | 8B    | SubtreeID     | SHA-256 Merkle root of the subtree (content ID)       |
-| 40     | 8    | 8B    | HashKey       | XXH64(senderIPv6 ∥ 0xFFFB ∥ SubtreeID); proxy-stamped |
+| Offset | Size | Align | Field         | Value / Notes                                          |
+| ------ | ---- | ----- | ------------- | ------------------------------------------------------ |
+| 0      | 4    | —     | Network Magic | `0xE3E1F3E8` (BSV mainnet P2P magic)                   |
+| 4      | 2    | —     | Protocol Ver  | `0x02BF` (703, BSV large-block baseline)               |
+| 6      | 1    | —     | Frame Version | `0x05` — BRC-132 subtree data                          |
+| 7      | 1    | —     | MsgType       | `0x01` = HashesOnly, `0x02` = FullNodes                |
+| 8      | 32   | 8B    | SubtreeID     | SHA-256 Merkle root of the subtree (content ID)        |
+| 40     | 8    | 8B    | HashKey       | `XXH64(senderIPv6 ∥ 0xFFFB ∥ SubtreeID)`; proxy-stamped |
 | 48     | 8    | 8B    | SeqNum        | Monotonic counter per (sender, SubtreeID); proxy-stamped |
-| 56     | 32   | 8B    | LayoutPad32   | All zeros; retained for uniform HeaderSize = 92       |
-| 88     | 4    | 8B    | PayloadLen    | Payload size in bytes (uint32 BE)                     |
-| 92     | *    | —     | Payload       | MsgType-specific subtree data (see §Payload Format)   |
-```
+| 56     | 32   | 8B    | LayoutPad32   | All zeros; retained for uniform `HeaderSize = 92`      |
+| 88     | 4    | 8B    | PayloadLen    | Payload size in bytes (uint32 BE)                      |
+| 92     | *    | —     | Payload       | MsgType-specific subtree data (see §Payload Format)    |
 
 **Key distinctions from BRC-124:**
 
@@ -84,12 +80,10 @@ BRC-124 and BRC-131.
 
 ### MsgType Values
 
-```text
-| MsgType | Constant             | Node Size | Description                              |
-|---------|----------------------|-----------|------------------------------------------|
-| 0x01    | SubtreeMsgHashesOnly | 32 bytes  | TxHashes only (network transfer format)  |
-| 0x02    | SubtreeMsgFullNodes  | 48 bytes  | TxHash + Fee + Size per node             |
-```
+| MsgType | Constant               | Node Size | Description                             |
+| ------- | ---------------------- | --------- | --------------------------------------- |
+| `0x01`  | `SubtreeMsgHashesOnly` | 32 bytes  | TxHashes only (network transfer format) |
+| `0x02`  | `SubtreeMsgFullNodes`  | 48 bytes  | TxHash + Fee + Size per node            |
 
 Any other MsgType value causes the frame to be rejected with `ErrBadSubtreeMsg`.
 
@@ -100,35 +94,29 @@ and a conflict set.
 
 #### Common Prefix (24 bytes)
 
-```text
 | Offset | Size | Field          | Description                                     |
-|--------|------|----------------|-------------------------------------------------|
+| ------ | ---- | -------------- | ----------------------------------------------- |
 | 0      | 8    | TotalFees      | Aggregate fee sum for the subtree (uint64 BE)   |
 | 8      | 8    | TotalSizeBytes | Aggregate serialised tx size (uint64 BE, bytes) |
 | 16     | 8    | NodeCount      | Number of transaction nodes (uint64 BE)         |
-```
 
 #### MsgType 0x01 — HashesOnly
 
-```text
-| Offset        | Size   | Field         |
-|---------------|--------|---------------|
-| 24            | 32 × N | TxHashes      |
-| 24 + 32N      | 8      | ConflictCount (uint64 BE) |
-| 24 + 32N + 8  | 32 × M | ConflictHashes |
-```
+| Offset       | Size   | Field                     |
+| ------------ | ------ | ------------------------- |
+| 24           | 32 × N | TxHashes                  |
+| 24 + 32N     | 8      | ConflictCount (uint64 BE) |
+| 24 + 32N + 8 | 32 × M | ConflictHashes            |
 
 Maximum size at 1M nodes, 0 conflicts: 24 + 32 × 1,048,576 + 8 ≈ **32 MB**.
 
 #### MsgType 0x02 — FullNodes
 
-```text
-| Offset        | Size   | Field                                |
-|---------------|--------|--------------------------------------|
-| 24            | 48 × N | Nodes: TxHash (32B) ∥ Fee (8B BE) ∥ Size (8B BE) |
-| 24 + 48N      | 8      | ConflictCount (uint64 BE) |
-| 24 + 48N + 8  | 32 × M | ConflictHashes |
-```
+| Offset       | Size   | Field                                             |
+| ------------ | ------ | ------------------------------------------------- |
+| 24           | 48 × N | Nodes: TxHash (32B) ∥ Fee (8B BE) ∥ Size (8B BE) |
+| 24 + 48N     | 8      | ConflictCount (uint64 BE)                         |
+| 24 + 48N + 8 | 32 × M | ConflictHashes                                    |
 
 Maximum size at 1M nodes, 0 conflicts: 24 + 48 × 1,048,576 + 8 ≈ **48 MB**.
 
@@ -150,12 +138,10 @@ using BRC-130:
 
 Fragment counts at MTU 9000 (fragDataSize = 8848 bytes):
 
-```text
-| Subtree size                       | Fragments |
-|------------------------------------|-----------|
-| ~32 MB (HashesOnly, 1M nodes)      | ~3,793    |
-| ~48 MB (FullNodes, 1M nodes)       | ~5,689    |
-```
+| Subtree size                  | Fragments |
+| ----------------------------- | --------- |
+| ~32 MB (HashesOnly, 1M nodes) | ~3,793    |
+| ~48 MB (FullNodes, 1M nodes)  | ~5,689    |
 
 Both fit within the `uint16` `FragTotal` limit of 65,535.
 
@@ -189,91 +175,30 @@ After reassembly, optional Merkle-root recomputation verifies the SubtreeID:
 - On mismatch: drop the reassembly slot; increment
   `bsl_reassembly_merkle_mismatch_total`.
 
-### Proxy Forwarding Rules
-
-1. **Receive** — BRC-132 frames are accepted over TCP ingress. The switch in
-   `handleConn` recognises `FrameVerV5` using the same 44+48 two-step header
-   read as V2/V4.
-2. **Decode** — `DecodeSubtreeData` validates Magic, FrameVer, MsgType, and
-   PayloadLen. Invalid frames are dropped.
-3. **Stamp** — If `SeqNum == 0`, stamp `HashKey` and `SeqNum` in-place per
-   `(senderIPv6, 0xFFFB, SubtreeID)` flow, reading SubtreeID from bytes 8–39.
-4. **Fragment** — If `len(Payload) > fragDataSize`, fragment via BRC-130 with
-   `OrigFrameVer = 0x05` and MsgType preserved in byte 7.
-5. **Forward** — Write the frame to all egress interfaces with destination
-   `FF0X::B:FFFB:<egressPort>`.
-
-### Listener Processing Rules
-
-1. **Detection** — `IsSubtreeDataFrame(raw)` checks Magic and `raw[6] == 0x05`
-   before decode.
-2. **Decode** — `DecodeSubtreeData` validates the frame and returns a
-   `SubtreeDataFrame` with `MsgType`, `SubtreeID`, `HashKey`, `SeqNum`, and
-   `Payload`.
-3. **Gap tracking** — `Tracker.Observe(0xFFFB, SubtreeID, HashKey, SeqNum)` when
-   `SeqNum != 0`.
-4. **Filtering** — Subtree data frames bypass shard filtering. Listeners may
-   optionally filter by SubtreeID.
-5. **Reassembly** — BRC-130 fragments with `OrigFrameVer = 0x05` are routed to
-   `processSubtreeDataFrame` via the callback registered on construction.
-
-### Infrastructure Impact
-
-```text
-| Component              | Change                                                                          |
-|------------------------|---------------------------------------------------------------------------------|
-| bitcoin-shard-common   | FrameVerV5, SubtreeMsgHashesOnly, SubtreeMsgFullNodes, ErrBadSubtreeMsg         |
-|                        | constants; SubtreeDataFrame, SubtreeDataPayload structs;                        |
-|                        | EncodeSubtreeData, DecodeSubtreeData, IsSubtreeDataFrame,                       |
-|                        | EncodeSubtreeDataPayload, DecodeSubtreeDataPayload                              |
-| bitcoin-shard-proxy    | FrameVerV5 case in TCP handleConn; ProcessSubtreeData + fragmentSubtreeData     |
-| bitcoin-shard-listener | Joins FF0X::B:FFFB; IsSubtreeDataFrame detection; processSubtreeDataFrame;      |
-|                        | reassembly OrigFrameVer=0x05 callback path; optional Merkle verification        |
-| bitcoin-retry-endpoint | Joins FF0X::B:FFFB; processSubtreeDataFrame in ingress;                         |
-|                        | FrameVerV5-aware retransmit routing to FF0X::B:FFFB                            |
-| Firewall               | No new rules — FF0X::B:FFFB shares the same port as other groups               |
-```
-
 ### Error Handling
 
-```text
-| Condition                      | Action                                       |
-|--------------------------------|----------------------------------------------|
-| raw[6] != 0x05                 | Not BRC-132; handled by other decoders       |
-| Bad magic                      | Silent drop                                  |
-| Unknown MsgType                | Drop; ErrBadSubtreeMsg                       |
-| PayloadLen exceeds buffer      | Drop; io.ErrUnexpectedEOF                    |
-| Datagram shorter than 92 bytes | Drop; ErrTooShort                            |
-| SeqNum == 0                    | Frame not proxy-stamped; listener discards   |
-| Merkle mismatch (optional)     | Drop; bsl_reassembly_merkle_mismatch_total++ |
-```
+| Condition                      | Action                                        |
+| ------------------------------ | --------------------------------------------- |
+| `raw[6] != 0x05`               | Not BRC-132; handled by other decoders        |
+| Bad magic                      | Silent drop                                   |
+| Unknown MsgType                | Drop; `ErrBadSubtreeMsg`                      |
+| PayloadLen exceeds buffer      | Drop; `io.ErrUnexpectedEOF`                   |
+| Datagram shorter than 92 bytes | Drop; `ErrTooShort`                           |
+| `SeqNum == 0`                  | Frame not proxy-stamped; listener discards    |
+| Merkle mismatch (optional)     | Drop; `bsl_reassembly_merkle_mismatch_total++` |
 
 ## Constants Reference
 
-```text
-| Name                        | Value | Hex    | Description                                         |
-|-----------------------------|-------|--------|-----------------------------------------------------|
-| FrameVerV5                  | 5     | 0x05   | BRC-132 subtree data frame version                  |
-| SubtreeMsgHashesOnly        | 1     | 0x01   | MsgType: TxHashes only (32B per node)               |
-| SubtreeMsgFullNodes         | 2     | 0x02   | MsgType: TxHash + Fee + Size (48B per node)         |
-| CtrlGroupSubtreeAnnounce    | 65531 | 0xFFFB | Subtree data multicast group index                  |
-| HeaderSize                  | 92    | 0x5C   | BRC-132 header size (identical to BRC-124)          |
-| SubtreeDataPayloadHeaderSize| 24    | 0x18   | Fixed metadata prefix size                          |
-| SubtreeNodeHashSize         | 32    | 0x20   | Node size in HashesOnly payload                     |
-| SubtreeNodeFullSize         | 48    | 0x30   | Node size in FullNodes payload                      |
-```
-
-## Implementations
-
-- **Go**:
-  [bitcoin-shard-common/frame](https://github.com/lightwebinc/bitcoin-shard-common/tree/main/frame)
-  — `EncodeSubtreeData`, `DecodeSubtreeData`, `IsSubtreeDataFrame`,
-  `EncodeSubtreeDataPayload`, `DecodeSubtreeDataPayload`
-- **Services**:
-  [bitcoin-shard-proxy](https://github.com/lightwebinc/bitcoin-shard-proxy),
-  [bitcoin-shard-listener](https://github.com/lightwebinc/bitcoin-shard-listener),
-  [bitcoin-retry-endpoint](https://github.com/lightwebinc/bitcoin-retry-endpoint)
-  — Network multicast infrastructure
+| Name                         | Value | Hex    | Description                                 |
+| ---------------------------- | ----- | ------ | ------------------------------------------- |
+| `FrameVerV5`                 | 5     | `0x05` | BRC-132 subtree data frame version          |
+| `SubtreeMsgHashesOnly`       | 1     | `0x01` | MsgType: TxHashes only (32B per node)       |
+| `SubtreeMsgFullNodes`        | 2     | `0x02` | MsgType: TxHash + Fee + Size (48B per node) |
+| `CtrlGroupSubtreeAnnounce`   | 65531 | `0xFFFB` | Subtree data multicast group index        |
+| `HeaderSize`                 | 92    | `0x5C` | BRC-132 header size (identical to BRC-124)  |
+| `SubtreeDataPayloadHeaderSize` | 24  | `0x18` | Fixed metadata prefix size                  |
+| `SubtreeNodeHashSize`        | 32    | `0x20` | Node size in HashesOnly payload             |
+| `SubtreeNodeFullSize`        | 48    | `0x30` | Node size in FullNodes payload              |
 
 ## References
 

--- a/transactions/0132.md
+++ b/transactions/0132.md
@@ -1,0 +1,228 @@
+# BRC-132: Subtree Data Multicast Protocol
+
+Jeff Harris (jeff@lightweb.net)
+
+## Abstract
+
+This BRC defines frame version `0x05` for distributing complete Merkle subtree contents — transaction hashes and optional per-transaction metadata — over the IPv6 multicast fabric. Subtree data frames are delivered to all subscribers via the dedicated `CtrlGroupSubtreeAnnounce` multicast group (`FF0X::B:FFFB`), independently of the per-shard groups used for individual transaction distribution.
+
+## Copyright
+
+This BRC is licensed under the Open BSV License.
+
+## Motivation
+
+The multicast fabric distributes individual transactions shard-by-shard (BRC-124) and block-level metadata (BRC-131). BRC-132 fills the remaining gap: delivering the contents of each Merkle subtree so that subscribers can:
+
+1. Reconstruct the subtree Merkle tree locally.
+2. Verify block inclusion without fetching individual transactions.
+3. Power block-assembly tooling and downstream analytics without per-transaction retrieval.
+
+BRC-132 complements BRC-127, which maps SubtreeIDs to GroupIDs for shard-level filtering. BRC-127 announces _where_ a subtree lives; BRC-132 delivers _what_ it contains.
+
+## Specification
+
+### Multicast Group
+
+Subtree data frames are sent to the `CtrlGroupSubtreeAnnounce` group (index `0xFFFB`):
+
+```text
+| Index  | Scope  | Compressed Address | Constant                   |
+|--------|--------|--------------------|----------------------------|
+| 0xFFFB | site   | FF05::B:FFFB       | CtrlGroupSubtreeAnnounce   |
+| 0xFFFB | org    | FF08::B:FFFB       | CtrlGroupSubtreeAnnounce   |
+| 0xFFFB | global | FF0E::B:FFFB       | CtrlGroupSubtreeAnnounce   |
+```
+
+Scope selection follows the `CtrlGroupBeacon` pattern defined in BRC-129. Operators select one or more scopes via the `-announce-scope` flag on listening components.
+
+### Frame Header Format (92 bytes)
+
+The BRC-132 header is layout-identical to the BRC-124 header. All infrastructure components that inspect Magic, HashKey, or SeqNum read correct values at the same offsets. The header is read using the same 44+48 two-step protocol as BRC-124 and BRC-131.
+
+```text
+| Offset | Size | Align | Field         | Value / Notes                                         |
+|--------|------|-------|---------------|-------------------------------------------------------|
+| 0      | 4    | —     | Network Magic | 0xE3E1F3E8 (BSV mainnet P2P magic)                    |
+| 4      | 2    | —     | Protocol Ver  | 0x02BF (703, BSV large-block baseline)                |
+| 6      | 1    | —     | Frame Version | 0x05 — BRC-132 subtree data                           |
+| 7      | 1    | —     | MsgType       | 0x01 = HashesOnly, 0x02 = FullNodes                   |
+| 8      | 32   | 8B    | SubtreeID     | SHA-256 Merkle root of the subtree (content ID)       |
+| 40     | 8    | 8B    | HashKey       | XXH64(senderIPv6 ∥ 0xFFFB ∥ SubtreeID); proxy-stamped |
+| 48     | 8    | 8B    | SeqNum        | Monotonic counter per (sender, SubtreeID); proxy-stamped |
+| 56     | 32   | 8B    | LayoutPad32   | All zeros; retained for uniform HeaderSize = 92       |
+| 88     | 4    | 8B    | PayloadLen    | Payload size in bytes (uint32 BE)                     |
+| 92     | *    | —     | Payload       | MsgType-specific subtree data (see §Payload Format)   |
+```
+
+**Key distinctions from BRC-124:**
+
+- Byte 7 carries `MsgType` rather than `Reserved = 0x00`.
+- Bytes 8–39 carry `SubtreeID` (the Merkle root), not a `TxID`.
+- `LayoutPad32` (bytes 56–87) is always zero. SubtreeID already serves as content identifier and flow scope; no secondary field is needed. The field is retained so that `HeaderSize = 92` remains uniform across V2/V4/V5.
+- `HashKey` is computed as `XXH64(senderIPv6 ∥ 0xFFFB ∥ SubtreeID)`. Each distinct subtree from the same sender has an independent sequence stream, so loss in one subtree does not create false gaps in another.
+
+### MsgType Values
+
+```text
+| MsgType | Constant             | Node Size | Description                              |
+|---------|----------------------|-----------|------------------------------------------|
+| 0x01    | SubtreeMsgHashesOnly | 32 bytes  | TxHashes only (network transfer format)  |
+| 0x02    | SubtreeMsgFullNodes  | 48 bytes  | TxHash + Fee + Size per node             |
+```
+
+Any other MsgType value causes the frame to be rejected with `ErrBadSubtreeMsg`.
+
+### Payload Format
+
+Both MsgType variants share a 24-byte metadata prefix followed by N node entries and a conflict set.
+
+#### Common Prefix (24 bytes)
+
+```text
+| Offset | Size | Field          | Description                                     |
+|--------|------|----------------|-------------------------------------------------|
+| 0      | 8    | TotalFees      | Aggregate fee sum for the subtree (uint64 BE)   |
+| 8      | 8    | TotalSizeBytes | Aggregate serialised tx size (uint64 BE, bytes) |
+| 16     | 8    | NodeCount      | Number of transaction nodes (uint64 BE)         |
+```
+
+#### MsgType 0x01 — HashesOnly
+
+```text
+| Offset        | Size   | Field         |
+|---------------|--------|---------------|
+| 24            | 32 × N | TxHashes      |
+| 24 + 32N      | 8      | ConflictCount (uint64 BE) |
+| 24 + 32N + 8  | 32 × M | ConflictHashes |
+```
+
+Maximum size at 1M nodes, 0 conflicts: 24 + 32 × 1,048,576 + 8 ≈ **32 MB**.
+
+#### MsgType 0x02 — FullNodes
+
+```text
+| Offset        | Size   | Field                                |
+|---------------|--------|--------------------------------------|
+| 24            | 48 × N | Nodes: TxHash (32B) ∥ Fee (8B BE) ∥ Size (8B BE) |
+| 24 + 48N      | 8      | ConflictCount (uint64 BE) |
+| 24 + 48N + 8  | 32 × M | ConflictHashes |
+```
+
+Maximum size at 1M nodes, 0 conflicts: 24 + 48 × 1,048,576 + 8 ≈ **48 MB**.
+
+### Fragmentation
+
+Payloads of 32–48 MB exceed any path MTU. The proxy fragments each BRC-132 frame using BRC-130:
+
+- `OrigFrameVer = 0x05` in each BRC-130 fragment header (byte 100).
+- `MsgType` is preserved in fragment header byte 7 (same pattern as BRC-131 `fragmentBlock`).
+- Fragment reassembly is keyed by SubtreeID (bytes 8–39), matching the `TxID` slot used by BRC-124 fragments.
+- SHA256d hash verification does **not** apply — SubtreeID is a Merkle root, not a payload double-hash. The `verifyHash` flag must be `false` for V5 reassembly slots.
+- Optional post-reassembly Merkle-root verification is available (see §Merkle Verification).
+
+Fragment counts at MTU 9000 (fragDataSize = 8848 bytes):
+
+```text
+| Subtree size                       | Fragments |
+|------------------------------------|-----------|
+| ~32 MB (HashesOnly, 1M nodes)      | ~3,793    |
+| ~48 MB (FullNodes, 1M nodes)       | ~5,689    |
+```
+
+Both fit within the `uint16` `FragTotal` limit of 65,535.
+
+### Sequence Tracking and Retransmission
+
+BRC-132 frames participate in the same NACK-based reliability mechanism as BRC-124 and BRC-131:
+
+- The proxy stamps `HashKey` and `SeqNum` in-place before forwarding. Each `(senderIPv6, SubtreeID)` pair owns an independent monotonic sequence stream.
+- If `SeqNum` is already non-zero on arrival, the frame is forwarded verbatim (pre-stamped path).
+- Listeners detect gaps on the `(HashKey, 0xFFFB, SubtreeID)` flow and dispatch BRC-126 NACKs to retry endpoints.
+- Retry endpoints join `FF0X::B:FFFB` and cache BRC-132 frames and BRC-130 fragments (`OrigFrameVer = 0x05`) by `HashKey ∥ SeqNum`. On NACK, the frame is retransmitted to `FF0X::B:FFFB`. The retry endpoint TTL for BRC-132 frames defaults to 120 s (compared to 60 s for transaction frames) to accommodate large reassembly windows.
+
+### Merkle Verification
+
+After reassembly, optional Merkle-root recomputation verifies the SubtreeID:
+
+- Enabled by `-subtree-data-verify-merkle` / `SUBTREE_DATA_VERIFY_MERKLE=true` on the listener.
+- The listener decodes the payload into nodes and computes SHA256d pairwise up the binary tree, then compares the root to SubtreeID.
+- Computationally significant at 1M nodes (~1M double-SHA256 operations); **disabled by default**.
+- On mismatch: drop the reassembly slot; increment `bsl_reassembly_merkle_mismatch_total`.
+
+### Proxy Forwarding Rules
+
+1. **Receive** — BRC-132 frames are accepted over TCP ingress. The switch in `handleConn` recognises `FrameVerV5` using the same 44+48 two-step header read as V2/V4.
+2. **Decode** — `DecodeSubtreeData` validates Magic, FrameVer, MsgType, and PayloadLen. Invalid frames are dropped.
+3. **Stamp** — If `SeqNum == 0`, stamp `HashKey` and `SeqNum` in-place per `(senderIPv6, 0xFFFB, SubtreeID)` flow, reading SubtreeID from bytes 8–39.
+4. **Fragment** — If `len(Payload) > fragDataSize`, fragment via BRC-130 with `OrigFrameVer = 0x05` and MsgType preserved in byte 7.
+5. **Forward** — Write the frame to all egress interfaces with destination `FF0X::B:FFFB:<egressPort>`.
+
+### Listener Processing Rules
+
+1. **Detection** — `IsSubtreeDataFrame(raw)` checks Magic and `raw[6] == 0x05` before decode.
+2. **Decode** — `DecodeSubtreeData` validates the frame and returns a `SubtreeDataFrame` with `MsgType`, `SubtreeID`, `HashKey`, `SeqNum`, and `Payload`.
+3. **Gap tracking** — `Tracker.Observe(0xFFFB, SubtreeID, HashKey, SeqNum)` when `SeqNum != 0`.
+4. **Filtering** — Subtree data frames bypass shard filtering. Listeners may optionally filter by SubtreeID.
+5. **Reassembly** — BRC-130 fragments with `OrigFrameVer = 0x05` are routed to `processSubtreeDataFrame` via the callback registered on construction.
+
+### Infrastructure Impact
+
+```text
+| Component              | Change                                                                          |
+|------------------------|---------------------------------------------------------------------------------|
+| bitcoin-shard-common   | FrameVerV5, SubtreeMsgHashesOnly, SubtreeMsgFullNodes, ErrBadSubtreeMsg         |
+|                        | constants; SubtreeDataFrame, SubtreeDataPayload structs;                        |
+|                        | EncodeSubtreeData, DecodeSubtreeData, IsSubtreeDataFrame,                       |
+|                        | EncodeSubtreeDataPayload, DecodeSubtreeDataPayload                              |
+| bitcoin-shard-proxy    | FrameVerV5 case in TCP handleConn; ProcessSubtreeData + fragmentSubtreeData     |
+| bitcoin-shard-listener | Joins FF0X::B:FFFB; IsSubtreeDataFrame detection; processSubtreeDataFrame;      |
+|                        | reassembly OrigFrameVer=0x05 callback path; optional Merkle verification        |
+| bitcoin-retry-endpoint | Joins FF0X::B:FFFB; processSubtreeDataFrame in ingress;                         |
+|                        | FrameVerV5-aware retransmit routing to FF0X::B:FFFB                            |
+| Firewall               | No new rules — FF0X::B:FFFB shares the same port as other groups               |
+```
+
+### Error Handling
+
+```text
+| Condition                      | Action                                       |
+|--------------------------------|----------------------------------------------|
+| raw[6] != 0x05                 | Not BRC-132; handled by other decoders       |
+| Bad magic                      | Silent drop                                  |
+| Unknown MsgType                | Drop; ErrBadSubtreeMsg                       |
+| PayloadLen exceeds buffer      | Drop; io.ErrUnexpectedEOF                    |
+| Datagram shorter than 92 bytes | Drop; ErrTooShort                            |
+| SeqNum == 0                    | Frame not proxy-stamped; listener discards   |
+| Merkle mismatch (optional)     | Drop; bsl_reassembly_merkle_mismatch_total++ |
+```
+
+## Constants Reference
+
+```text
+| Name                        | Value | Hex    | Description                                         |
+|-----------------------------|-------|--------|-----------------------------------------------------|
+| FrameVerV5                  | 5     | 0x05   | BRC-132 subtree data frame version                  |
+| SubtreeMsgHashesOnly        | 1     | 0x01   | MsgType: TxHashes only (32B per node)               |
+| SubtreeMsgFullNodes         | 2     | 0x02   | MsgType: TxHash + Fee + Size (48B per node)         |
+| CtrlGroupSubtreeAnnounce    | 65531 | 0xFFFB | Subtree data multicast group index                  |
+| HeaderSize                  | 92    | 0x5C   | BRC-132 header size (identical to BRC-124)          |
+| SubtreeDataPayloadHeaderSize| 24    | 0x18   | Fixed metadata prefix size                          |
+| SubtreeNodeHashSize         | 32    | 0x20   | Node size in HashesOnly payload                     |
+| SubtreeNodeFullSize         | 48    | 0x30   | Node size in FullNodes payload                      |
+```
+
+## Implementations
+
+- **Go**: [bitcoin-shard-common/frame](https://github.com/lightwebinc/bitcoin-shard-common/tree/main/frame) — `EncodeSubtreeData`, `DecodeSubtreeData`, `IsSubtreeDataFrame`, `EncodeSubtreeDataPayload`, `DecodeSubtreeDataPayload`
+- **Services**: [bitcoin-shard-proxy](https://github.com/lightwebinc/bitcoin-shard-proxy), [bitcoin-shard-listener](https://github.com/lightwebinc/bitcoin-shard-listener), [bitcoin-retry-endpoint](https://github.com/lightwebinc/bitcoin-retry-endpoint) — Network multicast infrastructure
+
+## References
+
+- [BRC-119: SubTree Unified Merkle Path (STUMP) Format](./0119.md) — SubtreeID definition and Merkle subtree structure
+- [BRC-124: Multicast Transaction Frame Format](./0124.md) — Base header layout reused by BRC-132
+- [BRC-126: Multicast Retransmission Protocol](../peer-to-peer/0126.md) — NACK-based reliability used for subtree frame retransmission
+- [BRC-127: Subtree Group Announcement](../peer-to-peer/0127.md) — SubtreeID→GroupID metadata; distinct from BRC-132 data delivery
+- [BRC-129: Multicast Group Address Assignments](../peer-to-peer/0129.md) — Group index allocations; `0xFFFB` = CtrlGroupSubtreeAnnounce
+- [BRC-130: Multicast Frame Fragmentation](./0130.md) — Fragmentation for large subtree payloads; `OrigFrameVer = 0x05`
+- [BRC-131: Block Announcement Protocol](./0131.md) — `FrameVerV4` pattern followed by BRC-132

--- a/transactions/0132.md
+++ b/transactions/0132.md
@@ -4,7 +4,12 @@ Jeff Harris (jeff@lightweb.net)
 
 ## Abstract
 
-This BRC defines frame version `0x05` for distributing complete Merkle subtree contents — transaction hashes and optional per-transaction metadata — over the IPv6 multicast fabric. Subtree data frames are delivered to all subscribers via the dedicated `CtrlGroupSubtreeAnnounce` multicast group (`FF0X::B:FFFB`), independently of the per-shard groups used for individual transaction distribution.
+This BRC defines frame version `0x05` for distributing complete Merkle subtree
+contents — transaction hashes and optional per-transaction metadata — over the
+IPv6 multicast fabric. Subtree data frames are delivered to all subscribers via
+the dedicated `CtrlGroupSubtreeAnnounce` multicast group (`FF0X::B:FFFB`),
+independently of the per-shard groups used for individual transaction
+distribution.
 
 ## Copyright
 
@@ -12,19 +17,25 @@ This BRC is licensed under the Open BSV License.
 
 ## Motivation
 
-The multicast fabric distributes individual transactions shard-by-shard (BRC-124) and block-level metadata (BRC-131). BRC-132 fills the remaining gap: delivering the contents of each Merkle subtree so that subscribers can:
+The multicast fabric distributes individual transactions shard-by-shard
+(BRC-124) and block-level metadata (BRC-131). BRC-132 fills the remaining gap:
+delivering the contents of each Merkle subtree so that subscribers can:
 
 1. Reconstruct the subtree Merkle tree locally.
 2. Verify block inclusion without fetching individual transactions.
-3. Power block-assembly tooling and downstream analytics without per-transaction retrieval.
+3. Power block-assembly tooling and downstream analytics without per-transaction
+   retrieval.
 
-BRC-132 complements BRC-127, which maps SubtreeIDs to GroupIDs for shard-level filtering. BRC-127 announces _where_ a subtree lives; BRC-132 delivers _what_ it contains.
+BRC-132 complements BRC-127, which maps SubtreeIDs to GroupIDs for shard-level
+filtering. BRC-127 announces _where_ a subtree lives; BRC-132 delivers _what_ it
+contains.
 
 ## Specification
 
 ### Multicast Group
 
-Subtree data frames are sent to the `CtrlGroupSubtreeAnnounce` group (index `0xFFFB`):
+Subtree data frames are sent to the `CtrlGroupSubtreeAnnounce` group (index
+`0xFFFB`):
 
 ```text
 | Index  | Scope  | Compressed Address | Constant                   |
@@ -34,11 +45,16 @@ Subtree data frames are sent to the `CtrlGroupSubtreeAnnounce` group (index `0xF
 | 0xFFFB | global | FF0E::B:FFFB       | CtrlGroupSubtreeAnnounce   |
 ```
 
-Scope selection follows the `CtrlGroupBeacon` pattern defined in BRC-129. Operators select one or more scopes via the `-announce-scope` flag on listening components.
+Scope selection follows the `CtrlGroupBeacon` pattern defined in BRC-129.
+Operators select one or more scopes via the `-announce-scope` flag on listening
+components.
 
 ### Frame Header Format (92 bytes)
 
-The BRC-132 header is layout-identical to the BRC-124 header. All infrastructure components that inspect Magic, HashKey, or SeqNum read correct values at the same offsets. The header is read using the same 44+48 two-step protocol as BRC-124 and BRC-131.
+The BRC-132 header is layout-identical to the BRC-124 header. All infrastructure
+components that inspect Magic, HashKey, or SeqNum read correct values at the
+same offsets. The header is read using the same 44+48 two-step protocol as
+BRC-124 and BRC-131.
 
 ```text
 | Offset | Size | Align | Field         | Value / Notes                                         |
@@ -59,8 +75,12 @@ The BRC-132 header is layout-identical to the BRC-124 header. All infrastructure
 
 - Byte 7 carries `MsgType` rather than `Reserved = 0x00`.
 - Bytes 8–39 carry `SubtreeID` (the Merkle root), not a `TxID`.
-- `LayoutPad32` (bytes 56–87) is always zero. SubtreeID already serves as content identifier and flow scope; no secondary field is needed. The field is retained so that `HeaderSize = 92` remains uniform across V2/V4/V5.
-- `HashKey` is computed as `XXH64(senderIPv6 ∥ 0xFFFB ∥ SubtreeID)`. Each distinct subtree from the same sender has an independent sequence stream, so loss in one subtree does not create false gaps in another.
+- `LayoutPad32` (bytes 56–87) is always zero. SubtreeID already serves as
+  content identifier and flow scope; no secondary field is needed. The field is
+  retained so that `HeaderSize = 92` remains uniform across V2/V4/V5.
+- `HashKey` is computed as `XXH64(senderIPv6 ∥ 0xFFFB ∥ SubtreeID)`. Each
+  distinct subtree from the same sender has an independent sequence stream, so
+  loss in one subtree does not create false gaps in another.
 
 ### MsgType Values
 
@@ -75,7 +95,8 @@ Any other MsgType value causes the frame to be rejected with `ErrBadSubtreeMsg`.
 
 ### Payload Format
 
-Both MsgType variants share a 24-byte metadata prefix followed by N node entries and a conflict set.
+Both MsgType variants share a 24-byte metadata prefix followed by N node entries
+and a conflict set.
 
 #### Common Prefix (24 bytes)
 
@@ -113,13 +134,19 @@ Maximum size at 1M nodes, 0 conflicts: 24 + 48 × 1,048,576 + 8 ≈ **48 MB**.
 
 ### Fragmentation
 
-Payloads of 32–48 MB exceed any path MTU. The proxy fragments each BRC-132 frame using BRC-130:
+Payloads of 32–48 MB exceed any path MTU. The proxy fragments each BRC-132 frame
+using BRC-130:
 
 - `OrigFrameVer = 0x05` in each BRC-130 fragment header (byte 100).
-- `MsgType` is preserved in fragment header byte 7 (same pattern as BRC-131 `fragmentBlock`).
-- Fragment reassembly is keyed by SubtreeID (bytes 8–39), matching the `TxID` slot used by BRC-124 fragments.
-- SHA256d hash verification does **not** apply — SubtreeID is a Merkle root, not a payload double-hash. The `verifyHash` flag must be `false` for V5 reassembly slots.
-- Optional post-reassembly Merkle-root verification is available (see §Merkle Verification).
+- `MsgType` is preserved in fragment header byte 7 (same pattern as BRC-131
+  `fragmentBlock`).
+- Fragment reassembly is keyed by SubtreeID (bytes 8–39), matching the `TxID`
+  slot used by BRC-124 fragments.
+- SHA256d hash verification does **not** apply — SubtreeID is a Merkle root, not
+  a payload double-hash. The `verifyHash` flag must be `false` for V5 reassembly
+  slots.
+- Optional post-reassembly Merkle-root verification is available (see §Merkle
+  Verification).
 
 Fragment counts at MTU 9000 (fragDataSize = 8848 bytes):
 
@@ -134,37 +161,61 @@ Both fit within the `uint16` `FragTotal` limit of 65,535.
 
 ### Sequence Tracking and Retransmission
 
-BRC-132 frames participate in the same NACK-based reliability mechanism as BRC-124 and BRC-131:
+BRC-132 frames participate in the same NACK-based reliability mechanism as
+BRC-124 and BRC-131:
 
-- The proxy stamps `HashKey` and `SeqNum` in-place before forwarding. Each `(senderIPv6, SubtreeID)` pair owns an independent monotonic sequence stream.
-- If `SeqNum` is already non-zero on arrival, the frame is forwarded verbatim (pre-stamped path).
-- Listeners detect gaps on the `(HashKey, 0xFFFB, SubtreeID)` flow and dispatch BRC-126 NACKs to retry endpoints.
-- Retry endpoints join `FF0X::B:FFFB` and cache BRC-132 frames and BRC-130 fragments (`OrigFrameVer = 0x05`) by `HashKey ∥ SeqNum`. On NACK, the frame is retransmitted to `FF0X::B:FFFB`. The retry endpoint TTL for BRC-132 frames defaults to 120 s (compared to 60 s for transaction frames) to accommodate large reassembly windows.
+- The proxy stamps `HashKey` and `SeqNum` in-place before forwarding. Each
+  `(senderIPv6, SubtreeID)` pair owns an independent monotonic sequence stream.
+- If `SeqNum` is already non-zero on arrival, the frame is forwarded verbatim
+  (pre-stamped path).
+- Listeners detect gaps on the `(HashKey, 0xFFFB, SubtreeID)` flow and dispatch
+  BRC-126 NACKs to retry endpoints.
+- Retry endpoints join `FF0X::B:FFFB` and cache BRC-132 frames and BRC-130
+  fragments (`OrigFrameVer = 0x05`) by `HashKey ∥ SeqNum`. On NACK, the frame is
+  retransmitted to `FF0X::B:FFFB`. The retry endpoint TTL for BRC-132 frames
+  defaults to 120 s (compared to 60 s for transaction frames) to accommodate
+  large reassembly windows.
 
 ### Merkle Verification
 
 After reassembly, optional Merkle-root recomputation verifies the SubtreeID:
 
-- Enabled by `-subtree-data-verify-merkle` / `SUBTREE_DATA_VERIFY_MERKLE=true` on the listener.
-- The listener decodes the payload into nodes and computes SHA256d pairwise up the binary tree, then compares the root to SubtreeID.
-- Computationally significant at 1M nodes (~1M double-SHA256 operations); **disabled by default**.
-- On mismatch: drop the reassembly slot; increment `bsl_reassembly_merkle_mismatch_total`.
+- Enabled by `-subtree-data-verify-merkle` / `SUBTREE_DATA_VERIFY_MERKLE=true`
+  on the listener.
+- The listener decodes the payload into nodes and computes SHA256d pairwise up
+  the binary tree, then compares the root to SubtreeID.
+- Computationally significant at 1M nodes (~1M double-SHA256 operations);
+  **disabled by default**.
+- On mismatch: drop the reassembly slot; increment
+  `bsl_reassembly_merkle_mismatch_total`.
 
 ### Proxy Forwarding Rules
 
-1. **Receive** — BRC-132 frames are accepted over TCP ingress. The switch in `handleConn` recognises `FrameVerV5` using the same 44+48 two-step header read as V2/V4.
-2. **Decode** — `DecodeSubtreeData` validates Magic, FrameVer, MsgType, and PayloadLen. Invalid frames are dropped.
-3. **Stamp** — If `SeqNum == 0`, stamp `HashKey` and `SeqNum` in-place per `(senderIPv6, 0xFFFB, SubtreeID)` flow, reading SubtreeID from bytes 8–39.
-4. **Fragment** — If `len(Payload) > fragDataSize`, fragment via BRC-130 with `OrigFrameVer = 0x05` and MsgType preserved in byte 7.
-5. **Forward** — Write the frame to all egress interfaces with destination `FF0X::B:FFFB:<egressPort>`.
+1. **Receive** — BRC-132 frames are accepted over TCP ingress. The switch in
+   `handleConn` recognises `FrameVerV5` using the same 44+48 two-step header
+   read as V2/V4.
+2. **Decode** — `DecodeSubtreeData` validates Magic, FrameVer, MsgType, and
+   PayloadLen. Invalid frames are dropped.
+3. **Stamp** — If `SeqNum == 0`, stamp `HashKey` and `SeqNum` in-place per
+   `(senderIPv6, 0xFFFB, SubtreeID)` flow, reading SubtreeID from bytes 8–39.
+4. **Fragment** — If `len(Payload) > fragDataSize`, fragment via BRC-130 with
+   `OrigFrameVer = 0x05` and MsgType preserved in byte 7.
+5. **Forward** — Write the frame to all egress interfaces with destination
+   `FF0X::B:FFFB:<egressPort>`.
 
 ### Listener Processing Rules
 
-1. **Detection** — `IsSubtreeDataFrame(raw)` checks Magic and `raw[6] == 0x05` before decode.
-2. **Decode** — `DecodeSubtreeData` validates the frame and returns a `SubtreeDataFrame` with `MsgType`, `SubtreeID`, `HashKey`, `SeqNum`, and `Payload`.
-3. **Gap tracking** — `Tracker.Observe(0xFFFB, SubtreeID, HashKey, SeqNum)` when `SeqNum != 0`.
-4. **Filtering** — Subtree data frames bypass shard filtering. Listeners may optionally filter by SubtreeID.
-5. **Reassembly** — BRC-130 fragments with `OrigFrameVer = 0x05` are routed to `processSubtreeDataFrame` via the callback registered on construction.
+1. **Detection** — `IsSubtreeDataFrame(raw)` checks Magic and `raw[6] == 0x05`
+   before decode.
+2. **Decode** — `DecodeSubtreeData` validates the frame and returns a
+   `SubtreeDataFrame` with `MsgType`, `SubtreeID`, `HashKey`, `SeqNum`, and
+   `Payload`.
+3. **Gap tracking** — `Tracker.Observe(0xFFFB, SubtreeID, HashKey, SeqNum)` when
+   `SeqNum != 0`.
+4. **Filtering** — Subtree data frames bypass shard filtering. Listeners may
+   optionally filter by SubtreeID.
+5. **Reassembly** — BRC-130 fragments with `OrigFrameVer = 0x05` are routed to
+   `processSubtreeDataFrame` via the callback registered on construction.
 
 ### Infrastructure Impact
 
@@ -214,15 +265,29 @@ After reassembly, optional Merkle-root recomputation verifies the SubtreeID:
 
 ## Implementations
 
-- **Go**: [bitcoin-shard-common/frame](https://github.com/lightwebinc/bitcoin-shard-common/tree/main/frame) — `EncodeSubtreeData`, `DecodeSubtreeData`, `IsSubtreeDataFrame`, `EncodeSubtreeDataPayload`, `DecodeSubtreeDataPayload`
-- **Services**: [bitcoin-shard-proxy](https://github.com/lightwebinc/bitcoin-shard-proxy), [bitcoin-shard-listener](https://github.com/lightwebinc/bitcoin-shard-listener), [bitcoin-retry-endpoint](https://github.com/lightwebinc/bitcoin-retry-endpoint) — Network multicast infrastructure
+- **Go**:
+  [bitcoin-shard-common/frame](https://github.com/lightwebinc/bitcoin-shard-common/tree/main/frame)
+  — `EncodeSubtreeData`, `DecodeSubtreeData`, `IsSubtreeDataFrame`,
+  `EncodeSubtreeDataPayload`, `DecodeSubtreeDataPayload`
+- **Services**:
+  [bitcoin-shard-proxy](https://github.com/lightwebinc/bitcoin-shard-proxy),
+  [bitcoin-shard-listener](https://github.com/lightwebinc/bitcoin-shard-listener),
+  [bitcoin-retry-endpoint](https://github.com/lightwebinc/bitcoin-retry-endpoint)
+  — Network multicast infrastructure
 
 ## References
 
-- [BRC-119: SubTree Unified Merkle Path (STUMP) Format](./0119.md) — SubtreeID definition and Merkle subtree structure
-- [BRC-124: Multicast Transaction Frame Format](./0124.md) — Base header layout reused by BRC-132
-- [BRC-126: Multicast Retransmission Protocol](../peer-to-peer/0126.md) — NACK-based reliability used for subtree frame retransmission
-- [BRC-127: Subtree Group Announcement](../peer-to-peer/0127.md) — SubtreeID→GroupID metadata; distinct from BRC-132 data delivery
-- [BRC-129: Multicast Group Address Assignments](../peer-to-peer/0129.md) — Group index allocations; `0xFFFB` = CtrlGroupSubtreeAnnounce
-- [BRC-130: Multicast Frame Fragmentation](./0130.md) — Fragmentation for large subtree payloads; `OrigFrameVer = 0x05`
-- [BRC-131: Block Announcement Protocol](./0131.md) — `FrameVerV4` pattern followed by BRC-132
+- [BRC-119: SubTree Unified Merkle Path (STUMP) Format](./0119.md) — SubtreeID
+  definition and Merkle subtree structure
+- [BRC-124: Multicast Transaction Frame Format](./0124.md) — Base header layout
+  reused by BRC-132
+- [BRC-126: Multicast Retransmission Protocol](../peer-to-peer/0126.md) —
+  NACK-based reliability used for subtree frame retransmission
+- [BRC-127: Subtree Group Announcement](../peer-to-peer/0127.md) —
+  SubtreeID→GroupID metadata; distinct from BRC-132 data delivery
+- [BRC-129: Multicast Group Address Assignments](../peer-to-peer/0129.md) —
+  Group index allocations; `0xFFFB` = CtrlGroupSubtreeAnnounce
+- [BRC-130: Multicast Frame Fragmentation](./0130.md) — Fragmentation for large
+  subtree payloads; `OrigFrameVer = 0x05`
+- [BRC-131: Block Announcement Protocol](./0131.md) — `FrameVerV4` pattern
+  followed by BRC-132

--- a/transactions/README.md
+++ b/transactions/README.md
@@ -23,3 +23,4 @@ BRC | Standard
 96   | [BEEF V2 Txid Only Extension](./0096.md)
 119  | [SubTree Unified Merkle Path (STUMP) Format](./0119.md)
 124  | [Multicast Transaction Frame Format](./0124.md)
+132  | [BRC-132: Subtree Data Multicast Protocol](./0132.md)


### PR DESCRIPTION
### This pull request:

Proposes a new standard by creating a new markdown file in the appropriate directory and requests discussion and assignment of a BRC number

### Summary

## BRC-132: Multicast Subtree Data Frame Format

Defines frame version 0x05 for distributing the full contents of each Merkle subtree — transaction hashes and optional per-transaction fee/size metadata — over the IPv6 multicast fabric.

Introduces the CtrlGroupSubtreeAnnounce group (FF0X::B:FFFB) with two payload variants:
- HashesOnly (32B/node, ~32 MB at 1M txs)
- FullNodes (48B/node, ~48 MB).

Reuses the BRC-124 header layout; SubtreeID (the Merkle root) serves as both content identifier and sequence-stream scope.

Large payloads are fragmented via BRC-130 (OrigFrameVer = 0x05); optional post-reassembly Merkle-root verification is available but disabled by default.

Complements BRC-127 (SubtreeID→GroupID mapping) by delivering subtree contents rather than routing metadata.