### PR TITLE
BRC-133: Multicast Coinbase Transaction Frame Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ BRC | Standard
 123  | [Basket Identifier Namespace Framework](./wallet/0123.md)
 124  | [Multicast Transaction Frame Format](./transactions/0124.md)
 125  | [PeerPay URI Scheme for BRC-29 Payments](./payments/0125.md)
+133  | [Multicast Coinbase Transaction Frame Format](./transactions/0133.md)
 
 ## License
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -61,6 +61,7 @@
 * [BEEF V2 Txid Only Extension](./transactions/0096.md)
 * [SubTree Unified Merkle Path (STUMP) Format](./transactions/0119.md)
 * [Multicast Transaction Frame Format](./transactions/0124.md)
+* [Multicast Coinbase Transaction Frame Format](./transactions/0133.md)
 
 ## Scripts
 

--- a/transactions/0133.md
+++ b/transactions/0133.md
@@ -1,0 +1,117 @@
+# BRC-133: Multicast Coinbase Transaction Frame Format
+
+Jeff Harris (jeff@lightweb.net)
+
+## Abstract
+
+This BRC defines the policy and wire mechanism for distributing coinbase transactions over the IPv6 multicast fabric. Coinbase transactions are carried as a dedicated message type within BRC-131 block control frames and delivered to all subscribers via the control-plane multicast group, independently of the shard groups used for ordinary transaction distribution.
+
+## Copyright
+
+This BRC is licensed under the Open BSV License.
+
+## Motivation
+
+The multicast fabric shards ordinary transactions across per-shard multicast groups based on the top bits of each transaction's TxID. Coinbase transactions cannot be sharded this way because:
+
+1. **Universal relevance** — the coinbase TxID is included in every block announcement and is required to verify the block's Merkle root.
+2. **Fee aggregation** — coinbase outputs pay the block subsidy and miner fee aggregations that downstream systems need to validate template construction.
+3. **Unpredictable placement** — no subscriber can predict which shard a coinbase TxID would hash to before the block is found.
+
+BRC-133 addresses this by routing coinbase frames to the **CtrlGroupControl** group (`FF0E::B:FFFE`), a global control channel that all subscribers join unconditionally.
+
+## Specification
+
+### Control-Plane Multicast Group
+
+Coinbase frames are delivered on the **CtrlGroupControl** group:
+
+| Index    | Scope  | Compressed Address | Constant           |
+| -------- | ------ | ------------------ | ------------------ |
+| `0xFFFE` | global | `FF0E::B:FFFE`     | `CtrlGroupControl` |
+
+The global scope (`FF0E`) ensures coinbase transactions cross site boundaries. The group index `0xFFFE` is in the reserved control-plane range and never overlaps with data-plane shard groups (maximum shard group index is `0x7FFF` for `shard_bits=15`).
+
+### Wire Format
+
+Coinbase transactions are carried as BRC-131 frames (FrameVer `0x04`) with `MsgType = 0x02` (`BlockMsgCoinbase`).
+
+| Offset | Size | Field        | Value                                                 |
+| ------ | ---- | ------------ | ----------------------------------------------------- |
+| 6      | 1    | FrameVersion | `0x04` (BRC-131)                                      |
+| 7      | 1    | MsgType      | `0x02` = `BlockMsgCoinbase`                           |
+| 8      | 32   | ContentID    | CoinbaseTxID — SHA256d of the raw coinbase tx bytes   |
+| 40     | 8    | HashKey      | XXH64(senderIPv6 ∥ 0xFFFE ∥ zeros); stamped by proxy  |
+| 48     | 8    | SeqNum       | Monotonic per-sender counter; stamped by proxy        |
+| 56     | 32   | LayoutPad32  | All zeros                                             |
+| 88     | 4    | PayloadLen   | Length of the raw coinbase transaction bytes           |
+| 92     | *    | Payload      | Raw serialised coinbase transaction (no P2P envelope) |
+
+**Payload encoding:** The payload is a raw BSV serialised transaction — version (4 bytes LE), input vector, output vector, locktime (4 bytes LE) — identical to the encoding used in BRC-12/BRC-124 frames.
+
+### Sequencing and Retransmission
+
+Coinbase frames participate in the same NACK-based reliability mechanism as BRC-124 shard frames:
+
+- The proxy stamps `HashKey = XXH64(senderIPv6 ∥ 0xFFFE ∥ zeros)` and `SeqNum` (monotonic per sender) in-place before forwarding. If the frame arrives pre-stamped (`SeqNum != 0`), it is forwarded verbatim.
+- Listeners observe `(ctrlGroupIdx=0xFFFE, zeroSubtreeID, HashKey, SeqNum, ContentID)` for gap detection and dispatch NACKs to retry endpoints on gap.
+- Retry endpoints join `FF0E::B:FFFE` and cache coinbase frames by `HashKey ∥ SeqNum`. On NACK, the frame is retransmitted to `FF0E::B:FFFE`.
+
+### Proxy Forwarding Rules
+
+1. **Receive** — BRC-131 frames (FrameVer `0x04`) are accepted over UDP or TCP ingress. The proxy detects version byte `0x04` before dispatching to `ProcessBlock`.
+2. **Decode** — `frame.DecodeBlock` validates Magic, FrameVer, MsgType, and PayLen. Invalid MsgType values are dropped.
+3. **Stamp** — If `SeqNum == 0`, stamp HashKey and SeqNum in-place using `(senderIPv6, 0xFFFE, zeros)` flow key.
+4. **Fragment** — If `len(Payload) > fragDataSize`, fragment via BRC-130 with `OrigFrameVer = 0x04`.
+5. **Forward** — Write frame to `FF0E::B:FFFE:<egressPort>` on all egress interfaces.
+
+### Listener Processing Rules
+
+1. **Detection** — `frame.IsBlockFrame(raw)` checks Magic and `raw[6] == 0x04`.
+2. **Decode** — `frame.DecodeBlock` returns a `BlockFrame` with `MsgType`, `ContentID`, `HashKey`, `SeqNum`, and `Payload`.
+3. **Egress** — The frame (or payload only in strip-header mode) is forwarded downstream.
+4. **Gap tracking** — `Tracker.Observe(0xFFFE, zeroSubtreeID, HashKey, SeqNum, ContentID)` when `SeqNum != 0`.
+5. **Filtering** — Coinbase frames bypass all shard/subtree filters; every subscriber receives every coinbase frame.
+
+### Relationship to BRC-131 Block Announcements
+
+A `BlockAnnounce` frame (BRC-131, MsgType `0x01`) is sent first and carries the `CoinbaseTxID` in its payload. The separate `BlockMsgCoinbase` frame then carries the full raw coinbase bytes. Subscribers that only need to verify the Merkle root may use the `CoinbaseTxID` from the announce frame without waiting for the coinbase frame itself.
+
+The two frame types share the same `HashKey` per sender but have independent `SeqNum` sequences (they are distinct flows within the `(sender, 0xFFFE, zeros)` namespace because their ContentIDs differ). Gap tracking treats them as separate objects.
+
+### Error Handling
+
+| Condition                      | Action                                                                              |
+| ------------------------------ | ----------------------------------------------------------------------------------- |
+| `raw[6] != 0x04`              | Not BRC-131; handled by other decoders                                              |
+| Bad magic                      | Silent drop                                                                         |
+| PayloadLen exceeds buffer      | Drop; `io.ErrUnexpectedEOF`                                                        |
+| Datagram shorter than 92 bytes | Drop; `ErrTooShort`                                                                 |
+| SeqNum == 0                    | Frame not yet proxy-stamped; listener skips gap tracking but still forwards         |
+
+## Infrastructure Impact
+
+| Component              | Change                                                                            |
+| ---------------------- | --------------------------------------------------------------------------------- |
+| bitcoin-shard-proxy    | `ProcessBlock` handles MsgType `0x02`; routes to `CtrlGroupControl`               |
+| bitcoin-shard-listener | `processBlockFrame` handles MsgType `0x02`; gap tracking on ctrl flow             |
+| bitcoin-retry-endpoint | Joins `FF0E::B:FFFE`; caches and retransmits BRC-131 frames regardless of MsgType |
+| bitcoin-shard-common   | `BlockMsgCoinbase = 0x02` constant; `DecodeBlock` validates MsgType               |
+
+## Constants Reference
+
+| Name               | Value    | Description                         |
+| ------------------ | -------- | ----------------------------------- |
+| `FrameVerV4`       | `0x04`   | BRC-131 block control frame version |
+| `BlockMsgCoinbase` | `0x02`   | MsgType: raw coinbase transaction   |
+| `CtrlGroupControl` | `0xFFFE` | Block control multicast group index |
+
+## References
+
+- [BRC-124: Multicast Transaction Frame Format](./0124.md) — base header layout reused by BRC-131
+- [BRC-134: Chained Anchor Transaction Frames](./0134.md) — another control-group transaction type
+
+## Implementations
+
+- **Go**: [bitcoin-shard-common/frame](https://github.com/lightwebinc/bitcoin-shard-common/tree/main/frame) — `DecodeBlock`, `IsBlockFrame`, `BlockMsgCoinbase`
+- **Services**: [bitcoin-shard-proxy](https://github.com/lightwebinc/bitcoin-shard-proxy), [bitcoin-shard-listener](https://github.com/lightwebinc/bitcoin-shard-listener) — Network multicast infrastructure

--- a/transactions/README.md
+++ b/transactions/README.md
@@ -23,3 +23,4 @@ BRC | Standard
 96   | [BEEF V2 Txid Only Extension](./0096.md)
 119  | [SubTree Unified Merkle Path (STUMP) Format](./0119.md)
 124  | [Multicast Transaction Frame Format](./0124.md)
+133  | [Multicast Coinbase Transaction Frame Format](./0133.md)


### PR DESCRIPTION
### This pull request:

Proposes a new standard by creating a new markdown file in the appropriate directory and requests discussion and assignment of a BRC number

### Summary

## BRC-133: Multicast Coinbase Transaction Frame Format

Defines the policy and wire mechanism for distributing coinbase transactions over the IPv6 multicast fabric as a dedicated message type within BRC-131 block control frames.

Coinbase frames use FrameVer `0x04` with MsgType `0x02` (`BlockMsgCoinbase`) and are delivered on the CtrlGroupControl group (`FF0E::B:FFFE`), bypassing shard routing entirely.

Key points:

- Every subscriber receives coinbase transactions unconditionally — required for Merkle root verification and fee aggregation validation.
- Reuses the BRC-124 92-byte header layout; `ContentID` carries the CoinbaseTxID (SHA256d of the raw coinbase bytes).
- Participates in standard NACK-based retransmission (HashKey/SeqNum stamped by proxy).
- Large coinbase payloads are fragmented via BRC-130 (`OrigFrameVer = 0x04`).

Complements BRC-131 (BlockAnnounce carries `CoinbaseTxID`; this BRC delivers the full raw coinbase transaction).
