### PR TITLE
[Fix] proper BRC-132 title

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ BRC | Standard
 129  | [IPv6 Multicast Group Address Assignments](./transactions/0129.md)
 130  | [Multicast Transaction Frame Fragmentation](./transactions/0130.md)
 131  | [Multicast Block Announcement Frame Format](./transactions/0131.md)
-132  | [Subtree Data Multicast Protocol](./transactions/0132.md)
+132  | [Multicast Subtree Data Frame Format](./transactions/0132.md)
 133  | [Multicast Coinbase Transaction Frame Format](./transactions/0133.md)
 134  | [Multicast Anchor Transaction Frame Format](./transactions/0134.md)
 135  | [Multicast Block Header Frame Format](./transactions/0135.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -67,7 +67,7 @@
 * [IPv6 Multicast Group Address Assignments](./transactions/0129.md)
 * [Multicast Transaction Frame Fragmentation](./transactions/0130.md)
 * [Multicast Block Announcement Frame Format](./transactions/0131.md)
-* [Subtree Data Multicast Protocol](./transactions/0132.md)
+* [Multicast Subtree Data Frame Format](./transactions/0132.md)
 * [Multicast Coinbase Transaction Frame Format](./transactions/0133.md)
 * [Multicast Anchor Transaction Frame Format](./transactions/0134.md)
 * [Multicast Block Header Format](./transactions/0135.md)

--- a/transactions/0132.md
+++ b/transactions/0132.md
@@ -1,4 +1,4 @@
-# BRC-132: Subtree Data Multicast Protocol
+# BRC-132: Multicast Subtree Data Frame Format
 
 Jeff Harris (jeff@lightweb.net)
 

--- a/transactions/README.md
+++ b/transactions/README.md
@@ -29,7 +29,7 @@ BRC | Standard
 129  | [IPv6 Multicast Group Address Assignments](./0129.md)
 130  | [Multicast Transaction Frame Fragmentation](./0130.md)
 131  | [Multicast Block Announcement Frame Format](./0131.md)
-132  | [BRC-132: Subtree Data Multicast Protocol](./0132.md)
+132  | [Multicast Subtree Data Frame Format](./0132.md)
 133  | [Multicast Coinbase Transaction Frame Format](./0133.md)
 134  | [Multicast Anchor Transaction Frame Format](./0134.md)
 135  | [Multicast Block Header Format](./0135.md)


### PR DESCRIPTION
### This pull request:

Amends or corrects an existing standard, without the need for creating a new one

### Summary

Aligned with the other multicast BRCs, fixed the title of BRC-132: Multicast Subtree Data Frame Format

It is not really a protocol definition.
