### PR TITLE
[Fix] BRC-127 group addressing and title fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ BRC | Standard
 124  | [Multicast Transaction Frame Format](./transactions/0124.md)
 125  | [PeerPay URI Scheme for BRC-29 Payments](./payments/0125.md)
 126  | [Multicast Transaction NACK Retransmission Protocol](./transactions/0126.md)
-127  | [Multicast Subtree Group Announcement Protocol](./transactions/0127.md)
+127  | [Multicast Subtree Group Announcement Frame Format](./transactions/0127.md)
 128  | [Multicast Extended Transaction Frame Format](./transactions/0128.md)
 129  | [IPv6 Multicast Group Address Assignments](./transactions/0129.md)
 130  | [Multicast Transaction Frame Fragmentation](./transactions/0130.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -62,7 +62,7 @@
 * [SubTree Unified Merkle Path (STUMP) Format](./transactions/0119.md)
 * [Multicast Transaction Frame Format](./transactions/0124.md)
 * [Multicast Transaction NACK Retransmission Protocol](./transactions/0126.md)
-* [Multicast Subtree Group Announcement Protocol](./transactions/0127.md)
+* [Multicast Subtree Group Announcement Frame Format](./transactions/0127.md)
 * [Multicast Extended Transaction Frame Format](./transactions/0128.md)
 * [IPv6 Multicast Group Address Assignments](./transactions/0129.md)
 * [Multicast Transaction Frame Fragmentation](./transactions/0130.md)

--- a/transactions/0127.md
+++ b/transactions/0127.md
@@ -1,4 +1,4 @@
-# BRC-127: BSV Multicast Subtree Group Announcement Protocol
+# BRC-127: Multicast Subtree Group Frame Format
 
 Jeff Harris (jeff@lightweb.net)
 
@@ -26,17 +26,17 @@ Subtrees are temporal: they are valid only for the duration of a work candidate.
 
 ### Control-Plane Group
 
-SubtreeAnnounce datagrams are sent to the reserved control-plane multicast group index `0xFFFFFC`, one slot below the BRC-126 beacon group (`0xFFFFFD`).
+SubtreeAnnounce datagrams are sent to the reserved control-plane multicast group index `0xFFFC` (`CtrlGroupSubtreeGroupAnnounce`), one slot below the BRC-126 beacon group (`0xFFFD`).
 
-Control-plane addresses follow the same derivation as BRC-126:
+Control-plane addresses use the IANA-aligned layout: bytes 0–1 carry the scope prefix, bytes 2–12 are zero (IANA 96-bit boundary), bytes 12–13 carry the IANA Bitcoin group-id (`0x000B`), and bytes 14–15 carry the group index.
 
-| Scope           | Announce Group (no middle bytes) |
+| Scope           | Announce Group                   |
 | --------------- | -------------------------------- |
-| Site (`0x05`)   | `FF05::FF:FFFC`                  |
-| Org (`0x08`)    | `FF08::FF:FFFC`                  |
-| Global (`0x0E`) | `FF0E::FF:FFFC`                  |
+| Site (`0x05`)   | `FF05::B:FFFC`                   |
+| Org (`0x08`)    | `FF08::B:FFFC`                   |
+| Global (`0x0E`) | `FF0E::B:FFFC`                   |
 
-When `-mc-base-addr` middle bytes are configured, those bytes appear at positions 2–12 of the IPv6 address identically to data-plane shard groups and the beacon group.
+Operators MAY override the IANA group-id (`0x000B`) via the `-mc-group-id` configuration flag for private deployments; the resulting addresses change accordingly.
 
 ### SubtreeGroupAnnounce Wire Format (`MsgType 0x30`) — 64 bytes
 
@@ -120,8 +120,8 @@ A1B2C3D4E5F6A7B8C9D0E1F2A3B4C5D6          // GroupID (128-bit)
 | `MagicBSV`                 | 3823236072 | `0xE3E1F3E8` | BSV mainnet P2P magic                       |
 | `ProtoVer`                 | 703        | `0x02BF`     | Protocol version                            |
 | `MsgTypeSubtreeAnnounce`   | 48         | `0x30`       | SubtreeAnnounce datagram type               |
-| `CtrlGroupSubtreeAnnounce` | 16777212   | `0xFFFFFC`   | Control-plane subtree announce group        |
-| `CtrlGroupBeacon`          | 16777213   | `0xFFFFFD`   | Control-plane beacon group (BRC-126)        |
+| `CtrlGroupSubtreeGroupAnnounce` | 65532 | `0xFFFC`     | Control-plane subtree group announce group  |
+| `CtrlGroupBeacon`          | 65533      | `0xFFFD`     | Control-plane beacon group (BRC-126)        |
 | `SubtreeAnnounceSize`      | 64         | —            | Fixed datagram size in bytes                |
 | `DefaultAnnounceTTL`       | 900        | —            | Recommended listener default TTL (s)        |
 | `DefaultAnnounceInterval`  | 10         | —            | Recommended sender re-announce interval (s) |

--- a/transactions/README.md
+++ b/transactions/README.md
@@ -24,7 +24,7 @@ BRC | Standard
 119  | [SubTree Unified Merkle Path (STUMP) Format](./0119.md)
 124  | [Multicast Transaction Frame Format](./0124.md)
 126  | [Multicast Transaction NACK Retransmission Protocol](./0126.md)
-127  | [Multicast Subtree Group Announcement Protocol](./0127.md)
+127  | [Multicast Subtree Group Announcement Frame Format](./0127.md)
 128  | [Multicast Extended Transaction Frame Format](./0128.md)
 129  | [IPv6 Multicast Group Address Assignments](./0129.md)
 130  | [Multicast Transaction Frame Fragmentation](./0130.md)


### PR DESCRIPTION
### This pull request:

Amends or corrects an existing standard, without the need for creating a new one

### Summary

There was an unexpected issue with BRC-127. The group addressing was wrong, and so was the title. Both have been repaired.