### PR TITLE
BRC-134: Multicast Anchor Transaction Frame Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ BRC | Standard
 123  | [Basket Identifier Namespace Framework](./wallet/0123.md)
 124  | [Multicast Transaction Frame Format](./transactions/0124.md)
 125  | [PeerPay URI Scheme for BRC-29 Payments](./payments/0125.md)
+134  | [Multicast Anchor Transaction Frame Format](./transactions/0134.md)
 
 ## License
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -61,6 +61,7 @@
 * [BEEF V2 Txid Only Extension](./transactions/0096.md)
 * [SubTree Unified Merkle Path (STUMP) Format](./transactions/0119.md)
 * [Multicast Transaction Frame Format](./transactions/0124.md)
+* [Multicast Anchor Transaction Frame Format](./transactions/0134.md)
 
 ## Scripts
 

--- a/transactions/0134.md
+++ b/transactions/0134.md
@@ -1,0 +1,116 @@
+# BRC-134: Multicast Anchor Transaction Frame Format
+
+Jeff Harris (jeff@lightweb.net)
+
+## Abstract
+
+This BRC defines a new frame version (`0x06`) for distributing chained anchor transactions over the IPv6 multicast fabric. An anchor transaction is the root (first) transaction in a chain of dependent transactions. Because all subsequent transactions in the chain reference the anchor as an input, every subscriber must receive it regardless of which shard its TxID would otherwise hash to.
+
+## Copyright
+
+This BRC is licensed under the Open BSV License.
+
+## Motivation
+
+The multicast fabric shards ordinary transactions across per-shard multicast groups based on the top bits of each TxID. Chained anchor transactions cannot be sharded this way because:
+
+1. **Dependency root** — all dependent (chained) transactions in the set reference the anchor's TxID as an input. A subscriber that misses the anchor cannot validate any dependent transaction in the chain.
+2. **Unpredictable placement** — the anchor's TxID is not known in advance by subscribers; they cannot pre-join the correct shard group.
+3. **Cross-shard span** — the chain may span many shards. The anchor itself might hash to shard 0 while dependents are spread across shards 1–15. Every subscriber needs the anchor irrespective of which shards they follow.
+4. **Visibility over confirmation** — anchor transactions do not need to be confirmed before use; they need only to be visible and valid. Wide visibility is the primary requirement.
+
+BRC-134 addresses this by routing anchor frames to the **CtrlGroupControl** group (`FF0E::B:FFFE`), the same global control channel used for block headers and coinbase transactions (BRC-131, BRC-133). All subscribers join this group unconditionally.
+
+## Specification
+
+### Control-Plane Multicast Group
+
+Anchor frames are delivered on the **CtrlGroupControl** group:
+
+| Index    | Scope  | Compressed Address | Constant           |
+| -------- | ------ | ------------------ | ------------------ |
+| `0xFFFE` | global | `FF0E::B:FFFE`     | `CtrlGroupControl` |
+
+The global scope (`FF0E`) ensures anchor transactions cross site boundaries and reach all geographically distributed subscribers. The group index `0xFFFE` is in the reserved control-plane range and never overlaps with data-plane shard groups (maximum shard group index is `0x7FFF` for `shard_bits=15`).
+
+### Frame Header Format (92 bytes)
+
+The BRC-134 header is **layout-identical** to BRC-124. Infrastructure components that inspect the Magic, HashKey, or SeqNum fields read correct values at the same offsets.
+
+| Offset | Size | Align | Field       | Value / Notes                                             |
+| ------ | ---- | ----- | ----------- | --------------------------------------------------------- |
+| 0      | 4    | —     | Network Magic | `0xE3E1F3E8` (BSV mainnet P2P magic)                    |
+| 4      | 2    | —     | Protocol Ver  | `0x02BF` (703, BSV large-block baseline)                |
+| 6      | 1    | —     | Frame Version | **`0x06`** — BRC-134 anchor transaction                 |
+| 7      | 1    | —     | Reserved      | `0x00`                                                  |
+| 8      | 32   | 8B    | TxID          | SHA256d of the anchor transaction (internal byte order) |
+| 40     | 8    | 8B    | HashKey       | XXH64(senderIPv6 ∥ 0xFFFE ∥ zeros); stamped by proxy    |
+| 48     | 8    | 8B    | SeqNum        | Monotonic per-sender counter; stamped by proxy; 0 = unset |
+| 56     | 32   | 8B    | LayoutPad32   | All zeros (no subtree scope for anchor frames)          |
+| 88     | 4    | —     | PayloadLen    | Size of anchor transaction payload in bytes (uint32 BE) |
+| 92     | *    | —     | Payload       | Raw serialised anchor transaction (no P2P envelope)     |
+
+**Key distinction from BRC-124:** the version byte at offset 6 is `0x06` rather than `0x02`. All other field offsets and sizes are identical. The `LayoutPad32` field at bytes 56–87 is always zeros — anchor frames have no subtree scope. The field is kept for layout uniformity: the proxy TCP reader, stamping path, listener, and retry endpoint all share the single `HeaderSize` constant.
+
+**Payload encoding:** The payload is a raw BSV serialised transaction — version (4 bytes LE), input vector, output vector, locktime (4 bytes LE) — identical to the encoding used in BRC-12/BRC-124 frames.
+
+### Sequencing and Retransmission
+
+BRC-134 frames participate in the same NACK-based reliability mechanism as BRC-124 shard frames:
+
+- The proxy stamps `HashKey = XXH64(senderIPv6 ∥ 0xFFFE ∥ zeros)` and `SeqNum` (monotonic per sender) in-place before forwarding. If the frame arrives pre-stamped (`SeqNum != 0`), it is forwarded verbatim.
+- Listeners observe `(ctrlGroupIdx=0xFFFE, zeroSubtreeID, HashKey, SeqNum, TxID)` for gap detection and dispatch NACKs to retry endpoints on gap.
+- Retry endpoints join `FF0E::B:FFFE` and cache BRC-134 frames by `HashKey ∥ SeqNum`. On NACK, the frame is retransmitted to `FF0E::B:FFFE`.
+
+### Proxy Forwarding Rules
+
+1. **Receive** — BRC-134 frames are accepted over UDP or TCP ingress. The proxy detects version byte `0x06` before dispatching to `ProcessAnchor`.
+2. **Decode** — `frame.DecodeAnchor` validates Magic, FrameVer, and PayLen. Invalid frames are dropped.
+3. **Stamp** — If `SeqNum == 0`, stamp HashKey and SeqNum in-place using `(senderIPv6, 0xFFFE, zeros)` flow key.
+4. **Forward** — Write frame verbatim to `FF0E::B:FFFE:<egressPort>` on all egress interfaces.
+
+BRC-130 fragmentation is not defined for BRC-134. Anchor transactions are expected to be small (a typical BSV transaction). If fragmentation support becomes necessary it will be defined in a future revision.
+
+### Listener Processing Rules
+
+1. **Detection** — `frame.IsAnchorFrame(raw)` checks Magic and `raw[6] == 0x06`.
+2. **Decode** — `frame.DecodeAnchor` returns a `*Frame` with `Version=FrameVerV6`, `TxID`, `HashKey`, `SeqNum`, `SubtreeID` (zeros), and `Payload`.
+3. **Egress** — The frame (or payload only in strip-header mode) is forwarded downstream.
+4. **Gap tracking** — `Tracker.Observe(0xFFFE, zeroSubtreeID, HashKey, SeqNum, TxID)` when `SeqNum != 0`.
+5. **Filtering** — Anchor frames bypass all shard/subtree filters; every subscriber receives every anchor frame.
+
+### Error Handling
+
+| Condition                      | Action                                                                              |
+| ------------------------------ | ----------------------------------------------------------------------------------- |
+| `raw[6] != 0x06`              | Not BRC-134; handled by other decoders                                              |
+| Bad magic                      | Silent drop                                                                         |
+| PayloadLen exceeds buffer      | Drop; `io.ErrUnexpectedEOF`                                                        |
+| Datagram shorter than 92 bytes | Drop; `ErrTooShort`                                                                 |
+| SeqNum == 0                    | Frame not yet proxy-stamped; listener skips gap tracking but still forwards         |
+
+## Infrastructure Impact
+
+| Component              | Change                                                                                                                |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| bitcoin-shard-proxy    | UDP worker and TCP ingress: version `0x06` → `ProcessAnchor`; new `ProcessAnchor` method routes to `CtrlGroupControl` |
+| bitcoin-shard-listener | `IsAnchorFrame` dispatch; new `processAnchorFrame` method; gap tracking on ctrl flow                                  |
+| bitcoin-retry-endpoint | Joins `FF0E::B:FFFE`; caches and retransmits FrameVerV6 frames                                                       |
+| bitcoin-shard-common   | `FrameVerV6 = 0x06` constant; `DecodeAnchor`; `IsAnchorFrame`                                                        |
+
+## Constants Reference
+
+| Name               | Value    | Description                                                       |
+| ------------------ | -------- | ----------------------------------------------------------------- |
+| `FrameVerV6`       | `0x06`   | BRC-134 chained anchor transaction frame version                  |
+| `CtrlGroupControl` | `0xFFFE` | Control-plane multicast group index (shared with BRC-131/BRC-133) |
+
+## References
+
+- [BRC-124: Multicast Transaction Frame Format](./0124.md) — base header layout reused by BRC-134
+- [BRC-133: Coinbase Transaction Delivery](./0133.md) — another control-group transaction type using BRC-131
+
+## Implementations
+
+- **Go**: [bitcoin-shard-common/frame](https://github.com/lightwebinc/bitcoin-shard-common/tree/main/frame) — `DecodeAnchor`, `IsAnchorFrame`, `FrameVerV6`
+- **Services**: [bitcoin-shard-proxy](https://github.com/lightwebinc/bitcoin-shard-proxy), [bitcoin-shard-listener](https://github.com/lightwebinc/bitcoin-shard-listener) — Network multicast infrastructure

--- a/transactions/README.md
+++ b/transactions/README.md
@@ -23,3 +23,4 @@ BRC | Standard
 96   | [BEEF V2 Txid Only Extension](./0096.md)
 119  | [SubTree Unified Merkle Path (STUMP) Format](./0119.md)
 124  | [Multicast Transaction Frame Format](./0124.md)
+134  | [Multicast Anchor Transaction Frame Format](./0134.md)


### PR DESCRIPTION
### This pull request:

Proposes a new standard by creating a new markdown file in the appropriate directory and requests discussion and assignment of a BRC number

### Summary

## BRC-134: Multicast Anchor Transaction Frame Format

Defines frame version 0x06 for distributing chained anchor transactions — the root transaction in a chain of dependent transactions — over the IPv6 multicast fabric.

Anchor frames are delivered on the CtrlGroupControl group (FF0E::B:FFFE), the same global control channel used for block headers and coinbase transactions.

Key points:

- Every subscriber receives anchor frames unconditionally — dependents reference the anchor's TxID as an input, so missing it invalidates the entire chain.
- Header is layout-identical to BRC-124 (92 bytes); distinguished by FrameVer 0x06. LayoutPad32 is always zeros (no subtree scope).
- Participates in standard NACK-based retransmission (HashKey/SeqNum stamped by proxy).
- No BRC-130 fragmentation defined (anchor transactions are expected to be standard-sized).
- Complements BRC-133 (coinbase delivery) as another control-group transaction type that requires universal visibility regardless of shard assignment.
