### PR TITLE
Multicast BRC Fix rollup

### DIFF
--- a/transactions/0124.md
+++ b/transactions/0124.md
@@ -181,7 +181,7 @@ E3E1F3E8                                                          // Network Mag
 
 | Name               | Value      | Hex          | Description                   |
 | ------------------ | ---------- | ------------ | ----------------------------- |
-| `MagicBSV`         | 3811983336 | `0xE3E1F3E8` | BSV mainnet P2P magic         |
+| `MagicBSV`         | 3823236072 | `0xE3E1F3E8` | BSV mainnet P2P magic         |
 | `ProtoVer`         | 703        | `0x02BF`     | Protocol version              |
 | `FrameVerLegacy`   | 1          | `0x01`       | Legacy BRC-12 frame version   |
 | `FrameVerBRC124`   | 2          | `0x02`       | Current BRC-124 frame version |

--- a/transactions/0124.md
+++ b/transactions/0124.md
@@ -31,7 +31,6 @@ A frame consists of a 92-byte header followed by a variable-length payload conta
 
 ### Header Format (92 bytes)
 
-```text
 | Offset | Size | Alignment | Field                 | Description                                    |
 |--------|------|-----------|-----------------------|------------------------------------------------|
 | 0      | 4    | —         | Network Magic         | `0xE3E1F3E8` (BSV mainnet P2P magic)           |
@@ -44,7 +43,6 @@ A frame consists of a 92-byte header followed by a variable-length payload conta
 | 56     | 32   | 8-byte    | Subtree ID            | 32-byte batch identifier; zeros = unset        |
 | 88     | 4    | 8-byte    | Payload Length        | `uint32` BE                                    |
 | 92     | *    | —         | Payload               | BRC-12 raw transaction bytes                   |
-```
 
 ### Field Definitions
 
@@ -102,7 +100,6 @@ Raw serialized BSV transaction in BRC-12 format: version (4 bytes LE) + input ve
 
 ### Alignment Verification
 
-```text
 | Field                 | Offset | Offset % 8 |
 |-----------------------|--------|------------|
 | Transaction ID        | 8      | 0 ✓        |
@@ -111,7 +108,6 @@ Raw serialized BSV transaction in BRC-12 format: version (4 bytes LE) + input ve
 | Subtree ID            | 56     | 0 ✓        |
 | Payload Length        | 88     | 0 ✓        |
 | Payload               | 92     | 4          |
-```
 
 ### Compatibility with BRC-12 Legacy Format
 
@@ -138,14 +134,7 @@ When transported over TCP, frames are concatenated end-to-end with no additional
 3. Reads exactly `PayLen` bytes
 4. Processes the complete frame
 
-### Error Handling
-
-| Condition                | UDP Behavior | TCP Behavior      |
-| ------------------------ | ------------ | ----------------- |
-| Bad magic                | Silent drop  | Connection closed |
-| Unknown frame version    | Silent drop  | Connection closed |
-| Payload length too large | Silent drop  | Connection closed |
-| Truncated datagram       | Silent drop  | Connection closed |
+### Frame Hex Dump
 
 A frame following this specification carrying a 200-byte transaction:
 
@@ -187,7 +176,6 @@ E3E1F3E8                                                          // Network Mag
 - [BRC-12: Raw Transaction Format](./0012.md) — Payload format for transaction data
 - [BRC-74: BSV Unified Merkle Path (BUMP) Format](./0074.md) — Merkle proof format used for transaction verification
 - [BRC-119: SubTree Unified Merkle Path (STUMP) Format](./0119.md) — Defines the Subtree ID concept referenced in this frame format
-- [bitcoin-shard-common](https://github.com/lightwebinc/bitcoin-shard-common) — Reference implementation (Go)
 
 ## Constants Reference
 
@@ -199,9 +187,3 @@ E3E1F3E8                                                          // Network Mag
 | `FrameVerBRC124`   | 2          | `0x02`       | Current BRC-124 frame version |
 | `HeaderSizeLegacy` | 44         | `0x2C`       | Legacy header size in bytes   |
 | `HeaderSize`       | 92         | `0x5C`       | BRC-124 header size in bytes  |
-
-## Implementations
-
-- **Go**: [bitcoin-shard-common/frame](https://github.com/lightwebinc/bitcoin-shard-common/tree/main/frame) — `Encode()`, `Decode()`, wire constants
-- **Proxy:** [bitcoin-shard-proxy](https://github.com/lightwebinc/bitcoin-shard-proxy) — HashKey / SeqNum stamping (`forwarder/forwarder.go`)
-- **Services**: [bitcoin-shard-listener](https://github.com/lightwebinc/bitcoin-shard-listener), [bitcoin-multicast](https://github.com/lightwebinc/bitcoin-multicast) — Network multicast infrastructure

--- a/transactions/0126.md
+++ b/transactions/0126.md
@@ -5,8 +5,8 @@ Jeff Harris (jeff@lightweb.net)
 ## Abstract
 
 This BRC specifies the NACK-based retransmission and endpoint discovery protocol
-for the BSV multicast transaction distribution pipeline. It defines four UDP
-datagram formats — ADVERT, NACK, MISS, and ACK — along with
+for the BSV multicast transaction distribution pipeline. It defines five UDP
+datagram formats — ADVERT, NACK, MISS, ACK, and THROTTLED — along with
 tier/preference-based endpoint selection, an escalation state machine, and
 configurable retransmit modes. The protocol operates on top of the BRC-124
 data-plane and enables reliable gap recovery without requiring connection state
@@ -32,9 +32,10 @@ This BRC adds the reliability layer that allows listeners to recover those gaps:
 2. **NACK dispatch** — listeners send a 64-byte NACK datagram to a retry
    endpoint identifying the missing frame by its flow (`HashKey`) and sequence
    number.
-3. **ACK/MISS responses** — every NACK receives a deterministic 16-byte
-   response; ACK confirms retransmit dispatched, MISS triggers immediate
-   escalation.
+3. **ACK/MISS/THROTTLED responses** — every served NACK receives a deterministic
+   16-byte response; ACK confirms retransmit dispatched, MISS triggers immediate
+   escalation, and the optional THROTTLED signals honest congestion (hold and
+   retry the same endpoint without escalating).
 4. **Endpoint discovery** — retry endpoints periodically multicast a 56-byte
    ADVERT beacon; listeners maintain a dynamic registry sorted by tier and
    preference, with no manual configuration required in well-connected
@@ -60,12 +61,13 @@ messages and are distinct from the data-frame version codes (`0x01`–`0x07`).
 
 ### MsgType Values
 
-| MsgType | Name   | Size | Direction                     |
-| ------- | ------ | ---- | ----------------------------- |
-| `0x10`  | NACK   | 64 B | Listener → Retry endpoint     |
-| `0x11`  | MISS   | 16 B | Retry endpoint → Listener     |
-| `0x12`  | ACK    | 16 B | Retry endpoint → Listener     |
-| `0x20`  | ADVERT | 56 B | Retry endpoint → Beacon group |
+| MsgType | Name      | Size | Direction                     |
+| ------- | --------- | ---- | ----------------------------- |
+| `0x10`  | NACK      | 64 B | Listener → Retry endpoint     |
+| `0x11`  | MISS      | 16 B | Retry endpoint → Listener     |
+| `0x12`  | ACK       | 16 B | Retry endpoint → Listener     |
+| `0x13`  | THROTTLED | 16 B | Retry endpoint → Listener     |
+| `0x20`  | ADVERT    | 56 B | Retry endpoint → Beacon group |
 
 ---
 
@@ -231,6 +233,48 @@ cancelling it.
 
 ---
 
+### THROTTLED Response (`MsgType 0x13`) — 16 bytes
+
+Sent unicast to the NACK source when the request was rejected by a
+congestion-control tier that limits per-gap or per-flow request rate (see
+[Flood Prevention](#flood-prevention)). It is a flow-control signal, **not** a
+failure: the endpoint is healthy, and for a per-gap throttle a retransmit for
+this exact gap was likely just served and is propagating over the multicast data
+plane. On receipt a listener MUST hold the gap for the hinted backoff and retry
+the **same** endpoint; it MUST NOT escalate to another endpoint and MUST NOT
+count the throttle as a recovery failure.
+
+| Offset | Size | Field    | Description                                |
+| ------ | ---- | -------- | ------------------------------------------ |
+| 0      | 4    | Magic    | `0xE3E1F3E8`                               |
+| 4      | 2    | ProtoVer | `0x02BF`                                   |
+| 6      | 1    | MsgType  | `0x13` (THROTTLED)                         |
+| 7      | 1    | Flags    | Bits 0-3 = backoff bucket; 4-7 reserved    |
+| 8      | 8    | SeqNum   | Echo of the throttled request's `StartSeq` |
+
+**Backoff hint.** The suggested hold is `ThrottleHintBase << bucket`, where
+`ThrottleHintBase = 125 ms` and `bucket` is the Flags low nibble. Endpoints
+SHOULD use bucket `2` (~500 ms) for a per-gap throttle and bucket `3` (~1 s) for
+a per-flow throttle. Listeners SHOULD apply jitter (e.g. uniform over
+`[hold/2, hold]`) to de-synchronise and MAY clamp the hold to a local maximum.
+The gap's absolute TTL remains the upper bound; a multicast repair cancels the
+gap regardless.
+
+**Emission rules.**
+
+- THROTTLED is OPTIONAL and SHOULD default to disabled; it is a load-shedding
+  refinement for high-fan-out deployments.
+- An endpoint MUST NOT send THROTTLED for a flood-tier (per-source) rejection:
+  that tier sheds abusive or spoofed-source load, and answering it would permit
+  reflection. (The 16-byte response is smaller than the 64-byte NACK, so the
+  protocol is never a bandwidth _amplifier_ regardless.)
+- An endpoint that does not implement THROTTLED stays silent; the listener falls
+  back to timeout + backoff.
+- A listener that does not recognise `0x13` treats it as an unparseable response
+  (timeout-equivalent), so emission is backward-compatible.
+
+---
+
 ### Tier / Preference Model
 
 Retry endpoints are organised into tiers representing proximity to the
@@ -265,9 +309,12 @@ listener advances to the next position.
       │    │   │
       │    │   └── Timeout ──► exponential backoff; retry next sweep
       │    │
-      │    └── MISS ──► advance to next endpoint at same tier (Preference DESC);
-      │                 if tier exhausted, escalate to Tier K+1;
-      │                 retry IMMEDIATELY (no backoff on MISS)
+      │    ├── MISS ──► advance to next endpoint at same tier (Preference DESC);
+      │    │            if tier exhausted, escalate to Tier K+1;
+      │    │            retry IMMEDIATELY (no backoff on MISS)
+      │    │
+      │    └── THROTTLED ──► hold for the hinted backoff; retry the SAME endpoint;
+      │                      do NOT escalate, do NOT count as a recovery failure
       │
       └── ACK ──► gap entry cancelled; done
 
@@ -280,6 +327,10 @@ listener advances to the next position.
   tier exhausted, move to next tier; retry immediately.
 - **Timeout:** Apply exponential backoff (capped at `nack-backoff-max`); retry
   on next sweeper tick.
+- **THROTTLED received:** Hold the gap for the hinted backoff and retry the same
+  endpoint. Do not escalate and do not count it as a recovery failure — it is
+  congestion control (see
+  [THROTTLED Response](#throttled-response-msgtype-0x13--16-bytes)).
 - **Multicast fill:** The data-plane receive goroutine calls `Tracker.Fill()`
   independently; gap cancelled regardless of NACK state.
 
@@ -335,13 +386,14 @@ Retransmit behavior is controlled by flags on the retry endpoint:
 
 ### Flood Prevention
 
-| Mechanism               | Component      | Effect                                                              |
-| ----------------------- | -------------- | ------------------------------------------------------------------- |
-| Cache TTL (60 s)        | Retry endpoint | Frames expire naturally; bounds retransmit window                   |
-| `Tracker.Fill()`        | Listener       | Multicast repair cancels all pending NACKs for a gap                |
-| Jitter hold-off         | Listener       | Randomised delay before first NACK suppresses correlated duplicates |
-| Exponential backoff     | Listener       | Reduces NACK rate on persistent or repeated gaps                    |
-| `MaxRetries` + `GapTTL` | Listener       | Gap entries evicted after retry exhaustion or absolute deadline     |
+| Mechanism               | Component      | Effect                                                                                                                         |
+| ----------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Cache TTL (60 s)        | Retry endpoint | Frames expire naturally; bounds retransmit window                                                                              |
+| `Tracker.Fill()`        | Listener       | Multicast repair cancels all pending NACKs for a gap                                                                           |
+| Jitter hold-off         | Listener       | Randomised delay before first NACK suppresses correlated duplicates                                                            |
+| Exponential backoff     | Listener       | Reduces NACK rate on persistent or repeated gaps                                                                               |
+| `MaxRetries` + `GapTTL` | Listener       | Gap entries evicted after retry exhaustion or absolute deadline                                                                |
+| THROTTLED hint          | Retry endpoint | Tells throttled listeners to hold (vs. timeout + escalate), cutting NACK load on honest congestion; IP flood tier stays silent |
 
 ---
 

--- a/transactions/0126.md
+++ b/transactions/0126.md
@@ -4,7 +4,13 @@ Jeff Harris (jeff@lightweb.net)
 
 ## Abstract
 
-This BRC specifies the NACK-based retransmission and endpoint discovery protocol for the BSV multicast transaction distribution pipeline. It defines four UDP datagram formats — ADVERT, NACK, MISS, and ACK — along with tier/preference-based endpoint selection, an escalation state machine, and configurable retransmit modes. The protocol operates on top of the BRC-124 data-plane and enables reliable gap recovery without requiring connection state at the ingress or listener tiers.
+This BRC specifies the NACK-based retransmission and endpoint discovery protocol
+for the BSV multicast transaction distribution pipeline. It defines four UDP
+datagram formats — ADVERT, NACK, MISS, and ACK — along with
+tier/preference-based endpoint selection, an escalation state machine, and
+configurable retransmit modes. The protocol operates on top of the BRC-124
+data-plane and enables reliable gap recovery without requiring connection state
+at the ingress or listener tiers.
 
 ## Copyright
 
@@ -12,15 +18,29 @@ This BRC is licensed under the Open BSV License.
 
 ## Motivation
 
-The BRC-124 data-plane delivers BSV transactions over IPv6 multicast with best-effort semantics. Network congestion, interface buffer overflows, and MLD snooping transitions can cause individual frames to be lost. Because BRC-124 frames carry a stable per-flow `HashKey` and a monotonic `SeqNum` stamped by the ingress proxy, listeners can detect exactly which frame is missing without a central sequence authority.
+The BRC-124 data-plane delivers BSV transactions over IPv6 multicast with
+best-effort semantics. Network congestion, interface buffer overflows, and MLD
+snooping transitions can cause individual frames to be lost. Because BRC-124
+frames carry a stable per-flow `HashKey` and a monotonic `SeqNum` stamped by the
+ingress proxy, listeners can detect exactly which frame is missing without a
+central sequence authority.
 
 This BRC adds the reliability layer that allows listeners to recover those gaps:
 
-1. **Gap detection** — listeners identify missing frames when a frame's `SeqNum` advances by more than 1 from the last-seen value for a given `HashKey` flow.
-2. **NACK dispatch** — listeners send a 64-byte NACK datagram to a retry endpoint identifying the missing frame by its flow (`HashKey`) and sequence number.
-3. **ACK/MISS responses** — every NACK receives a deterministic 16-byte response; ACK confirms retransmit dispatched, MISS triggers immediate escalation.
-4. **Endpoint discovery** — retry endpoints periodically multicast a 56-byte ADVERT beacon; listeners maintain a dynamic registry sorted by tier and preference, with no manual configuration required in well-connected deployments.
-5. **Flood prevention** — deduplication and fill-suppression mechanisms prevent retransmit storms at scale.
+1. **Gap detection** — listeners identify missing frames when a frame's `SeqNum`
+   advances by more than 1 from the last-seen value for a given `HashKey` flow.
+2. **NACK dispatch** — listeners send a 64-byte NACK datagram to a retry
+   endpoint identifying the missing frame by its flow (`HashKey`) and sequence
+   number.
+3. **ACK/MISS responses** — every NACK receives a deterministic 16-byte
+   response; ACK confirms retransmit dispatched, MISS triggers immediate
+   escalation.
+4. **Endpoint discovery** — retry endpoints periodically multicast a 56-byte
+   ADVERT beacon; listeners maintain a dynamic registry sorted by tier and
+   preference, with no manual configuration required in well-connected
+   deployments.
+5. **Flood prevention** — deduplication and fill-suppression mechanisms prevent
+   retransmit storms at scale.
 
 ## Specification
 
@@ -34,7 +54,9 @@ All BRC-126 datagrams begin with a 7-byte preamble:
 | 4      | 2    | Protocol Ver  | `0x02BF` (703, BSV large-block baseline) |
 | 6      | 1    | MsgType       | Identifies the message type (see below)  |
 
-The `MsgType` byte at offset 6 is in the same position as `FrameVersion` in BRC-124 data frames. Values `0x10`–`0x2F` are reserved for BRC-126 control messages and are distinct from the data-frame version codes (`0x01`, `0x02`).
+The `MsgType` byte at offset 6 is in the same position as `FrameVersion` in
+BRC-124 data frames. Values `0x10`–`0x2F` are reserved for BRC-126 control
+messages and are distinct from the data-frame version codes (`0x01`, `0x02`).
 
 ### MsgType Values
 
@@ -49,7 +71,8 @@ The `MsgType` byte at offset 6 is in the same position as `FrameVersion` in BRC-
 
 ### ADVERT Wire Format (`MsgType 0x20`) — 56 bytes
 
-Sent periodically by retry endpoints to the beacon multicast group. Listeners use it to build and maintain their endpoint registry.
+Sent periodically by retry endpoints to the beacon multicast group. Listeners
+use it to build and maintain their endpoint registry.
 
 | Offset | Size | Field          | Description                                                   |
 | ------ | ---- | -------------- | ------------------------------------------------------------- |
@@ -63,7 +86,7 @@ Sent periodically by retry endpoints to the beacon multicast group. Listeners us
 | 27     | 1    | Preference     | Within-tier priority; higher = more preferred (default `128`) |
 | 28     | 2    | BeaconInterval | Beacon send interval in seconds; listeners TTL = `3 × this`   |
 | 30     | 2    | Flags          | Capability bitmask (see below)                                |
-| 32     | 4    | InstanceID     | CRC32c of hostname; stable across restarts                   |
+| 32     | 4    | InstanceID     | CRC32c of hostname; stable across restarts                    |
 | 36     | 4    | Reserved       | Must be `0x00000000`                                          |
 | 40     | 16   | Reserved       | Must be all zeros; reserved for future capability bitmap      |
 
@@ -77,23 +100,32 @@ Sent periodically by retry endpoints to the beacon multicast group. Listeners us
 | `0x08` | UnicastRetransmit   | Supports unicast frame delivery to the NACK source         |
 | `0x10` | MulticastRetransmit | Retransmits via multicast to the original shard group      |
 
-**HasParent:** When set, the endpoint maintains a connection to a parent (higher-tier) endpoint and forwards NACKs on local cache miss. Listeners need only know their local tier; inter-tier forwarding is handled transparently.
+**HasParent:** When set, the endpoint maintains a connection to a parent
+(higher-tier) endpoint and forwards NACKs on local cache miss. Listeners need
+only know their local tier; inter-tier forwarding is handled transparently.
 
-**Beacon group addresses** are derived from the shard address scheme using the reserved control-plane index `0xFFFD`:
+**Beacon group addresses** are derived from the shard address scheme using the
+reserved control-plane index `0xFFFD`:
 
-| Scope           | Beacon Group                   |
-| --------------- | ------------------------------ |
-| Site (`0x05`)   | `FF05::B:FFFD`                 |
-| Org (`0x08`)    | `FF08::B:FFFD`                 |
-| Global (`0x0E`) | `FF0E::B:FFFD`                 |
+| Scope           | Beacon Group   |
+| --------------- | -------------- |
+| Site (`0x05`)   | `FF05::B:FFFD` |
+| Org (`0x08`)    | `FF08::B:FFFD` |
+| Global (`0x0E`) | `FF0E::B:FFFD` |
 
-Addresses use the IANA-aligned layout: bytes 0–1 carry the scope prefix, bytes 2–11 are zero (IANA 96-bit boundary), bytes 12–13 carry the IANA Bitcoin group-id (`0x000B`), and bytes 14–15 carry the group index. Operators MAY override the group-id via `-mc-group-id`.
+Addresses use the IANA-aligned layout: bytes 0–1 carry the scope prefix, bytes
+2–11 are zero (IANA 96-bit boundary), bytes 12–13 carry the IANA Bitcoin
+group-id (`0x000B`), and bytes 14–15 carry the group index. Operators MAY
+override the group-id via `-mc-group-id`.
 
 ---
 
 ### NACK Wire Format (`MsgType 0x10`) — 64 bytes
 
-Sent by a listener to a retry endpoint when a gap is detected. Identifies the missing frame by its flow (`HashKey`) and sequence number range. For current single-frame retrieval, `StartSeq == EndSeq`; range requests (`StartSeq < EndSeq`) are reserved for future use.
+Sent by a listener to a retry endpoint when a gap is detected. Identifies the
+missing frame by its flow (`HashKey`) and sequence number range. For current
+single-frame retrieval, `StartSeq == EndSeq`; range requests
+(`StartSeq < EndSeq`) are reserved for future use.
 
 | Offset | Size | Field     | Description                                                                     |
 | ------ | ---- | --------- | ------------------------------------------------------------------------------- |
@@ -101,54 +133,66 @@ Sent by a listener to a retry endpoint when a gap is detected. Identifies the mi
 | 4      | 2    | ProtoVer  | `0x02BF`                                                                        |
 | 6      | 1    | MsgType   | `0x10` (NACK)                                                                   |
 | 7      | 1    | Flags     | Reserved; must be `0x00`                                                        |
-| 8      | 8    | HashKey   | Stable per-flow XXH64 identifier; from BRC-124 frame bytes 40–47               |
+| 8      | 8    | HashKey   | Stable per-flow XXH64 identifier; from BRC-124 frame bytes 40–47                |
 | 16     | 8    | StartSeq  | First missing `SeqNum` (inclusive)                                              |
 | 24     | 8    | EndSeq    | Last missing `SeqNum` (inclusive); equals `StartSeq` for single-frame retrieval |
-| 32     | 32   | SubtreeID | 32-byte batch identifier; from BRC-124 frame bytes 56–87; zeros = unset        |
+| 32     | 32   | SubtreeID | 32-byte batch identifier; from BRC-124 frame bytes 56–87; zeros = unset         |
 
-The listener opens a per-request ephemeral UDP socket (`[::]:0`), sends the NACK, and waits up to 300 ms for a single response (`MISS` or `ACK`).
+The listener opens a per-request ephemeral UDP socket (`[::]:0`), sends the
+NACK, and waits up to 300 ms for a single response (`MISS` or `ACK`).
 
-> **HashKey** (offset 8) is the `HashKey` field from the BRC-124 frame, computed as `XXH64(senderIPv6 ∥ groupIdx ∥ subtreeID)`. It uniquely identifies the flow. The retry endpoint uses `HashKey` as a per-flow rate-limiting key (NACK storm cap). A value of `0` bypasses the per-flow check.
+> **HashKey** (offset 8) is the `HashKey` field from the BRC-124 frame, computed
+> as `XXH64(senderIPv6 ∥ groupIdx ∥ subtreeID)`. It uniquely identifies the
+> flow. The retry endpoint uses `HashKey` as a per-flow rate-limiting key (NACK
+> storm cap). A value of `0` bypasses the per-flow check.
 
-> **StartSeq / EndSeq** (offsets 16/24) specify the range of missing sequence numbers. For current single-frame retrieval, `StartSeq == EndSeq`. The retry endpoint looks up the frame using the 16-byte cache key `HashKey ∥ StartSeq`.
+> **StartSeq / EndSeq** (offsets 16/24) specify the range of missing sequence
+> numbers. For current single-frame retrieval, `StartSeq == EndSeq`. The retry
+> endpoint looks up the frame using the 16-byte cache key `HashKey ∥ StartSeq`.
 
-> **SubtreeID** (offset 32) is carried for informational purposes; the cache key is `HashKey ∥ SeqNum` and does not require SubtreeID for disambiguation.
+> **SubtreeID** (offset 32) is carried for informational purposes; the cache key
+> is `HashKey ∥ SeqNum` and does not require SubtreeID for disambiguation.
 
 ---
 
 ### MISS Response (`MsgType 0x11`) — 16 bytes
 
-Sent unicast to the NACK source when the requested frame is not in the endpoint's cache. On receipt, the listener advances immediately to the next endpoint (no backoff delay).
+Sent unicast to the NACK source when the requested frame is not in the
+endpoint's cache. On receipt, the listener advances immediately to the next
+endpoint (no backoff delay).
 
-| Offset | Size | Field    | Description                         |
-| ------ | ---- | -------- | ----------------------------------- |
-| 0      | 4    | Magic    | `0xE3E1F3E8`                        |
-| 4      | 2    | ProtoVer | `0x02BF`                            |
-| 6      | 1    | MsgType  | `0x11` (MISS)                       |
-| 7      | 1    | Flags    | Reserved; must be `0x00`            |
-| 8      | 8    | SeqNum   | Always `0` on MISS                  |
+| Offset | Size | Field    | Description              |
+| ------ | ---- | -------- | ------------------------ |
+| 0      | 4    | Magic    | `0xE3E1F3E8`             |
+| 4      | 2    | ProtoVer | `0x02BF`                 |
+| 6      | 1    | MsgType  | `0x11` (MISS)            |
+| 7      | 1    | Flags    | Reserved; must be `0x00` |
+| 8      | 8    | SeqNum   | Always `0` on MISS       |
 
 ---
 
 ### ACK Response (`MsgType 0x12`) — 16 bytes
 
-Sent unicast to the NACK source when the frame was found and retransmit dispatched. On receipt, the listener cancels the gap entry immediately.
+Sent unicast to the NACK source when the frame was found and retransmit
+dispatched. On receipt, the listener cancels the gap entry immediately.
 
-| Offset | Size | Field    | Description                                        |
-| ------ | ---- | -------- | -------------------------------------------------- |
-| 0      | 4    | Magic    | `0xE3E1F3E8`                                       |
-| 4      | 2    | ProtoVer | `0x02BF`                                           |
-| 6      | 1    | MsgType  | `0x12` (ACK)                                       |
-| 7      | 1    | Flags    | `0x01` = multicast sent; `0x02` = unicast sent     |
+| Offset | Size | Field    | Description                                                    |
+| ------ | ---- | -------- | -------------------------------------------------------------- |
+| 0      | 4    | Magic    | `0xE3E1F3E8`                                                   |
+| 4      | 2    | ProtoVer | `0x02BF`                                                       |
+| 6      | 1    | MsgType  | `0x12` (ACK)                                                   |
+| 7      | 1    | Flags    | `0x01` = multicast sent; `0x02` = unicast sent                 |
 | 8      | 8    | SeqNum   | `SeqNum` of the retransmitted frame (from BRC-124 bytes 48–55) |
 
-The listener uses the `SeqNum` echo to confirm the gap entry matches before cancelling it.
+The listener uses the `SeqNum` echo to confirm the gap entry matches before
+cancelling it.
 
 ---
 
 ### Tier / Preference Model
 
-Retry endpoints are organised into tiers representing proximity to the transaction source, and assigned a preference within each tier.
+Retry endpoints are organised into tiers representing proximity to the
+transaction source, and assigned a preference within each tier.
 
 | Tier   | Meaning                                            |
 | ------ | -------------------------------------------------- |
@@ -157,9 +201,13 @@ Retry endpoints are organised into tiers representing proximity to the transacti
 | `N`    | N AS hops from source                              |
 | `0xFF` | Static seed (no beacon received; lowest priority)  |
 
-Endpoints discovered via ADVERT carry their operator-assigned `Tier` (0–254) and `Preference` (0–255). Endpoints registered via static configuration seed the registry at `Tier=0xFF, Preference=0`.
+Endpoints discovered via ADVERT carry their operator-assigned `Tier` (0–254) and
+`Preference` (0–255). Endpoints registered via static configuration seed the
+registry at `Tier=0xFF, Preference=0`.
 
-Listeners sort the endpoint registry by `(Tier ASC, Preference DESC)`. NACK dispatch always selects the head of the sorted list; on MISS or timeout, the listener advances to the next position.
+Listeners sort the endpoint registry by `(Tier ASC, Preference DESC)`. NACK
+dispatch always selects the head of the sorted list; on MISS or timeout, the
+listener advances to the next position.
 
 #### Escalation State Machine
 
@@ -186,27 +234,38 @@ Listeners sort the endpoint registry by `(Tier ASC, Preference DESC)`. NACK disp
 ```
 
 - **ACK received:** Cancel gap entry. No further NACKs sent for this gap.
-- **MISS received:** Advance to next endpoint at same tier by Preference; if tier exhausted, move to next tier; retry immediately.
-- **Timeout:** Apply exponential backoff (capped at `nack-backoff-max`); retry on next sweeper tick.
-- **Multicast fill:** The data-plane receive goroutine calls `Tracker.Fill()` independently; gap cancelled regardless of NACK state.
+- **MISS received:** Advance to next endpoint at same tier by Preference; if
+  tier exhausted, move to next tier; retry immediately.
+- **Timeout:** Apply exponential backoff (capped at `nack-backoff-max`); retry
+  on next sweeper tick.
+- **Multicast fill:** The data-plane receive goroutine calls `Tracker.Fill()`
+  independently; gap cancelled regardless of NACK state.
 
 ---
 
 ### Beacon Scopes
 
-Three scope bytes are defined for the ADVERT wire format. The reference implementation's `-beacon-scope` flag accepts `site`, `global`, or `both` (sends to site + global simultaneously):
+Three scope bytes are defined for the ADVERT wire format. The reference
+implementation's `-beacon-scope` flag accepts `site`, `global`, or `both` (sends
+to site + global simultaneously):
 
-| Scope           | Scope byte | Beacon group    | Use case                                            |
-| --------------- | ---------- | --------------- | --------------------------------------------------- |
-| Site (`0x05`)   | `0x05`     | `FF05::B:FFFD`  | Intra-site discovery; all listeners join at startup |
-| Org (`0x08`)    | `0x08`     | `FF08::B:FFFD`  | Organisation-wide discovery for multi-site AS       |
-| Global (`0x0E`) | `0x0E`     | `FF0E::B:FFFD`  | Inter-AS discovery via MP-BGP MVPN / MSDP           |
+| Scope           | Scope byte | Beacon group   | Use case                                            |
+| --------------- | ---------- | -------------- | --------------------------------------------------- |
+| Site (`0x05`)   | `0x05`     | `FF05::B:FFFD` | Intra-site discovery; all listeners join at startup |
+| Org (`0x08`)    | `0x08`     | `FF08::B:FFFD` | Organisation-wide discovery for multi-site AS       |
+| Global (`0x0E`) | `0x0E`     | `FF0E::B:FFFD` | Inter-AS discovery via MP-BGP MVPN / MSDP           |
 
-Scope byte `0xFF` is used in ADVERT datagrams when the sender intends to cover both site and global simultaneously (sends two ADVERTs). Listeners parse the scope byte from each individual datagram.
+Scope byte `0xFF` is used in ADVERT datagrams when the sender intends to cover
+both site and global simultaneously (sends two ADVERTs). Listeners parse the
+scope byte from each individual datagram.
 
-To cover multiple scopes, run separate endpoint instances each configured with a different `-beacon-scope` value. Each scope can use independent `Tier` and `Preference` tuning.
+To cover multiple scopes, run separate endpoint instances each configured with a
+different `-beacon-scope` value. Each scope can use independent `Tier` and
+`Preference` tuning.
 
-Listeners compute TTL as `3 × BeaconInterval`. An endpoint not heard for that duration is evicted from the registry. Static seeds (`-retry-endpoints`) are never evicted.
+Listeners compute TTL as `3 × BeaconInterval`. An endpoint not heard for that
+duration is evicted from the registry. Static seeds (`-retry-endpoints`) are
+never evicted.
 
 ---
 
@@ -223,9 +282,12 @@ Retransmit behavior is controlled by flags on the retry endpoint:
 
 **Deployment profiles:**
 
-- **On-fabric (default):** `-retransmit-multicast=true` — all listeners on the fabric receive the retransmit simultaneously.
-- **Edge / unicast:** `-retransmit-unicast=true -retransmit-multicast=false` — for listeners not on the multicast fabric.
-- **High-volume:** `-suppress-ack=true` — reduces per-frame ACK traffic; MISS responses are preserved for escalation correctness.
+- **On-fabric (default):** `-retransmit-multicast=true` — all listeners on the
+  fabric receive the retransmit simultaneously.
+- **Edge / unicast:** `-retransmit-unicast=true -retransmit-multicast=false` —
+  for listeners not on the multicast fabric.
+- **High-volume:** `-suppress-ack=true` — reduces per-frame ACK traffic; MISS
+  responses are preserved for escalation correctness.
 
 ---
 
@@ -245,7 +307,8 @@ Retransmit behavior is controlled by flags on the retry endpoint:
 
 ### ADVERT Datagram (56 bytes)
 
-A site-scope endpoint at `fd20::24`, port 9300, Tier 0, Preference 128, 60-second interval, multicast retransmit enabled:
+A site-scope endpoint at `fd20::24`, port 9300, Tier 0, Preference 128,
+60-second interval, multicast retransmit enabled:
 
 ```text
 E3E1F3E8                                  // Network Magic
@@ -265,7 +328,8 @@ A1B2C3D4                                  // InstanceID (CRC32c of hostname)
 
 ### NACK Datagram (64 bytes)
 
-Single-frame retrieval: missing frame for flow `HashKey=0xA1B2C3D400000001`, `SeqNum=1235`:
+Single-frame retrieval: missing frame for flow `HashKey=0xA1B2C3D400000001`,
+`SeqNum=1235`:
 
 ```text
 E3E1F3E8                                  // Network Magic
@@ -304,45 +368,35 @@ E3E1F3E8                                  // Network Magic
 
 ## References
 
-- [BRC-12: Raw Transaction Format](./0012.md) — Payload format for transaction data within BRC-124 frames
-- [BRC-124: Multicast Transaction Frame Format](./0124.md) — Data-plane frame format; defines `HashKey`, `SeqNum`, and `Subtree ID` stamped by the proxy
-- [bitcoin-shard-common](https://github.com/lightwebinc/bitcoin-shard-common) — Reference implementation of frame and shard primitives (Go)
+- [BRC-12: Raw Transaction Format](./0012.md) — Payload format for transaction
+  data within BRC-124 frames
+- [BRC-124: Multicast Transaction Frame Format](./0124.md) — Data-plane frame
+  format; defines `HashKey`, `SeqNum`, and `Subtree ID` stamped by the proxy
 
 ---
 
 ## Constants Reference
 
-```text
-| Name                   | Value      | Hex          | Description                          |
-|------------------------|------------|--------------|--------------------------------------|
-| `MagicBSV`             | 3823236072 | `0xE3E1F3E8` | BSV mainnet P2P magic                |
-| `ProtoVer`             | 703        | `0x02BF`     | Protocol version                     |
-| `MsgTypeNACK`          | 16         | `0x10`       | NACK request                         |
-| `MsgTypeMISS`          | 17         | `0x11`       | MISS response                        |
-| `MsgTypeACK`           | 18         | `0x12`       | ACK response                         |
-| `MsgTypeADVERT`        | 32         | `0x20`       | Endpoint advertisement beacon        |
-| `ScopesSite`           | 5          | `0x05`       | Site-local beacon scope              |
-| `ScopeOrg`             | 8          | `0x08`       | Organisation beacon scope            |
-| `ScopeGlobal`          | 14         | `0x0E`       | Global beacon scope                  |
-| `NACKSize`             | 64         | `0x40`       | NACK datagram size in bytes          |
-| `FlagMulticastSent`    | 1          | `0x01`       | ACK flag: multicast retransmit sent  |
-| `FlagUnicastSent`      | 2          | `0x02`       | ACK flag: unicast retransmit sent    |
-| `FlagHasParent`        | 2          | `0x02`       | ADVERT flag: upstream endpoint set   |
-| `FlagDraining`         | 4          | `0x04`       | ADVERT flag: endpoint is draining    |
-| `FlagUnicastRetransmit`| 8          | `0x08`       | ADVERT flag: unicast retransmit      |
-| `FlagMcastRetransmit`  | 16         | `0x10`       | ADVERT flag: multicast retransmit    |
-| `CtrlGroupBeacon`      | 65533      | `0xFFFD`     | Control-plane beacon group index     |
-| `DefaultNACKPort`      | 9300       | `0x2454`     | Default NACK/ADVERT UDP port         |
-| `DefaultBeaconInterval`| 60         | —            | Default ADVERT send interval (s)     |
-| `DefaultCacheTTL`      | 60         | —            | Default frame cache TTL (s)          |
+| Name                   | Value      | Hex          | Description                            |
+|------------------------|------------|--------------|----------------------------------------|
+| `MagicBSV`             | 3823236072 | `0xE3E1F3E8` | BSV mainnet P2P magic                  |
+| `ProtoVer`             | 703        | `0x02BF`     | Protocol version                       |
+| `MsgTypeNACK`          | 16         | `0x10`       | NACK request                           |
+| `MsgTypeMISS`          | 17         | `0x11`       | MISS response                          |
+| `MsgTypeACK`           | 18         | `0x12`       | ACK response                           |
+| `MsgTypeADVERT`        | 32         | `0x20`       | Endpoint advertisement beacon          |
+| `ScopesSite`           | 5          | `0x05`       | Site-local beacon scope                |
+| `ScopeOrg`             | 8          | `0x08`       | Organisation beacon scope              |
+| `ScopeGlobal`          | 14         | `0x0E`       | Global beacon scope                    |
+| `NACKSize`             | 64         | `0x40`       | NACK datagram size in bytes            |
+| `FlagMulticastSent`    | 1          | `0x01`       | ACK flag: multicast retransmit sent    |
+| `FlagUnicastSent`      | 2          | `0x02`       | ACK flag: unicast retransmit sent      |
+| `FlagHasParent`        | 2          | `0x02`       | ADVERT flag: upstream endpoint set     |
+| `FlagDraining`         | 4          | `0x04`       | ADVERT flag: endpoint is draining      |
+| `FlagUnicastRetransmit`| 8          | `0x08`       | ADVERT flag: unicast retransmit        |
+| `FlagMcastRetransmit`  | 16         | `0x10`       | ADVERT flag: multicast retransmit      |
+| `CtrlGroupBeacon`      | 65533      | `0xFFFD`     | Control-plane beacon group index       |
+| `DefaultNACKPort`      | 9300       | `0x2454`     | Default NACK/ADVERT UDP port           |
+| `DefaultBeaconInterval`| 60         | —            | Default ADVERT send interval (s)       |
+| `DefaultCacheTTL`      | 60         | —            | Default frame cache TTL (s)            |
 | `TierStaticSeed`       | 255        | `0xFF`       | Tier assigned to static seed endpoints |
-```
-
----
-
-## Implementations
-
-- **Retry endpoint:** [bitcoin-retry-endpoint](https://github.com/lightwebinc/bitcoin-retry-endpoint) — NACK server (`server/server.go`), ADVERT sender (`beacon/beacon.go`), frame cache (`cache/`), rate limiting (`ratelimit/`)
-- **Listener:** [bitcoin-shard-listener](https://github.com/lightwebinc/bitcoin-shard-listener) — NACK wire encode/decode (`nack/wire.go`), gap tracker (`nack/nack.go`), ADVERT decode + endpoint registry (`discovery/`)
-- **Common:** [bitcoin-shard-common](https://github.com/lightwebinc/bitcoin-shard-common) — Frame decode (`frame/frame.go`), shard group derivation (`shard/shard.go`), control group address helper (`shard/control.go`)
-- **Proxy:** [bitcoin-shard-proxy](https://github.com/lightwebinc/bitcoin-shard-proxy) — HashKey / SeqNum stamping (`forwarder/forwarder.go`)

--- a/transactions/0126.md
+++ b/transactions/0126.md
@@ -132,7 +132,7 @@ single-frame retrieval, `StartSeq == EndSeq`; range requests
 | 0      | 4    | Magic     | `0xE3E1F3E8`                                                                    |
 | 4      | 2    | ProtoVer  | `0x02BF`                                                                        |
 | 6      | 1    | MsgType   | `0x10` (NACK)                                                                   |
-| 7      | 1    | Flags     | Reserved; must be `0x00`                                                        |
+| 7      | 1    | Flags     | Bit 0 (`0x01`) = Proxied; bits 1–7 reserved, must be `0`                        |
 | 8      | 8    | HashKey   | Stable per-flow XXH64 identifier; from BRC-124 frame bytes 40–47                |
 | 16     | 8    | StartSeq  | First missing `SeqNum` (inclusive)                                              |
 | 24     | 8    | EndSeq    | Last missing `SeqNum` (inclusive); equals `StartSeq` for single-frame retrieval |
@@ -145,13 +145,55 @@ NACK, and waits up to 300 ms for a single response (`MISS` or `ACK`).
 > as `XXH64(senderIPv6 ∥ groupIdx ∥ subtreeID)`. It uniquely identifies the
 > flow. The retry endpoint uses `HashKey` as a per-flow rate-limiting key (NACK
 > storm cap). A value of `0` bypasses the per-flow check.
-
+>
 > **StartSeq / EndSeq** (offsets 16/24) specify the range of missing sequence
 > numbers. For current single-frame retrieval, `StartSeq == EndSeq`. The retry
 > endpoint looks up the frame using the 16-byte cache key `HashKey ∥ StartSeq`.
-
+>
 > **SubtreeID** (offset 32) is carried for informational purposes; the cache key
 > is `HashKey ∥ SeqNum` and does not require SubtreeID for disambiguation.
+>
+> **Flags / Proxied** (offset 7, bit `0x01`) marks a NACK that an endpoint
+> issued on behalf of a downstream multicast domain (cross-domain proxying — see
+> [NACK Proxying](#nack-proxying-cross-domain-recovery)). An endpoint receiving
+> a NACK with this bit set MUST serve it from its own cache but MUST NOT
+> re-proxy it, bounding any proxy chain to a single hop. The bit was previously
+> reserved and is ignored by legacy endpoints, which simply never re-proxy.
+
+---
+
+### NACK Proxying (cross-domain recovery)
+
+A retry endpoint serving a downstream multicast domain (one fed by a listener's
+multicast egress rather than directly by the ingress proxy) can only cache what
+the listener actually emitted. A frame the listener never put on the downstream
+wire — egress send error, interface flap, or in-fabric loss — is missed
+identically by the downstream endpoint and every downstream consumer, so a
+downstream-only cache cannot repair it. NACK proxying recovers such frames from
+an upstream endpoint that received them directly from the ingress proxy:
+
+1. A downstream consumer NACKs the downstream endpoint, which suffers a local
+   cache miss and returns `MISS` immediately.
+2. The downstream endpoint forwards the NACK to a statically configured upstream
+   endpoint with the **Proxied** flag set (`0x01`). Recovery is asynchronous
+   ("cache-warm"); no NACK worker is held waiting.
+3. The upstream endpoint serves the proxied NACK from its cache. Because the
+   requester (the downstream endpoint) is not joined to the upstream shard
+   groups, the frame is returned by **unicast** to the NACK source — a proxied
+   NACK is always served a unicast copy regardless of the upstream's advertised
+   retransmit mode.
+4. The downstream endpoint re-caches the recovered frame (keyed
+   `HashKey ∥ SeqNum`, per-FrameVer TTL) and multicast-retransmits it into the
+   downstream domain; the consumer's gap auto-fills via `Tracker.Fill()`.
+
+**One-hop bound.** The `Proxied` flag prevents an upstream endpoint from
+re-proxying, so any proxy chain is at most one hop. Upstream discovery is by
+static configuration, because a separated downstream domain generally cannot
+receive upstream multicast ADVERT beacons. The `HasParent` ADVERT flag (`0x02`)
+signals that an endpoint has an upstream parent configured. When several
+downstream endpoints run with proxying enabled against a shared cache backend,
+an in-flight claim deduplicates the upstream NACKs so only one endpoint recovers
+each gap.
 
 ---
 
@@ -389,6 +431,7 @@ E3E1F3E8                                  // Network Magic
 | `ScopeOrg`              | 8          | `0x08`       | Organisation beacon scope              |
 | `ScopeGlobal`           | 14         | `0x0E`       | Global beacon scope                    |
 | `NACKSize`              | 64         | `0x40`       | NACK datagram size in bytes            |
+| `FlagProxied`           | 1          | `0x01`       | NACK flag: proxied, one-hop downstream |
 | `FlagMulticastSent`     | 1          | `0x01`       | ACK flag: multicast retransmit sent    |
 | `FlagUnicastSent`       | 2          | `0x02`       | ACK flag: unicast retransmit sent      |
 | `FlagHasParent`         | 2          | `0x02`       | ADVERT flag: upstream endpoint set     |

--- a/transactions/0126.md
+++ b/transactions/0126.md
@@ -377,26 +377,26 @@ E3E1F3E8                                  // Network Magic
 
 ## Constants Reference
 
-| Name                   | Value      | Hex          | Description                            |
-|------------------------|------------|--------------|----------------------------------------|
-| `MagicBSV`             | 3823236072 | `0xE3E1F3E8` | BSV mainnet P2P magic                  |
-| `ProtoVer`             | 703        | `0x02BF`     | Protocol version                       |
-| `MsgTypeNACK`          | 16         | `0x10`       | NACK request                           |
-| `MsgTypeMISS`          | 17         | `0x11`       | MISS response                          |
-| `MsgTypeACK`           | 18         | `0x12`       | ACK response                           |
-| `MsgTypeADVERT`        | 32         | `0x20`       | Endpoint advertisement beacon          |
-| `ScopesSite`           | 5          | `0x05`       | Site-local beacon scope                |
-| `ScopeOrg`             | 8          | `0x08`       | Organisation beacon scope              |
-| `ScopeGlobal`          | 14         | `0x0E`       | Global beacon scope                    |
-| `NACKSize`             | 64         | `0x40`       | NACK datagram size in bytes            |
-| `FlagMulticastSent`    | 1          | `0x01`       | ACK flag: multicast retransmit sent    |
-| `FlagUnicastSent`      | 2          | `0x02`       | ACK flag: unicast retransmit sent      |
-| `FlagHasParent`        | 2          | `0x02`       | ADVERT flag: upstream endpoint set     |
-| `FlagDraining`         | 4          | `0x04`       | ADVERT flag: endpoint is draining      |
-| `FlagUnicastRetransmit`| 8          | `0x08`       | ADVERT flag: unicast retransmit        |
-| `FlagMcastRetransmit`  | 16         | `0x10`       | ADVERT flag: multicast retransmit      |
-| `CtrlGroupBeacon`      | 65533      | `0xFFFD`     | Control-plane beacon group index       |
-| `DefaultNACKPort`      | 9300       | `0x2454`     | Default NACK/ADVERT UDP port           |
-| `DefaultBeaconInterval`| 60         | —            | Default ADVERT send interval (s)       |
-| `DefaultCacheTTL`      | 60         | —            | Default frame cache TTL (s)            |
-| `TierStaticSeed`       | 255        | `0xFF`       | Tier assigned to static seed endpoints |
+| Name                    | Value      | Hex          | Description                            |
+| ----------------------- | ---------- | ------------ | -------------------------------------- |
+| `MagicBSV`              | 3823236072 | `0xE3E1F3E8` | BSV mainnet P2P magic                  |
+| `ProtoVer`              | 703        | `0x02BF`     | Protocol version                       |
+| `MsgTypeNACK`           | 16         | `0x10`       | NACK request                           |
+| `MsgTypeMISS`           | 17         | `0x11`       | MISS response                          |
+| `MsgTypeACK`            | 18         | `0x12`       | ACK response                           |
+| `MsgTypeADVERT`         | 32         | `0x20`       | Endpoint advertisement beacon          |
+| `ScopesSite`            | 5          | `0x05`       | Site-local beacon scope                |
+| `ScopeOrg`              | 8          | `0x08`       | Organisation beacon scope              |
+| `ScopeGlobal`           | 14         | `0x0E`       | Global beacon scope                    |
+| `NACKSize`              | 64         | `0x40`       | NACK datagram size in bytes            |
+| `FlagMulticastSent`     | 1          | `0x01`       | ACK flag: multicast retransmit sent    |
+| `FlagUnicastSent`       | 2          | `0x02`       | ACK flag: unicast retransmit sent      |
+| `FlagHasParent`         | 2          | `0x02`       | ADVERT flag: upstream endpoint set     |
+| `FlagDraining`          | 4          | `0x04`       | ADVERT flag: endpoint is draining      |
+| `FlagUnicastRetransmit` | 8          | `0x08`       | ADVERT flag: unicast retransmit        |
+| `FlagMcastRetransmit`   | 16         | `0x10`       | ADVERT flag: multicast retransmit      |
+| `GroupBeacon`           | 65533      | `0xFFFD`     | Control-plane beacon group index       |
+| `DefaultNACKPort`       | 9300       | `0x2454`     | Default NACK/ADVERT UDP port           |
+| `DefaultBeaconInterval` | 60         | —            | Default ADVERT send interval (s)       |
+| `DefaultCacheTTL`       | 60         | —            | Default frame cache TTL (s)            |
+| `TierStaticSeed`        | 255        | `0xFF`       | Tier assigned to static seed endpoints |

--- a/transactions/0126.md
+++ b/transactions/0126.md
@@ -56,7 +56,7 @@ All BRC-126 datagrams begin with a 7-byte preamble:
 
 The `MsgType` byte at offset 6 is in the same position as `FrameVersion` in
 BRC-124 data frames. Values `0x10`–`0x2F` are reserved for BRC-126 control
-messages and are distinct from the data-frame version codes (`0x01`, `0x02`).
+messages and are distinct from the data-frame version codes (`0x01`–`0x07`).
 
 ### MsgType Values
 
@@ -427,7 +427,7 @@ E3E1F3E8                                  // Network Magic
 | `MsgTypeMISS`           | 17         | `0x11`       | MISS response                          |
 | `MsgTypeACK`            | 18         | `0x12`       | ACK response                           |
 | `MsgTypeADVERT`         | 32         | `0x20`       | Endpoint advertisement beacon          |
-| `ScopesSite`            | 5          | `0x05`       | Site-local beacon scope                |
+| `ScopeSite`             | 5          | `0x05`       | Site-local beacon scope                |
 | `ScopeOrg`              | 8          | `0x08`       | Organisation beacon scope              |
 | `ScopeGlobal`           | 14         | `0x0E`       | Global beacon scope                    |
 | `NACKSize`              | 64         | `0x40`       | NACK datagram size in bytes            |

--- a/transactions/0127.md
+++ b/transactions/0127.md
@@ -4,7 +4,11 @@ Jeff Harris (jeff@lightweb.net)
 
 ## Abstract
 
-This BRC specifies a periodic multicast announcement protocol that maps BRC-124 `SubtreeID` values to stable 128-bit group identifiers. Senders broadcast compact 64-byte datagrams on a reserved control-plane multicast group, allowing listeners to dynamically learn which subtree IDs belong to which groups and filter incoming transaction traffic accordingly — without static configuration.
+This BRC specifies a periodic multicast announcement protocol that maps BRC-124
+`SubtreeID` values to stable 128-bit group identifiers. Senders broadcast
+compact 64-byte datagrams on a reserved control-plane multicast group, allowing
+listeners to dynamically learn which subtree IDs belong to which groups and
+filter incoming transaction traffic accordingly — without static configuration.
 
 ## Copyright
 
@@ -12,31 +16,48 @@ This BRC is licensed under the Open BSV License.
 
 ## Motivation
 
-BRC-124 frames carry a 32-byte `SubtreeID` that identifies the transaction subtree to which each frame belongs. Subtree IDs are derived deterministically by each block assembler and change with every new work candidate. Static subtree ID lists are impractical for listeners that want to subscribe to a logical class of transactions (a _subtree group_) across block boundaries.
+BRC-124 frames carry a 32-byte `SubtreeID` that identifies the transaction
+subtree to which each frame belongs. Subtree IDs are derived deterministically
+by each block assembler and change with every new work candidate. Static subtree
+ID lists are impractical for listeners that want to subscribe to a logical class
+of transactions (a _subtree group_) across block boundaries.
 
 This BRC introduces:
 
-1. **Subtree groups** — stable 128-bit identifiers that logically group related subtree IDs. A group ID is an XXH3-128 hash of a canonical group name, or any operator-assigned 128-bit value.
-2. **SubtreeAnnounce** — a periodic 64-byte control datagram sent by block assemblers announcing that a given `SubtreeID` is a member of a given group.
-3. **Dynamic listener filtering** — listeners join a dedicated control-plane multicast group, process SubtreeAnnounce datagrams, maintain a time-bounded registry, and pass transactions based on group membership.
+1. **Subtree groups** — stable 128-bit identifiers that logically group related
+   subtree IDs. A group ID is an XXH3-128 hash of a canonical group name, or any
+   operator-assigned 128-bit value.
+2. **SubtreeAnnounce** — a periodic 64-byte control datagram sent by block
+   assemblers announcing that a given `SubtreeID` is a member of a given group.
+3. **Dynamic listener filtering** — listeners join a dedicated control-plane
+   multicast group, process SubtreeAnnounce datagrams, maintain a time-bounded
+   registry, and pass transactions based on group membership.
 
-Subtrees are temporal: they are valid only for the duration of a work candidate. Announcements are sent periodically; entries not refreshed within their TTL are evicted automatically.
+Subtrees are temporal: they are valid only for the duration of a work candidate.
+Announcements are sent periodically; entries not refreshed within their TTL are
+evicted automatically.
 
 ## Specification
 
 ### Control-Plane Group
 
-SubtreeAnnounce datagrams are sent to the reserved control-plane multicast group index `0xFFFC` (`CtrlGroupSubtreeGroupAnnounce`), one slot below the BRC-126 beacon group (`0xFFFD`).
+SubtreeAnnounce datagrams are sent to the reserved control-plane multicast group
+index `0xFFFC` (`CtrlGroupSubtreeGroupAnnounce`), one slot below the BRC-126
+beacon group (`0xFFFD`).
 
-Control-plane addresses use the IANA-aligned layout: bytes 0–1 carry the scope prefix, bytes 2–12 are zero (IANA 96-bit boundary), bytes 12–13 carry the IANA Bitcoin group-id (`0x000B`), and bytes 14–15 carry the group index.
+Control-plane addresses use the IANA-aligned layout: bytes 0–1 carry the scope
+prefix, bytes 2–12 are zero (IANA 96-bit boundary), bytes 12–13 carry the IANA
+Bitcoin group-id (`0x000B`), and bytes 14–15 carry the group index.
 
-| Scope           | Announce Group                   |
-| --------------- | -------------------------------- |
-| Site (`0x05`)   | `FF05::B:FFFC`                   |
-| Org (`0x08`)    | `FF08::B:FFFC`                   |
-| Global (`0x0E`) | `FF0E::B:FFFC`                   |
+| Scope           | Announce Group |
+| --------------- | -------------- |
+| Site (`0x05`)   | `FF05::B:FFFC` |
+| Org (`0x08`)    | `FF08::B:FFFC` |
+| Global (`0x0E`) | `FF0E::B:FFFC` |
 
-Operators MAY override the IANA group-id (`0x000B`) via the `-mc-group-id` configuration flag for private deployments; the resulting addresses change accordingly.
+Operators MAY override the IANA group-id (`0x000B`) via the `-mc-group-id`
+configuration flag for private deployments; the resulting addresses change
+accordingly.
 
 ### SubtreeGroupAnnounce Wire Format (`MsgType 0x30`) — 64 bytes
 
@@ -52,51 +73,75 @@ Operators MAY override the IANA group-id (`0x000B`) via the `-mc-group-id` confi
 | 60     | 2    | TTL           | Validity in seconds (uint16 BE); `0` = use listener default   |
 | 62     | 2    | Reserved      | Must be `0x0000`                                              |
 
-Total: **64 bytes**. Power-of-two message size; `GroupID` at offset 40 is 8-byte aligned.
+Total: **64 bytes**. Power-of-two message size; `GroupID` at offset 40 is 8-byte
+aligned.
 
 #### Flags (byte 7)
 
-All bits are reserved and must be zero. Future versions of this protocol may define flag bits.
+All bits are reserved and must be zero. Future versions of this protocol may
+define flag bits.
 
 #### GroupID
 
-A GroupID is a 128-bit value uniquely identifying a logical subtree group. It is recommended to derive GroupIDs using XXH3-128 applied to a canonical group name string, as this provides hardware-accelerated, collision-resistant derivation. GroupIDs may also be assigned directly as opaque 128-bit values.
+A GroupID is a 128-bit value uniquely identifying a logical subtree group. It is
+recommended to derive GroupIDs using XXH3-128 applied to a canonical group name
+string, as this provides hardware-accelerated, collision-resistant derivation.
+GroupIDs may also be assigned directly as opaque 128-bit values.
 
 #### TTL and Expiry
 
-A `TTL` value of `0` instructs the listener to apply its locally configured default TTL. Listeners SHOULD set the default TTL to at least 900 seconds (15 minutes) to accommodate block creation intervals. Senders SHOULD re-announce each (SubtreeID, GroupID) pair at an interval well below the effective TTL (recommended: every 10–30 seconds).
+A `TTL` value of `0` instructs the listener to apply its locally configured
+default TTL. Listeners SHOULD set the default TTL to at least 900 seconds (15
+minutes) to accommodate block creation intervals. Senders SHOULD re-announce
+each (SubtreeID, GroupID) pair at an interval well below the effective TTL
+(recommended: every 10–30 seconds).
 
 #### Multi-Group Membership
 
-A single SubtreeID may belong to multiple groups. The sender emits one SubtreeAnnounce datagram per (SubtreeID, GroupID) pair per announcement interval.
+A single SubtreeID may belong to multiple groups. The sender emits one
+SubtreeAnnounce datagram per (SubtreeID, GroupID) pair per announcement
+interval.
 
 ### Sender Behaviour
 
-1. For each (SubtreeID, GroupID) pair, construct a 64-byte SubtreeAnnounce datagram.
-2. Send the datagram as a UDP packet to the SubtreeAnnounce control group on the configured multicast scope(s).
+1. For each (SubtreeID, GroupID) pair, construct a 64-byte SubtreeAnnounce
+   datagram.
+2. Send the datagram as a UDP packet to the SubtreeAnnounce control group on the
+   configured multicast scope(s).
 3. Repeat at the configured announcement interval (recommended: 10–30 seconds).
-4. On work reset (new block), stop announcing old SubtreeIDs. Listeners will evict them when the TTL expires.
+4. On work reset (new block), stop announcing old SubtreeIDs. Listeners will
+   evict them when the TTL expires.
 
-No retransmission or sequencing is required. Periodic re-announcement provides eventual consistency.
+No retransmission or sequencing is required. Periodic re-announcement provides
+eventual consistency.
 
 ### Listener Behaviour
 
-1. Join the SubtreeAnnounce control-plane multicast group on the configured scope(s).
-2. For each received datagram, validate the magic, ProtoVer, MsgType, and length.
-3. If a sender include/exclude filter is configured, check the UDP source address before processing.
-4. If the GroupID matches a subscribed group, record `(SubtreeID → expiry)` in the group registry.
+1. Join the SubtreeAnnounce control-plane multicast group on the configured
+   scope(s).
+2. For each received datagram, validate the magic, ProtoVer, MsgType, and
+   length.
+3. If a sender include/exclude filter is configured, check the UDP source
+   address before processing.
+4. If the GroupID matches a subscribed group, record `(SubtreeID → expiry)` in
+   the group registry.
 5. Periodically evict entries whose expiry has passed.
-6. On data-plane frame receipt, allow the frame if its SubtreeID is present in any subscribed group's registry.
+6. On data-plane frame receipt, allow the frame if its SubtreeID is present in
+   any subscribed group's registry.
 
 ### Sender Filtering
 
-Listeners MAY configure include and exclude filters on announcement source addresses (IPv6 addresses or CIDR prefixes). The evaluation order is: exclude first, then include. An empty include list accepts all non-excluded sources.
+Listeners MAY configure include and exclude filters on announcement source
+addresses (IPv6 addresses or CIDR prefixes). The evaluation order is: exclude
+first, then include. An empty include list accepts all non-excluded sources.
 
 ---
 
 ## Example
 
-SubtreeAnnounce for SubtreeID `A3F1...9247`, GroupID `A1B2C3D4E5F6A7B8C9D0E1F2A3B4C5D6`, Epoch `1746800000`, TTL `0` (use listener default):
+SubtreeAnnounce for SubtreeID `A3F1...9247`, GroupID
+`A1B2C3D4E5F6A7B8C9D0E1F2A3B4C5D6`, Epoch `1746800000`, TTL `0` (use listener
+default):
 
 ```text
 E3E1F3E8                                  // Network Magic
@@ -115,28 +160,20 @@ A1B2C3D4E5F6A7B8C9D0E1F2A3B4C5D6          // GroupID (128-bit)
 
 ## Constants Reference
 
-| Name                       | Value      | Hex          | Description                                 |
-| -------------------------- | ---------- | ------------ | ------------------------------------------- |
-| `MagicBSV`                 | 3823236072 | `0xE3E1F3E8` | BSV mainnet P2P magic                       |
-| `ProtoVer`                 | 703        | `0x02BF`     | Protocol version                            |
-| `MsgTypeSubtreeAnnounce`   | 48         | `0x30`       | SubtreeAnnounce datagram type               |
-| `CtrlGroupSubtreeGroupAnnounce` | 65532 | `0xFFFC`     | Control-plane subtree group announce group  |
-| `CtrlGroupBeacon`          | 65533      | `0xFFFD`     | Control-plane beacon group (BRC-126)        |
-| `SubtreeAnnounceSize`      | 64         | —            | Fixed datagram size in bytes                |
-| `DefaultAnnounceTTL`       | 900        | —            | Recommended listener default TTL (s)        |
-| `DefaultAnnounceInterval`  | 10         | —            | Recommended sender re-announce interval (s) |
+| Name                            | Value      | Hex          | Description                                 |
+| ------------------------------- | ---------- | ------------ | ------------------------------------------- |
+| `MagicBSV`                      | 3823236072 | `0xE3E1F3E8` | BSV mainnet P2P magic                       |
+| `ProtoVer`                      | 703        | `0x02BF`     | Protocol version                            |
+| `MsgTypeSubtreeAnnounce`        | 48         | `0x30`       | SubtreeAnnounce datagram type               |
+| `CtrlGroupSubtreeGroupAnnounce` | 65532      | `0xFFFC`     | Control-plane subtree group announce group  |
+| `CtrlGroupBeacon`               | 65533      | `0xFFFD`     | Control-plane beacon group (BRC-126)        |
+| `SubtreeAnnounceSize`           | 64         | —            | Fixed datagram size in bytes                |
+| `DefaultAnnounceTTL`            | 900        | —            | Recommended listener default TTL (s)        |
+| `DefaultAnnounceInterval`       | 10         | —            | Recommended sender re-announce interval (s) |
 
 ---
 
 ## References
 
-- [BRC-124: Multicast Transaction Frame Format](./0124.md) — Data-plane frame format; defines `SubtreeID`
-
----
-
-## Implementations
-
-- **Sender:** [bitcoin-subtx-generator](https://github.com/lightwebinc/bitcoin-subtx-generator) — `-subtree-group`, `-announce-interval` flags; periodic SubtreeAnnounce sender
-- **Listener:** [bitcoin-shard-listener](https://github.com/lightwebinc/bitcoin-shard-listener) — subtree group registry (`subtreegroup/`), announcement listener (`discovery/subtree_announce.go`), filter integration
-- **Proxy:** [bitcoin-shard-proxy](https://github.com/lightwebinc/bitcoin-shard-proxy) — detects `MsgType 0x30` on TCP ingress and forwards to control-plane multicast
-- **Common:** [bitcoin-shard-common](https://github.com/lightwebinc/bitcoin-shard-common) — `CtrlGroupSubtreeAnnounce` constant, `MsgTypeSubtreeAnnounce`, SubtreeAnnounce codec (`frame/subtree_announce.go`)
+- [BRC-124: Multicast Transaction Frame Format](./0124.md) — Data-plane frame
+  format; defines `SubtreeID`

--- a/transactions/0127.md
+++ b/transactions/0127.md
@@ -1,4 +1,4 @@
-# BRC-127: Multicast Subtree Group Frame Format
+# BRC-127: Multicast Subtree Group Announcement Frame Format
 
 Jeff Harris (jeff@lightweb.net)
 
@@ -27,10 +27,10 @@ This BRC introduces:
 1. **Subtree groups** — stable 128-bit identifiers that logically group related
    subtree IDs. A group ID is an XXH3-128 hash of a canonical group name, or any
    operator-assigned 128-bit value.
-2. **SubtreeAnnounce** — a periodic 64-byte control datagram sent by block
+2. **SubtreeGroupAnnounce** — a periodic 64-byte control datagram sent by block
    assemblers announcing that a given `SubtreeID` is a member of a given group.
 3. **Dynamic listener filtering** — listeners join a dedicated control-plane
-   multicast group, process SubtreeAnnounce datagrams, maintain a time-bounded
+   multicast group, process SubtreeGroupAnnounce datagrams, maintain a time-bounded
    registry, and pass transactions based on group membership.
 
 Subtrees are temporal: they are valid only for the duration of a work candidate.
@@ -41,12 +41,12 @@ evicted automatically.
 
 ### Control-Plane Group
 
-SubtreeAnnounce datagrams are sent to the reserved control-plane multicast group
+SubtreeGroupAnnounce datagrams are sent to the reserved control-plane multicast group
 index `0xFFFC` (`GroupSubtreeGroupAnnounce`), one slot below the BRC-126 beacon
 group (`0xFFFD`).
 
 Control-plane addresses use the IANA-aligned layout: bytes 0–1 carry the scope
-prefix, bytes 2–12 are zero (IANA 96-bit boundary), bytes 12–13 carry the IANA
+prefix, bytes 2–11 are zero (IANA 96-bit boundary), bytes 12–13 carry the IANA
 Bitcoin group-id (`0x000B`), and bytes 14–15 carry the group index.
 
 | Scope           | Announce Group |
@@ -65,7 +65,7 @@ accordingly.
 | ------ | ---- | ------------- | ------------------------------------------------------------- |
 | 0      | 4    | Network Magic | `0xE3E1F3E8` (BSV mainnet P2P magic)                          |
 | 4      | 2    | Protocol Ver  | `0x02BF` (703, BSV large-block baseline)                      |
-| 6      | 1    | MsgType       | `0x30` (SubtreeAnnounce)                                      |
+| 6      | 1    | MsgType       | `0x30` (SubtreeGroupAnnounce)                                 |
 | 7      | 1    | Flags         | Reserved; must be `0x00`                                      |
 | 8      | 32   | SubtreeID     | SHA-256 subtree root hash (from BRC-124 frame header)         |
 | 40     | 16   | GroupID       | 128-bit group identifier, big-endian                          |
@@ -99,14 +99,14 @@ each (SubtreeID, GroupID) pair at an interval well below the effective TTL
 #### Multi-Group Membership
 
 A single SubtreeID may belong to multiple groups. The sender emits one
-SubtreeAnnounce datagram per (SubtreeID, GroupID) pair per announcement
+SubtreeGroupAnnounce datagram per (SubtreeID, GroupID) pair per announcement
 interval.
 
 ### Sender Behaviour
 
-1. For each (SubtreeID, GroupID) pair, construct a 64-byte SubtreeAnnounce
+1. For each (SubtreeID, GroupID) pair, construct a 64-byte SubtreeGroupAnnounce
    datagram.
-2. Send the datagram as a UDP packet to the SubtreeAnnounce control group on the
+2. Send the datagram as a UDP packet to the SubtreeGroupAnnounce control group on the
    configured multicast scope(s).
 3. Repeat at the configured announcement interval (recommended: 10–30 seconds).
 4. On work reset (new block), stop announcing old SubtreeIDs. Listeners will
@@ -117,7 +117,7 @@ eventual consistency.
 
 ### Listener Behaviour
 
-1. Join the SubtreeAnnounce control-plane multicast group on the configured
+1. Join the SubtreeGroupAnnounce control-plane multicast group on the configured
    scope(s).
 2. For each received datagram, validate the magic, ProtoVer, MsgType, and
    length.
@@ -139,14 +139,14 @@ first, then include. An empty include list accepts all non-excluded sources.
 
 ## Example
 
-SubtreeAnnounce for SubtreeID `A3F1...9247`, GroupID
+SubtreeGroupAnnounce for SubtreeID `A3F1...9247`, GroupID
 `A1B2C3D4E5F6A7B8C9D0E1F2A3B4C5D6`, Epoch `1746800000`, TTL `0` (use listener
 default):
 
 ```text
 E3E1F3E8                                  // Network Magic
 02BF                                      // Protocol Version
-30                                        // MsgType = SubtreeAnnounce
+30                                        // MsgType = SubtreeGroupAnnounce
 00                                        // Flags = 0
 A3F1E8B04C7D2A9156E3F08B4D7C2E9A          // SubtreeID bytes 0–15
 1B5F3D8E6C0A4279B1D5E8F3C6A09247          // SubtreeID bytes 16–31
@@ -160,16 +160,16 @@ A1B2C3D4E5F6A7B8C9D0E1F2A3B4C5D6          // GroupID (128-bit)
 
 ## Constants Reference
 
-| Name                        | Value      | Hex          | Description                                 |
-| --------------------------- | ---------- | ------------ | ------------------------------------------- |
-| `MagicBSV`                  | 3823236072 | `0xE3E1F3E8` | BSV mainnet P2P magic                       |
-| `ProtoVer`                  | 703        | `0x02BF`     | Protocol version                            |
-| `MsgTypeSubtreeAnnounce`    | 48         | `0x30`       | SubtreeAnnounce datagram type               |
-| `GroupSubtreeGroupAnnounce` | 65532      | `0xFFFC`     | Control-plane subtree group announce group  |
-| `GroupBeacon`               | 65533      | `0xFFFD`     | Control-plane beacon group (BRC-126)        |
-| `SubtreeAnnounceSize`       | 64         | —            | Fixed datagram size in bytes                |
-| `DefaultAnnounceTTL`        | 900        | —            | Recommended listener default TTL (s)        |
-| `DefaultAnnounceInterval`   | 10         | —            | Recommended sender re-announce interval (s) |
+| Name                          | Value      | Hex          | Description                                 |
+| ----------------------------- | ---------- | ------------ | ------------------------------------------- |
+| `MagicBSV`                    | 3823236072 | `0xE3E1F3E8` | BSV mainnet P2P magic                       |
+| `ProtoVer`                    | 703        | `0x02BF`     | Protocol version                            |
+| `MsgTypeSubtreeGroupAnnounce` | 48         | `0x30`       | SubtreeGroupAnnounce datagram type          |
+| `GroupSubtreeGroupAnnounce`   | 65532      | `0xFFFC`     | Control-plane subtree group announce group  |
+| `GroupBeacon`                 | 65533      | `0xFFFD`     | Control-plane beacon group (BRC-126)        |
+| `SubtreeGroupAnnounceSize`    | 64         | —            | Fixed datagram size in bytes                |
+| `DefaultAnnounceTTL`          | 900        | —            | Recommended listener default TTL (s)        |
+| `DefaultAnnounceInterval`     | 10         | —            | Recommended sender re-announce interval (s) |
 
 ---
 

--- a/transactions/0127.md
+++ b/transactions/0127.md
@@ -42,8 +42,8 @@ evicted automatically.
 ### Control-Plane Group
 
 SubtreeAnnounce datagrams are sent to the reserved control-plane multicast group
-index `0xFFFC` (`CtrlGroupSubtreeGroupAnnounce`), one slot below the BRC-126
-beacon group (`0xFFFD`).
+index `0xFFFC` (`GroupSubtreeGroupAnnounce`), one slot below the BRC-126 beacon
+group (`0xFFFD`).
 
 Control-plane addresses use the IANA-aligned layout: bytes 0–1 carry the scope
 prefix, bytes 2–12 are zero (IANA 96-bit boundary), bytes 12–13 carry the IANA
@@ -160,16 +160,16 @@ A1B2C3D4E5F6A7B8C9D0E1F2A3B4C5D6          // GroupID (128-bit)
 
 ## Constants Reference
 
-| Name                            | Value      | Hex          | Description                                 |
-| ------------------------------- | ---------- | ------------ | ------------------------------------------- |
-| `MagicBSV`                      | 3823236072 | `0xE3E1F3E8` | BSV mainnet P2P magic                       |
-| `ProtoVer`                      | 703        | `0x02BF`     | Protocol version                            |
-| `MsgTypeSubtreeAnnounce`        | 48         | `0x30`       | SubtreeAnnounce datagram type               |
-| `CtrlGroupSubtreeGroupAnnounce` | 65532      | `0xFFFC`     | Control-plane subtree group announce group  |
-| `CtrlGroupBeacon`               | 65533      | `0xFFFD`     | Control-plane beacon group (BRC-126)        |
-| `SubtreeAnnounceSize`           | 64         | —            | Fixed datagram size in bytes                |
-| `DefaultAnnounceTTL`            | 900        | —            | Recommended listener default TTL (s)        |
-| `DefaultAnnounceInterval`       | 10         | —            | Recommended sender re-announce interval (s) |
+| Name                        | Value      | Hex          | Description                                 |
+| --------------------------- | ---------- | ------------ | ------------------------------------------- |
+| `MagicBSV`                  | 3823236072 | `0xE3E1F3E8` | BSV mainnet P2P magic                       |
+| `ProtoVer`                  | 703        | `0x02BF`     | Protocol version                            |
+| `MsgTypeSubtreeAnnounce`    | 48         | `0x30`       | SubtreeAnnounce datagram type               |
+| `GroupSubtreeGroupAnnounce` | 65532      | `0xFFFC`     | Control-plane subtree group announce group  |
+| `GroupBeacon`               | 65533      | `0xFFFD`     | Control-plane beacon group (BRC-126)        |
+| `SubtreeAnnounceSize`       | 64         | —            | Fixed datagram size in bytes                |
+| `DefaultAnnounceTTL`        | 900        | —            | Recommended listener default TTL (s)        |
+| `DefaultAnnounceInterval`   | 10         | —            | Recommended sender re-announce interval (s) |
 
 ---
 

--- a/transactions/0128.md
+++ b/transactions/0128.md
@@ -4,7 +4,12 @@ Jeff Harris (jeff@lightweb.net)
 
 ## Abstract
 
-This BRC specifies a payload variant for the BRC-124 multicast frame format in which the transaction payload uses the BRC-30 Extended Format (EF) instead of the BRC-12 raw transaction format. The 92-byte BRC-124 header is unchanged; the payload is self-identifying via the BRC-30 EF marker. This enables multicast receivers and broadcast services to fully validate transaction signatures and fee amounts without external UTXO lookups.
+This BRC specifies a payload variant for the BRC-124 multicast frame format in
+which the transaction payload uses the BRC-30 Extended Format (EF) instead of
+the BRC-12 raw transaction format. The 92-byte BRC-124 header is unchanged; the
+payload is self-identifying via the BRC-30 EF marker. This enables multicast
+receivers and broadcast services to fully validate transaction signatures and
+fee amounts without external UTXO lookups.
 
 ## Copyright
 
@@ -12,43 +17,60 @@ This BRC is licensed under the Open BSV License.
 
 ## Motivation
 
-BRC-124 frames carry BSV transactions in BRC-12 raw format, which omits the locking scripts and satoshi amounts of spent inputs. Validating signatures or computing fees from a BRC-12 payload requires an external UTXO lookup — a bottleneck that BRC-30 was specifically designed to eliminate.
+BRC-124 frames carry BSV transactions in BRC-12 raw format, which omits the
+locking scripts and satoshi amounts of spent inputs. Validating signatures or
+computing fees from a BRC-12 payload requires an external UTXO lookup — a
+bottleneck that BRC-30 was specifically designed to eliminate.
 
-By defining BRC-124 frames with BRC-30 Extended Format payloads, multicast infrastructure gains:
+By defining BRC-124 frames with BRC-30 Extended Format payloads, multicast
+infrastructure gains:
 
-1. **Self-contained validation** — receivers can verify all input signatures and compute exact fee amounts from the frame payload alone, with no UTXO index dependency.
-2. **Zero header changes** — the BRC-124 header (Frame Version `0x02`, 92 bytes) is reused as-is. The EF marker embedded in the payload provides unambiguous format detection. No frame version bump is required.
-3. **Transparent infrastructure** — proxies, retry endpoints, and listeners treat the payload as opaque bytes. Existing multicast infrastructure forwards BRC-128 frames without modification.
-4. **Coexistence** — BRC-124 frames with BRC-12 payloads and BRC-128 frames with BRC-30 EF payloads share the same multicast groups, frame version, and processing pipeline.
+1. **Self-contained validation** — receivers can verify all input signatures and
+   compute exact fee amounts from the frame payload alone, with no UTXO index
+   dependency.
+2. **Zero header changes** — the BRC-124 header (Frame Version `0x02`, 92 bytes)
+   is reused as-is. The EF marker embedded in the payload provides unambiguous
+   format detection. No frame version bump is required.
+3. **Transparent infrastructure** — proxies, retry endpoints, and listeners
+   treat the payload as opaque bytes. Existing multicast infrastructure forwards
+   BRC-128 frames without modification.
+4. **Coexistence** — BRC-124 frames with BRC-12 payloads and BRC-128 frames with
+   BRC-30 EF payloads share the same multicast groups, frame version, and
+   processing pipeline.
 
 ## Specification
 
 ### Frame Structure Overview
 
-A BRC-128 frame consists of a standard 92-byte BRC-124 header followed by a variable-length payload containing a BRC-30 Extended Format transaction. The header is identical to BRC-124 in every respect — same field layout, same Frame Version byte (`0x02`), same alignment.
+A BRC-128 frame consists of a standard 92-byte BRC-124 header followed by a
+variable-length payload containing a BRC-30 Extended Format transaction. The
+header is identical to BRC-124 in every respect — same field layout, same Frame
+Version byte (`0x02`), same alignment.
 
 ### Header Format (92 bytes)
 
 The header is defined by [BRC-124](./0124.md) and reproduced here for reference:
 
-| Offset | Size | Alignment | Field            | Description                                |
-| ------ | ---- | --------- | ---------------- | ------------------------------------------ |
-| 0      | 4    | —         | Network Magic    | `0xE3E1F3E8` (BSV mainnet P2P magic)       |
-| 4      | 2    | —         | Protocol Version | `0x02BF` (703, BSV large-block baseline)   |
-| 6      | 1    | —         | Frame Version    | `0x02`                                     |
-| 7      | 1    | —         | Reserved         | Must be `0x00`                             |
-| 8      | 32   | 8-byte    | Transaction ID   | Raw 256-bit TXID (internal byte order)     |
-| 40     | 8    | 8-byte    | HashKey          | Stable per-flow XXH64 identifier; `0` = unstamped          |
-| 48     | 8    | 8-byte    | SeqNum           | Monotonic per-flow counter (starts at 1); `0` = unstamped  |
-| 56     | 32   | 8-byte    | Subtree ID       | 32-byte batch identifier; zeros = unset    |
-| 88     | 4    | 8-byte    | Payload Length   | `uint32` BE                                |
-| 92     | \*   | —         | Payload          | BRC-30 Extended Format transaction bytes   |
+| Offset | Size | Alignment | Field            | Description                                               |
+| ------ | ---- | --------- | ---------------- | --------------------------------------------------------- |
+| 0      | 4    | —         | Network Magic    | `0xE3E1F3E8` (BSV mainnet P2P magic)                      |
+| 4      | 2    | —         | Protocol Version | `0x02BF` (703, BSV large-block baseline)                  |
+| 6      | 1    | —         | Frame Version    | `0x02`                                                    |
+| 7      | 1    | —         | Reserved         | Must be `0x00`                                            |
+| 8      | 32   | 8-byte    | Transaction ID   | Raw 256-bit TXID (internal byte order)                    |
+| 40     | 8    | 8-byte    | HashKey          | Stable per-flow XXH64 identifier; `0` = unstamped         |
+| 48     | 8    | 8-byte    | SeqNum           | Monotonic per-flow counter (starts at 1); `0` = unstamped |
+| 56     | 32   | 8-byte    | Subtree ID       | 32-byte batch identifier; zeros = unset                   |
+| 88     | 4    | 8-byte    | Payload Length   | `uint32` BE                                               |
+| 92     | \*   | —         | Payload          | BRC-30 Extended Format transaction bytes                  |
 
-All header fields retain the semantics defined in BRC-124. The only difference from a BRC-124 frame is the payload format.
+All header fields retain the semantics defined in BRC-124. The only difference
+from a BRC-124 frame is the payload format.
 
 ### Payload Format (BRC-30 Extended Format)
 
-The payload is a BSV transaction serialized in the BRC-30 Extended Format. The format is summarized here; see [BRC-30](./0030.md) for the full specification.
+The payload is a BSV transaction serialized in the BRC-30 Extended Format. The
+format is summarized here; see [BRC-30](./0030.md) for the full specification.
 
 #### EF Transaction Structure
 
@@ -64,7 +86,8 @@ The payload is a BSV transaction serialized in the BRC-30 Extended Format. The f
 
 #### Extended Format Input Structure
 
-Each input in an EF transaction appends the spent output's satoshi value and locking script after the standard input fields:
+Each input in an EF transaction appends the spent output's satoshi value and
+locking script after the standard input fields:
 
 | Field                          | Description                                       | Size                      |
 | ------------------------------ | ------------------------------------------------- | ------------------------- |
@@ -79,7 +102,8 @@ Each input in an EF transaction appends the spent output's satoshi value and loc
 
 ### Payload Format Detection
 
-Receivers distinguish BRC-128 (EF) payloads from BRC-124 (BRC-12 raw) payloads by inspecting the first 10 bytes of the payload:
+Receivers distinguish BRC-128 (EF) payloads from BRC-124 (BRC-12 raw) payloads
+by inspecting the first 10 bytes of the payload:
 
 ```text
 Payload bytes 0–3:   Transaction version (4 bytes LE) — typically 0x02000000
@@ -88,27 +112,45 @@ Payload bytes 4–9:   EF marker check
   - BRC-12 raw:      VarInt input count (never matches the EF marker)
 ```
 
-The 6-byte EF marker `0x000000000000EF` is placed immediately after the 4-byte version number. In a BRC-12 raw transaction, bytes 4–9 contain the input count VarInt followed by the first bytes of the first input — a sequence that cannot produce the EF marker pattern. This makes detection unambiguous without any header-level signaling.
+The 6-byte EF marker `0x000000000000EF` is placed immediately after the 4-byte
+version number. In a BRC-12 raw transaction, bytes 4–9 contain the input count
+VarInt followed by the first bytes of the first input — a sequence that cannot
+produce the EF marker pattern. This makes detection unambiguous without any
+header-level signaling.
 
 ### Why No Frame Version Bump
 
 The Frame Version byte remains `0x02` for the following reasons:
 
-1. **Self-identifying payload** — BRC-30 was explicitly designed with the EF marker for format detection. A header-level signal is redundant.
-2. **Consistent BSV precedent** — BRC-62 (BEEF), BRC-95 (Atomic BEEF), and BRC-96 (BEEF V2) all use payload-level markers for format discrimination rather than outer envelope version numbers.
-3. **Non-breaking** — existing infrastructure (`frame.Decode`, TCP reader, proxy forwarder, retry endpoint cache) treats the payload as opaque bytes. A new frame version would cause all deployed components to reject frames (`ErrBadVer`) until updated, with no structural benefit.
-4. **Version semantics** — Frame Version `0x01` → `0x02` changed the header from 44 to 92 bytes. A version bump should signal a header structure change, not a payload format change.
+1. **Self-identifying payload** — BRC-30 was explicitly designed with the EF
+   marker for format detection. A header-level signal is redundant.
+2. **Consistent BSV precedent** — BRC-62 (BEEF), BRC-95 (Atomic BEEF), and
+   BRC-96 (BEEF V2) all use payload-level markers for format discrimination
+   rather than outer envelope version numbers.
+3. **Non-breaking** — existing infrastructure (`frame.Decode`, TCP reader, proxy
+   forwarder, retry endpoint cache) treats the payload as opaque bytes. A new
+   frame version would cause all deployed components to reject frames
+   (`ErrBadVer`) until updated, with no structural benefit.
+4. **Version semantics** — Frame Version `0x01` → `0x02` changed the header from
+   44 to 92 bytes. A version bump should signal a header structure change, not a
+   payload format change.
 
 ### Compatibility
 
 BRC-128 frames are fully compatible with the existing multicast infrastructure:
 
-- **Proxy** — forwards BRC-128 frames verbatim, stamps HashKey and SeqNum as usual. The proxy does not inspect the payload.
-- **Listener** — decodes the BRC-124 header, applies shard and subtree filters, tracks gaps via SeqNum per flow. Payload format is irrelevant to these operations.
-- **Retry endpoint** — caches and retransmits BRC-128 frames identically to BRC-124 frames. The cache indexes by `(HashKey, SeqNum)`, not payload content.
-- **Downstream consumers** — applications that receive forwarded frames inspect payload bytes 4–9 to determine whether to parse as BRC-12 raw or BRC-30 EF.
+- **Proxy** — forwards BRC-128 frames verbatim, stamps HashKey and SeqNum as
+  usual. The proxy does not inspect the payload.
+- **Listener** — decodes the BRC-124 header, applies shard and subtree filters,
+  tracks gaps via SeqNum per flow. Payload format is irrelevant to these
+  operations.
+- **Retry endpoint** — caches and retransmits BRC-128 frames identically to
+  BRC-124 frames. The cache indexes by `(HashKey, SeqNum)`, not payload content.
+- **Downstream consumers** — applications that receive forwarded frames inspect
+  payload bytes 4–9 to determine whether to parse as BRC-12 raw or BRC-30 EF.
 
-BRC-124 (BRC-12 payload) and BRC-128 (BRC-30 EF payload) frames can be intermixed on the same multicast group without conflict.
+BRC-124 (BRC-12 payload) and BRC-128 (BRC-30 EF payload) frames can be
+intermixed on the same multicast group without conflict.
 
 ### TCP Transport
 
@@ -117,31 +159,20 @@ TCP transport is unchanged from BRC-124. The reader:
 1. Reads 44 bytes (sufficient for legacy header or BRC-124 header start)
 2. Inspects byte 6 (Frame Version)
    - **Version 0x01 (legacy):** header complete; read `PayLen` at bytes 40–43
-   - **Version 0x02 (BRC-124/BRC-128):** read 48 more bytes; read `PayLen` at bytes 88–91
+   - **Version 0x02 (BRC-124/BRC-128):** read 48 more bytes; read `PayLen` at
+     bytes 88–91
 3. Reads exactly `PayLen` bytes
 4. Processes the complete frame
 
-The receiver determines the payload format (BRC-12 vs BRC-30 EF) after reading the payload, not from the header.
-
-### Error Handling
-
-Error handling is identical to BRC-124:
-
-| Condition                | UDP Behavior                                | TCP Behavior      |
-| ------------------------ | ------------------------------------------- | ----------------- |
-| Bad magic                | Silent drop                                 | Connection closed |
-| Unknown frame version    | Silent drop                                 | Connection closed |
-| Payload length too large | Silent drop                                 | Connection closed |
-| Truncated datagram       | Silent drop                                 | Connection closed |
-| Invalid EF marker        | Application-level error (not a frame error) | —                 |
-
-Invalid EF payload content (e.g., malformed EF marker, truncated extended inputs) is an application-layer concern, not a frame-layer error. The frame is structurally valid regardless of payload content.
+The receiver determines the payload format (BRC-12 vs BRC-30 EF) after reading
+the payload, not from the header.
 
 ## Examples
 
 ### BRC-128 Frame Hex Dump
 
-A frame carrying a BRC-30 EF transaction. The payload begins with the 4-byte version and 6-byte EF marker:
+A frame carrying a BRC-30 EF transaction. The payload begins with the 4-byte
+version and 6-byte EF marker:
 
 ```text
 // Header (92 bytes) — identical to BRC-124
@@ -197,14 +228,13 @@ Note that the headers are byte-identical; only the payload differs.
 
 ## References
 
-- [BRC-12: Raw Transaction Format](./0012.md) — Standard transaction payload format
-- [BRC-30: Transaction Extended Format (EF)](./0030.md) — Extended Format payload used by this specification
-- [BRC-74: BSV Unified Merkle Path (BUMP) Format](./0074.md) — Merkle proof format for transaction verification
-- [BRC-119: SubTree Unified Merkle Path (STUMP) Format](./0119.md) — Defines the Subtree ID concept referenced in the frame header
-- [BRC-124: Multicast Transaction Frame Format](./0124.md) — Header format reused by this specification
-- [bitcoin-shard-common](https://github.com/lightwebinc/bitcoin-shard-common) — Reference implementation (Go)
-
-## Implementations
-
-- **Go**: [bitcoin-shard-common/frame](https://github.com/lightwebinc/bitcoin-shard-common/tree/main/frame) — `Encode()`, `Decode()`, wire constants (payload format is opaque; EF detection is application-layer)
-- **Services**: [bitcoin-shard-proxy](https://github.com/lightwebinc/bitcoin-shard-proxy), [bitcoin-shard-listener](https://github.com/lightwebinc/bitcoin-shard-listener), [bitcoin-multicast](https://github.com/lightwebinc/bitcoin-multicast) — Network multicast infrastructure (forwards BRC-128 frames without modification)
+- [BRC-12: Raw Transaction Format](./0012.md) — Standard transaction payload
+  format
+- [BRC-30: Transaction Extended Format (EF)](./0030.md) — Extended Format
+  payload used by this specification
+- [BRC-74: BSV Unified Merkle Path (BUMP) Format](./0074.md) — Merkle proof
+  format for transaction verification
+- [BRC-119: SubTree Unified Merkle Path (STUMP) Format](./0119.md) — Defines the
+  Subtree ID concept referenced in the frame header
+- [BRC-124: Multicast Transaction Frame Format](./0124.md) — Header format
+  reused by this specification

--- a/transactions/0129.md
+++ b/transactions/0129.md
@@ -237,7 +237,7 @@ how receivers join a group:
 - **Source discovery.** Receivers must learn the set of publisher sources for
   each group before issuing `(S,G)` joins:
   - **Data-plane sources** are distributed via the shard manifest protocol
-    (BRC-137), whose announcements carry the active publisher source set; a
+    (BRC-139), whose announcements carry the active publisher source set; a
     receiver unions the sources across currently-valid manifests.
   - **Control-plane groups** (beacon, manifest, subtree announcement) are joined
     against per-group bootstrap source lists configured out of band (IPv6
@@ -301,7 +301,7 @@ inter-domain distribution uses the SSM address `FF3E::B:FFFE`.
   and endpoint discovery
 - [BRC-127: Subtree Group Announcement Protocol](./0127.md) — Subtree
   announcement wire format and listener integration
-- [BRC-137: Multicast Shard Manifest Announcement Protocol](./0137.md) — distributes the
+- BRC-139: Multicast Shard Manifest Announcement Protocol — distributes the
   active publisher source set used for SSM data-plane source discovery
 - [RFC 4607: Source-Specific Multicast for IP](https://www.rfc-editor.org/rfc/rfc4607)
   — defines the `FF3x::/32` SSM address range

--- a/transactions/0129.md
+++ b/transactions/0129.md
@@ -94,7 +94,7 @@ as shard group indices.
 
 The group index for a transaction is derived deterministically from its TxID:
 
-```
+```text
 groupIndex = binary.BigEndian.Uint32(txid[0:4]) >> (32 - shardBits)
 ```
 
@@ -139,7 +139,7 @@ The 16-bit IANA group-id field (bytes `[12:14]`) is configurable via the
 `-mc-group-id` flag (environment variable `MC_GROUP_ID`). The default is
 `0x000B` (IANA Bitcoin allocation).
 
-```
+```text
 -mc-group-id 0x000B    # default (IANA Bitcoin)
 -mc-group-id 0xCAFE    # private deployment / lab
 ```

--- a/transactions/0129.md
+++ b/transactions/0129.md
@@ -130,7 +130,7 @@ scopes indicated; additional scopes are permitted where operationally necessary.
 | `0xFFFD` | Beacon (site)                        | `FF05` | `FF05:0000:0000:0000:0000:0000:000B:FFFD`         | `FF05::B:FFFD`            |
 | `0xFFFD` | Beacon (org)                         | `FF08` | `FF08:0000:0000:0000:0000:0000:000B:FFFD`         | `FF08::B:FFFD`            |
 | `0xFFFD` | Beacon (global)                      | `FF0E` | `FF0E:0000:0000:0000:0000:0000:000B:FFFD`         | `FF0E::B:FFFD`            |
-| `0xFFFE` | Block Control channel                | `FF0E` | `FF0E:0000:0000:0000:0000:0000:000B:FFFE`         | `FF0E::B:FFFE`            |
+| `0xFFFE` | Block Broadcast channel              | `FF0E` | `FF0E:0000:0000:0000:0000:0000:000B:FFFE`         | `FF0E::B:FFFE`            |
 | `0xFFFF` | _(reserved)_                         | —      | reserved                                          | do not use                |
 
 ### Group-ID Override
@@ -144,9 +144,9 @@ The 16-bit IANA group-id field (bytes `[12:14]`) is configurable via the
 -mc-group-id 0xCAFE    # private deployment / lab
 ```
 
-All group addresses — both shard and control-plane — inherit the same group-id.
-Deployments using different group-ids are entirely isolated at the multicast
-layer with no protocol changes required.
+All group addresses — both shard and network-service — inherit the same
+group-id. Deployments using different group-ids are entirely isolated at the
+multicast layer with no protocol changes required.
 
 ### Beacon Groups
 
@@ -163,14 +163,13 @@ Subtree Announcement groups (`0xFFFB`) carry signed announcements of a subtree's
 transaction IDs and their ordering within the subtree's Merkle structure. The
 subtree ID is the Merkle root hash of the announced set. Listeners subscribe to
 this group to discover transaction batches for downstream filtering. The subtree
-announcement protocol is specified in
-[BRC-127](./0127.md).
+announcement protocol is specified in [BRC-127](./0127.md).
 
 ### Subtree Group Announcements
 
-Subtree Group Announcement groups (`0xFFFC`) carry announcements of new subtree
-inclusions in a logical group of subtrees. This enables listeners to discover
-related transaction groupings and configure automated filtering for
+Subtree Group Announcement groups (`0xFFFC`) carry batched announcements of new
+subtree inclusions in a logical group of subtrees. This enables listeners to
+discover related transaction groupings and configure automated filtering for
 special-interest downstream networks. Like beacon and subtree announcement
 groups, multiple scopes are supported.
 
@@ -184,7 +183,7 @@ isolation of the egress domain. BRC-135 frames MUST NOT be re-injected onto
 `FF0E::B:FFFE` to avoid feedback loops. The block header frame format is
 specified in [BRC-135](./0135.md).
 
-### Block Control Channel
+### Block Broadcast Channel
 
 `FF0E::B:FFFE` (index `0xFFFE`, global scope only) is a mandatory channel
 distributing block headers, block templates, coinbase transactions,
@@ -199,7 +198,7 @@ participants. All conformant network participants MUST join this group.
   data-plane frames
 - [BRC-119: SubTree Unified Merkle Path (STUMP) Format](./0119.md) — Subtree ID
   concept referenced by the subtree announcement groups
-- [BRC-126: NACK Retransmission Protocol](./0126.md)
-  — ADVERT beacon wire format and endpoint discovery
-- [BRC-127: Subtree Group Announcement Protocol](./0127.md)
-  — Subtree announcement wire format and listener integration
+- [BRC-126: NACK Retransmission Protocol](./0126.md) — ADVERT beacon wire format
+  and endpoint discovery
+- [BRC-127: Subtree Group Announcement Protocol](./0127.md) — Subtree
+  announcement wire format and listener integration

--- a/transactions/0129.md
+++ b/transactions/0129.md
@@ -9,7 +9,9 @@ transaction sharding pipeline. It defines how the 16-bit shard index space is
 allocated across data-plane shard groups and control-plane service groups, how
 addresses are derived from the IANA Bitcoin multicast allocation, and the
 canonical addresses for beacon discovery, subtree announcement, and the block
-control channel.
+control channel. The scheme defines addressing for both Any-Source Multicast
+(ASM, the default) and Source-Specific Multicast (SSM) transport modes, selected
+per deployment without any change to the frame, NACK, or sharding semantics.
 
 ## Copyright
 
@@ -25,7 +27,7 @@ infrastructure is deployed across multiple scopes (site-local,
 organisation-local, and global) and across independent operator networks, a
 shared addressing convention is needed so that:
 
-1. Any deployment with `shardBits ≤ 15` produces data-plane group indices that
+1. Any deployment with `shardBits ≤ 12` produces data-plane group indices that
    are orthogonal to control-plane groups.
 2. Control-plane services — beacon discovery, subtree announcements, and block
    control — use stable, well-known addresses operators can pre-configure in
@@ -33,6 +35,10 @@ shared addressing convention is needed so that:
 3. Operators running private or test networks can use an alternative group-id to
    isolate their multicast address space without modifying any other aspect of
    the protocol.
+4. Deployments can run the data plane under Source-Specific Multicast for
+   inter-domain scale — [RFC 8815](https://www.rfc-editor.org/rfc/rfc8815)
+   deprecates inter-domain ASM — using the same group-id and shard-index
+   conventions, so addresses differ only in their high-order prefix.
 
 ## Specification
 
@@ -59,14 +65,46 @@ group-id (see [Group-ID Override](#group-id-override)) for testing or private
 deployments. Deployments using different group-ids operate in entirely disjoint
 multicast address spaces.
 
+This bottom-32-bit split (group-id in bytes `[12:14]`, shard index in bytes
+`[14:16]`) is identical under both source modes defined in
+[Source Mode and Address Range](#source-mode-and-address-range); only the
+high-order prefix bytes `[0:2]` differ.
+
+### Source Mode and Address Range
+
+The fabric runs in one of two source modes. **Any-Source Multicast (ASM)** is
+the default; **Source-Specific Multicast (SSM)** is an opt-in transport mode for
+deployments that need inter-domain distribution (see
+[Source-Specific Multicast (SSM)](#source-specific-multicast-ssm)). The source
+mode selects the address range via the multicast prefix byte `[1]`, which
+encodes `flags(4 bits) | scope(4 bits)`:
+
+- **ASM** uses the well-known permanent prefix (`flags = 0`) → `FF0x`.
+- **SSM** uses the RFC 4607 SSM range `FF3x::/32` (`flags = 3`) → `FF3x`.
+
+The scope nibble (`5` site-local, `8` organisation-local, `E` global) is
+unchanged between modes. Because [RFC 8815](https://www.rfc-editor.org/rfc/rfc8815)
+deprecates inter-domain ASM, global scope is SSM-only.
+
+| Mode  | Site scope (intra-domain) | Global scope (inter-domain) |
+| ----- | ------------------------- | --------------------------- |
+| ASM   | `FF05::B:idx`             | not supported (RFC 8815)    |
+| SSM   | `FF35::B:idx`             | `FF3E::B:idx`               |
+
+The group-id (`0x000B`) and the shard-index field are preserved across modes —
+only the high 32 bits change. All addresses elsewhere in this BRC are written in
+their ASM (`FF0x`) form; under SSM, substitute the corresponding `FF3x` prefix.
+
 ### Address Derivation
 
 Every multicast group address in the BSV shard pipeline is derived from three
 components:
 
-1. **Scope prefix** (`MCPrefix`, 2 bytes) — the first two bytes of the IPv6
-   address. Common values: `FF05` (site-local), `FF08` (organisation-local),
-   `FF0E` (global).
+1. **Multicast prefix** (`MCPrefix`, 2 bytes) — the first two bytes of the IPv6
+   address, encoding `flags(4) | scope(4)`. Under ASM: `FF05` (site-local),
+   `FF08` (organisation-local), `FF0E` (global). Under SSM: `FF35`, `FF38`,
+   `FF3E` for the same scopes (see
+   [Source Mode and Address Range](#source-mode-and-address-range)).
 2. **IANA group-id** (`MCGroupID`, 2 bytes) — occupies bytes `[12:14]`. Default:
    `0x000B`.
 3. **Shard group index** (`IDX`, 2 bytes) — occupies bytes `[14:16]`.
@@ -77,13 +115,15 @@ The full 128-bit address is assembled as:
 [MCPrefix][0x00 × 10][MCGroupID][IDX]
 ```
 
-For example, with scope `FF05`, group-id `0x000B`, and shard index `0x0003`:
+For example, with prefix `FF05` (ASM site-local), group-id `0x000B`, and shard
+index `0x0003`:
 
 ```text
 FF05:0000:0000:0000:0000:0000:000B:0003
 ```
 
-Compressed form: `FF05::B:3`
+Compressed form: `FF05::B:3`. The same group under SSM site-local is `FF35::B:3`
+and under SSM global is `FF3E::B:3` — only the prefix changes.
 
 ### Data-Plane Shard Groups
 
@@ -133,6 +173,12 @@ scopes indicated; additional scopes are permitted where operationally necessary.
 | `0xFFFE` | Block Broadcast channel              | `FF0E` | `FF0E:0000:0000:0000:0000:0000:000B:FFFE`         | `FF0E::B:FFFE`            |
 | `0xFFFF` | _(reserved)_                         | —      | reserved                                          | do not use                |
 
+The addresses above are shown in their ASM (`FF0x`) form. Under SSM, substitute
+the `FF3x` prefix for the same scope (`FF35` site, `FF3E` global) — the group-id
+and index are unchanged. For example, the beacon group becomes `FF35::B:FFFD`
+(site) or `FF3E::B:FFFD` (global). See
+[Source-Specific Multicast (SSM)](#source-specific-multicast-ssm).
+
 ### Virtual HashKey Ingredient Indices
 
 Several control-plane frame types share `GroupBlockBroadcast` (`0xFFFE`) as
@@ -169,6 +215,34 @@ The 16-bit IANA group-id field (bytes `[12:14]`) is configurable via the
 All group addresses — both shard and network-service — inherit the same
 group-id. Deployments using different group-ids are entirely isolated at the
 multicast layer with no protocol changes required.
+
+### Source-Specific Multicast (SSM)
+
+SSM is a transport mode only: the frame format ([BRC-124](./0124.md)), the NACK
+protocol ([BRC-126](./0126.md)), the `HashKey` computation, and the shard
+derivation are all unchanged. SSM affects only the address range (the high 32
+bits, per [Source Mode and Address Range](#source-mode-and-address-range)) and
+how receivers join a group:
+
+- **Joins.** Under ASM, receivers perform an any-source `(*,G)` join. Under SSM,
+  receivers perform a source-specific `(S,G)` join per
+  [RFC 3678](https://www.rfc-editor.org/rfc/rfc3678) (`MCAST_JOIN_SOURCE_GROUP`),
+  one join per `(source, group)` pair.
+- **Distinct source per publisher.** Each publisher MUST emit from a distinct,
+  stable unicast source address (`bindSource`). This is required by PIM-SSM
+  reverse-path forwarding and preserves the per-publisher `HashKey` flow
+  identity. Anycast or shared-source emission is not supported under SSM; a
+  deployment needing a single stable identity SHOULD use VRRP active-standby
+  (failover, not load distribution).
+- **Source discovery.** Receivers must learn the set of publisher sources for
+  each group before issuing `(S,G)` joins:
+  - **Data-plane sources** are distributed via the shard manifest protocol
+    (BRC-137), whose announcements carry the active publisher source set; a
+    receiver unions the sources across currently-valid manifests.
+  - **Control-plane groups** (beacon, manifest, subtree announcement) are joined
+    against per-group bootstrap source lists configured out of band (IPv6
+    literals or DNS names re-resolved on refresh), since their sources cannot be
+    discovered from within the group itself.
 
 ### Beacon Groups
 
@@ -207,10 +281,13 @@ specified in [BRC-135](./0135.md).
 
 ### Block Broadcast Channel
 
-`FF0E::B:FFFE` (index `0xFFFE`, global scope only) is a mandatory channel
-distributing block headers, block templates, coinbase transactions,
-chained-transaction anchors, and other producer data of interest to all network
-participants. All conformant network participants MUST join this group.
+Index `0xFFFE` (global scope) is a mandatory channel distributing block headers,
+block templates, coinbase transactions, chained-transaction anchors, and other
+producer data of interest to all network participants. All conformant network
+participants MUST join this group. The concrete address depends on the source
+mode: under ASM the channel is `FF0E::B:FFFE` and is intra-domain only (inter-
+domain ASM is deprecated by [RFC 8815](https://www.rfc-editor.org/rfc/rfc8815));
+inter-domain distribution uses the SSM address `FF3E::B:FFFE`.
 
 ## References
 
@@ -224,3 +301,11 @@ participants. All conformant network participants MUST join this group.
   and endpoint discovery
 - [BRC-127: Subtree Group Announcement Protocol](./0127.md) — Subtree
   announcement wire format and listener integration
+- [BRC-137: Multicast Shard Manifest Announcement Protocol](./0137.md) — distributes the
+  active publisher source set used for SSM data-plane source discovery
+- [RFC 4607: Source-Specific Multicast for IP](https://www.rfc-editor.org/rfc/rfc4607)
+  — defines the `FF3x::/32` SSM address range
+- [RFC 3678: Socket Interface Extensions for Multicast Source Filters](https://www.rfc-editor.org/rfc/rfc3678)
+  — `MCAST_JOIN_SOURCE_GROUP` `(S,G)` join API
+- [RFC 8815: Deprecating Any-Source Multicast (ASM) for Interdomain Multicast](https://www.rfc-editor.org/rfc/rfc8815)
+  — rationale for SSM-only global scope

--- a/transactions/0129.md
+++ b/transactions/0129.md
@@ -133,6 +133,28 @@ scopes indicated; additional scopes are permitted where operationally necessary.
 | `0xFFFE` | Block Broadcast channel              | `FF0E` | `FF0E:0000:0000:0000:0000:0000:000B:FFFE`         | `FF0E::B:FFFE`            |
 | `0xFFFF` | _(reserved)_                         | —      | reserved                                          | do not use                |
 
+### Virtual HashKey Ingredient Indices
+
+Several control-plane frame types share `GroupBlockBroadcast` (`0xFFFE`) as
+their egress multicast destination but must form independent per-sender flows so
+each carries its own monotonic `SeqNum` counter. The proxy's flow key is
+`(senderIPv6, groupIdx, subtreeID)`; to keep these flows separate while still
+emitting to the same multicast group, the proxy substitutes a distinct virtual
+`groupIdx` into the `HashKey` computation defined in [BRC-124](./0124.md). These
+virtual indices are **never** assembled into an actual IPv6 multicast address
+and MUST NOT be joined or transmitted to; they exist only as inputs to the XXH64
+`HashKey` derivation.
+
+| Virtual index | Constant            | Used by             | Egress group |
+| ------------- | ------------------- | ------------------- | ------------ |
+| `0xFFF8`      | `GroupCoinbaseFlow` | BRC-133 coinbase tx | `0xFFFE`     |
+| `0xFFF9`      | `GroupAnchorFlow`   | BRC-134 anchor tx   | `0xFFFE`     |
+
+BRC-131 block announcements continue to use `0xFFFE` itself as the `HashKey`
+ingredient, so coinbase ([BRC-133](./0133.md)) and anchor ([BRC-134](./0134.md))
+frames remain distinct flows from block announcements even though all three
+egress to `FF0E::B:FFFE`.
+
 ### Group-ID Override
 
 The 16-bit IANA group-id field (bytes `[12:14]`) is configurable via the

--- a/transactions/0129.md
+++ b/transactions/0129.md
@@ -4,7 +4,12 @@ Jeff Harris (jeff@lightweb.net)
 
 ## Abstract
 
-This BRC specifies the IPv6 multicast group address scheme for the BSV transaction sharding pipeline. It defines how the 16-bit shard index space is allocated across data-plane shard groups and control-plane service groups, how addresses are derived from the IANA Bitcoin multicast allocation, and the canonical addresses for beacon discovery, subtree announcement, and the block control channel.
+This BRC specifies the IPv6 multicast group address scheme for the BSV
+transaction sharding pipeline. It defines how the 16-bit shard index space is
+allocated across data-plane shard groups and control-plane service groups, how
+addresses are derived from the IANA Bitcoin multicast allocation, and the
+canonical addresses for beacon discovery, subtree announcement, and the block
+control channel.
 
 ## Copyright
 
@@ -12,19 +17,33 @@ This BRC is licensed under the Open BSV License.
 
 ## Motivation
 
-[BRC-82](../peer-to-peer/0082.md) details a design for a scalable IPv6 multicast protocol for BSV transaction distribution. [BRC-124](./0124.md) defines a multicast transmission wire frame format. Both reference a set of multicast group addresses without specifying a canonical address scheme. As the multicast infrastructure is deployed across multiple scopes (site-local, organisation-local, and global) and across independent operator networks, a shared addressing convention is needed so that:
+[BRC-82](../peer-to-peer/0082.md) details a design for a scalable IPv6 multicast
+protocol for BSV transaction distribution. [BRC-124](./0124.md) defines a
+multicast transmission wire frame format. Both reference a set of multicast
+group addresses without specifying a canonical address scheme. As the multicast
+infrastructure is deployed across multiple scopes (site-local,
+organisation-local, and global) and across independent operator networks, a
+shared addressing convention is needed so that:
 
-1. Any deployment with `shardBits ≤ 15` produces data-plane group indices that are orthogonal to control-plane groups.
-2. Control-plane services — beacon discovery, subtree announcements, and block control — use stable, well-known addresses operators can pre-configure in firewalls and routing policy.
-3. Operators running private or test networks can use an alternative group-id to isolate their multicast address space without modifying any other aspect of the protocol.
+1. Any deployment with `shardBits ≤ 15` produces data-plane group indices that
+   are orthogonal to control-plane groups.
+2. Control-plane services — beacon discovery, subtree announcements, and block
+   control — use stable, well-known addresses operators can pre-configure in
+   firewalls and routing policy.
+3. Operators running private or test networks can use an alternative group-id to
+   isolate their multicast address space without modifying any other aspect of
+   the protocol.
 
 ## Specification
 
 ### IANA Allocation
 
-IANA allocates IPv6 multicast group addresses on the **96-bit boundary**: the top 96 bits (bytes `[0:12]`) identify the IANA-assigned group, leaving the bottom 32 bits (bytes `[12:16]`) for sub-allocation by the assignee.
+IANA allocates IPv6 multicast group addresses on the **96-bit boundary**: the
+top 96 bits (bytes `[0:12]`) identify the IANA-assigned group, leaving the
+bottom 32 bits (bytes `[12:16]`) for sub-allocation by the assignee.
 
-The IANA Bitcoin multicast allocation is `FF0X::B` (group-id `0x000B`). This BRC splits the bottom 32 bits of that allocation into two 16-bit subfields:
+The IANA Bitcoin multicast allocation is `FF0X::B` (group-id `0x000B`). This BRC
+splits the bottom 32 bits of that allocation into two 16-bit subfields:
 
 - **Bytes `[12:14]`** — IANA group-id (default `0x000B`)
 - **Bytes `[14:16]`** — shard index (16-bit, application-assigned)
@@ -35,14 +54,21 @@ Byte:   0  1    2  3  4  5  6  7  8  9 10 11   12 13   14 15
         FF 05    00 00 00 00 00 00 00 00 00 00         00 0B  XX XX
 ```
 
-Conformant deployments MUST use group-id `0x000B`. Operators MAY override the group-id (see [Group-ID Override](#group-id-override)) for testing or private deployments. Deployments using different group-ids operate in entirely disjoint multicast address spaces.
+Conformant deployments MUST use group-id `0x000B`. Operators MAY override the
+group-id (see [Group-ID Override](#group-id-override)) for testing or private
+deployments. Deployments using different group-ids operate in entirely disjoint
+multicast address spaces.
 
 ### Address Derivation
 
-Every multicast group address in the BSV shard pipeline is derived from three components:
+Every multicast group address in the BSV shard pipeline is derived from three
+components:
 
-1. **Scope prefix** (`MCPrefix`, 2 bytes) — the first two bytes of the IPv6 address. Common values: `FF05` (site-local), `FF08` (organisation-local), `FF0E` (global).
-2. **IANA group-id** (`MCGroupID`, 2 bytes) — occupies bytes `[12:14]`. Default: `0x000B`.
+1. **Scope prefix** (`MCPrefix`, 2 bytes) — the first two bytes of the IPv6
+   address. Common values: `FF05` (site-local), `FF08` (organisation-local),
+   `FF0E` (global).
+2. **IANA group-id** (`MCGroupID`, 2 bytes) — occupies bytes `[12:14]`. Default:
+   `0x000B`.
 3. **Shard group index** (`IDX`, 2 bytes) — occupies bytes `[14:16]`.
 
 The full 128-bit address is assembled as:
@@ -61,7 +87,10 @@ Compressed form: `FF05::B:3`
 
 ### Data-Plane Shard Groups
 
-Shard group indices MUST occupy the range `0x0000`–`0x0FFF` (4,096 indices). The maximum permitted value is `shardBits = 12` (4,096 groups), which keeps all shard indices within this range. Indices at or above `0x1000` MUST NOT be used as shard group indices.
+Shard group indices MUST occupy the range `0x0000`–`0x0FFF` (4,096 indices). The
+maximum permitted value is `shardBits = 12` (4,096 groups), which keeps all
+shard indices within this range. Indices at or above `0x1000` MUST NOT be used
+as shard group indices.
 
 The group index for a transaction is derived deterministically from its TxID:
 
@@ -69,66 +98,108 @@ The group index for a transaction is derived deterministically from its TxID:
 groupIndex = binary.BigEndian.Uint32(txid[0:4]) >> (32 - shardBits)
 ```
 
-Implementations MUST use only the low 16 bits of `groupIndex` when assembling the multicast address.
+Implementations MUST use only the low 16 bits of `groupIndex` when assembling
+the multicast address.
 
 ### Free Space and Specialty Transmission Domains
 
-Indices `0x1000`–`0xF7FF` (56,832 indices) are unassigned and reserved for future use. This range accommodates future expansion of the shard group space, as well as specialty transmission domains for purpose-specific multicast services that are not general-purpose transaction sharding. No current protocol assigns addresses in this range. Implementations MUST NOT join or transmit to addresses in this range unless explicitly specified by a future BRC.
+Indices `0x1000`–`0xF7FF` (56,832 indices) are unassigned and reserved for
+future use. This range accommodates future expansion of the shard group space,
+as well as specialty transmission domains for purpose-specific multicast
+services that are not general-purpose transaction sharding. No current protocol
+assigns addresses in this range. Implementations MUST NOT join or transmit to
+addresses in this range unless explicitly specified by a future BRC.
 
 ### Control-Plane Reserved Indices
 
-Network service groups occupy `0xF800`–`0xFFFF` (2,048 indices). Current protocol assignments are allocated from the top of this range; the remainder is reserved for future network services. Implementations MUST NOT use unassigned indices within this range. The defined assignments MUST be supported at the scopes indicated; additional scopes are permitted where operationally necessary.
+Network service groups occupy `0xF800`–`0xFFFF` (2,048 indices). Current
+protocol assignments are allocated from the top of this range; the remainder is
+reserved for future network services. Implementations MUST NOT use unassigned
+indices within this range. The defined assignments MUST be supported at the
+scopes indicated; additional scopes are permitted where operationally necessary.
 
-| Index    | Purpose                              | Scope    | Full address (default group-id)                     | Compressed       |
-| -------- | ------------------------------------ | -------- | --------------------------------------------------- | ---------------- |
-| `0xFFFB` | Subtree Announcements (site)         | `FF05`   | `FF05:0000:0000:0000:0000:0000:000B:FFFB`           | `FF05::B:FFFB`   |
-| `0xFFFB` | Subtree Announcements (org)          | `FF08`   | `FF08:0000:0000:0000:0000:0000:000B:FFFB`           | `FF08::B:FFFB`   |
-| `0xFFFB` | Subtree Announcements (global)       | `FF0E`   | `FF0E:0000:0000:0000:0000:0000:000B:FFFB`           | `FF0E::B:FFFB`   |
-| `0xFFFC` | Subtree Group Announcements (site)   | `FF05`   | `FF05:0000:0000:0000:0000:0000:000B:FFFC`           | `FF05::B:FFFC`   |
-| `0xFFFC` | Subtree Group Announcements (org)    | `FF08`   | `FF08:0000:0000:0000:0000:0000:000B:FFFC`           | `FF08::B:FFFC`   |
-| `0xFFFC` | Subtree Group Announcements (global) | `FF0E`   | `FF0E:0000:0000:0000:0000:0000:000B:FFFC`           | `FF0E::B:FFFC`   |
-| `0xFFFD` | Beacon (site)                        | `FF05`   | `FF05:0000:0000:0000:0000:0000:000B:FFFD`           | `FF05::B:FFFD`   |
-| `0xFFFD` | Beacon (org)                         | `FF08`   | `FF08:0000:0000:0000:0000:0000:000B:FFFD`           | `FF08::B:FFFD`   |
-| `0xFFFD` | Beacon (global)                      | `FF0E`   | `FF0E:0000:0000:0000:0000:0000:000B:FFFD`           | `FF0E::B:FFFD`   |
-| `0xFFFE` | Block Control channel                | `FF0E`   | `FF0E:0000:0000:0000:0000:0000:000B:FFFE`           | `FF0E::B:FFFE`   |
-| `0xFFFF` | _(reserved)_                         | —        | reserved                                            | do not use       |
+| Index    | Purpose                              | Scope  | Full address (default group-id)                   | Compressed                |
+| -------- | ------------------------------------ | ------ | ------------------------------------------------- | ------------------------- |
+| `0xFFFA` | Block Header egress (BRC-135)        | varies | `FF05:0000:0000:0000:0000:0000:<egress-gid>:FFFA` | `FF05::<egress-gid>:FFFA` |
+| `0xFFFB` | Subtree Announcements (site)         | `FF05` | `FF05:0000:0000:0000:0000:0000:000B:FFFB`         | `FF05::B:FFFB`            |
+| `0xFFFB` | Subtree Announcements (org)          | `FF08` | `FF08:0000:0000:0000:0000:0000:000B:FFFB`         | `FF08::B:FFFB`            |
+| `0xFFFB` | Subtree Announcements (global)       | `FF0E` | `FF0E:0000:0000:0000:0000:0000:000B:FFFB`         | `FF0E::B:FFFB`            |
+| `0xFFFC` | Subtree Group Announcements (site)   | `FF05` | `FF05:0000:0000:0000:0000:0000:000B:FFFC`         | `FF05::B:FFFC`            |
+| `0xFFFC` | Subtree Group Announcements (org)    | `FF08` | `FF08:0000:0000:0000:0000:0000:000B:FFFC`         | `FF08::B:FFFC`            |
+| `0xFFFC` | Subtree Group Announcements (global) | `FF0E` | `FF0E:0000:0000:0000:0000:0000:000B:FFFC`         | `FF0E::B:FFFC`            |
+| `0xFFFD` | Beacon (site)                        | `FF05` | `FF05:0000:0000:0000:0000:0000:000B:FFFD`         | `FF05::B:FFFD`            |
+| `0xFFFD` | Beacon (org)                         | `FF08` | `FF08:0000:0000:0000:0000:0000:000B:FFFD`         | `FF08::B:FFFD`            |
+| `0xFFFD` | Beacon (global)                      | `FF0E` | `FF0E:0000:0000:0000:0000:0000:000B:FFFD`         | `FF0E::B:FFFD`            |
+| `0xFFFE` | Block Control channel                | `FF0E` | `FF0E:0000:0000:0000:0000:0000:000B:FFFE`         | `FF0E::B:FFFE`            |
+| `0xFFFF` | _(reserved)_                         | —      | reserved                                          | do not use                |
 
 ### Group-ID Override
 
-The 16-bit IANA group-id field (bytes `[12:14]`) is configurable via the `-mc-group-id` flag (environment variable `MC_GROUP_ID`). The default is `0x000B` (IANA Bitcoin allocation).
+The 16-bit IANA group-id field (bytes `[12:14]`) is configurable via the
+`-mc-group-id` flag (environment variable `MC_GROUP_ID`). The default is
+`0x000B` (IANA Bitcoin allocation).
 
 ```
 -mc-group-id 0x000B    # default (IANA Bitcoin)
 -mc-group-id 0xCAFE    # private deployment / lab
 ```
 
-All group addresses — both shard and control-plane — inherit the same group-id. Deployments using different group-ids are entirely isolated at the multicast layer with no protocol changes required.
+All group addresses — both shard and control-plane — inherit the same group-id.
+Deployments using different group-ids are entirely isolated at the multicast
+layer with no protocol changes required.
 
 ### Beacon Groups
 
-Beacon groups (`0xFFFD`) carry ADVERT messages that enable listeners to discover retry endpoint addresses without manual configuration. Each beacon-enabled service instance advertises to exactly one scope group, selected via `-beacon-scope`. Deployments requiring coverage across multiple scopes run separate service instances per scope. The beacon protocol is specified in [BRC-126](https://github.com/lightwebinc/bitcoin-multicast/blob/main/docs/brc-126-retransmission-protocol.md).
+Beacon groups (`0xFFFD`) carry ADVERT messages that enable listeners to discover
+retry endpoint addresses without manual configuration. Each beacon-enabled
+service instance advertises to exactly one scope group, selected via
+`-beacon-scope`. Deployments requiring coverage across multiple scopes run
+separate service instances per scope. The beacon protocol is specified in
+[BRC-126](./0126.md).
 
 ### Subtree Announcements
 
-Subtree Announcement groups (`0xFFFB`) carry signed announcements of a subtree's transaction IDs and their ordering within the subtree's Merkle structure. The subtree ID is the Merkle root hash of the announced set. Listeners subscribe to this group to discover transaction batches for downstream filtering. The subtree announcement protocol is specified in [BRC-127](https://github.com/lightwebinc/bitcoin-multicast/blob/main/docs/brc-127-subtree-announce.md).
+Subtree Announcement groups (`0xFFFB`) carry signed announcements of a subtree's
+transaction IDs and their ordering within the subtree's Merkle structure. The
+subtree ID is the Merkle root hash of the announced set. Listeners subscribe to
+this group to discover transaction batches for downstream filtering. The subtree
+announcement protocol is specified in
+[BRC-127](./0127.md).
 
 ### Subtree Group Announcements
 
-Subtree Group Announcement groups (`0xFFFC`) carry announcements of new subtree inclusions in a logical group of subtrees. This enables listeners to discover related transaction groupings and configure automated filtering for special-interest downstream networks. Like beacon and subtree announcement groups, multiple scopes are supported.
+Subtree Group Announcement groups (`0xFFFC`) carry announcements of new subtree
+inclusions in a logical group of subtrees. This enables listeners to discover
+related transaction groupings and configure automated filtering for
+special-interest downstream networks. Like beacon and subtree announcement
+groups, multiple scopes are supported.
+
+### Block Header Egress Channel
+
+`FF05::<egress-gid>:FFFA` (index `0xFFFA`) is used by listener nodes to re-emit
+standalone BRC-135 block header frames to downstream consumers such as SPV
+wallets and header-chain validators. The scope and group-id are configured
+independently of the ingress fabric via the listener's egress flags, allowing
+isolation of the egress domain. BRC-135 frames MUST NOT be re-injected onto
+`FF0E::B:FFFE` to avoid feedback loops. The block header frame format is
+specified in [BRC-135](./0135.md).
 
 ### Block Control Channel
 
-`FF0E::B:FFFE` (index `0xFFFE`, global scope only) is a mandatory channel distributing block headers, block templates, coinbase transactions, chained-transaction anchors, and other producer data of interest to all network participants. All conformant network participants MUST join this group.
+`FF0E::B:FFFE` (index `0xFFFE`, global scope only) is a mandatory channel
+distributing block headers, block templates, coinbase transactions,
+chained-transaction anchors, and other producer data of interest to all network
+participants. All conformant network participants MUST join this group.
 
 ## References
 
-- [BRC-82: Defining a Scalable IPv6 Multicast Protocol for Blockchain Transaction Broadcast and Update Delivery](../peer-to-peer/0082.md) — Overall multicast protocol architecture
-- [BRC-124: Multicast Transaction Frame Format](./0124.md) — Wire format for data-plane frames
-- [BRC-119: SubTree Unified Merkle Path (STUMP) Format](./0119.md) — Subtree ID concept referenced by the subtree announcement groups
-- [BRC-126: NACK Retransmission Protocol](https://github.com/lightwebinc/bitcoin-multicast/blob/main/docs/brc-126-retransmission-protocol.md) — ADVERT beacon wire format and endpoint discovery
-- [BRC-127: Subtree Group Announcement Protocol](https://github.com/lightwebinc/bitcoin-multicast/blob/main/docs/brc-127-subtree-announce.md) — Subtree announcement wire format and listener integration
-
-## Implementations
-
-- **Go**: [bitcoin-shard-common/shard](https://github.com/lightwebinc/bitcoin-shard-common/tree/main/shard) — `Engine.Addr(groupIndex, port)` (data-plane addresses), `ControlGroupAddr(scopePrefix, groupID, index)` (control-plane addresses), `DefaultGroupID = 0x000B`, constants `CtrlGroupSubtreeAnnounce`, `CtrlGroupSubtreeGroupAnnounce`, `CtrlGroupBeacon`, `CtrlGroupControl`
-- **Services**: [bitcoin-shard-proxy](https://github.com/lightwebinc/bitcoin-shard-proxy), [bitcoin-shard-listener](https://github.com/lightwebinc/bitcoin-shard-listener), [bitcoin-retry-endpoint](https://github.com/lightwebinc/bitcoin-retry-endpoint), [bitcoin-multicast](https://github.com/lightwebinc/bitcoin-multicast)
+- [BRC-82: Defining a Scalable IPv6 Multicast Protocol for Blockchain Transaction Broadcast and Update Delivery](../peer-to-peer/0082.md)
+  — Overall multicast protocol architecture
+- [BRC-124: Multicast Transaction Frame Format](./0124.md) — Wire format for
+  data-plane frames
+- [BRC-119: SubTree Unified Merkle Path (STUMP) Format](./0119.md) — Subtree ID
+  concept referenced by the subtree announcement groups
+- [BRC-126: NACK Retransmission Protocol](./0126.md)
+  — ADVERT beacon wire format and endpoint discovery
+- [BRC-127: Subtree Group Announcement Protocol](./0127.md)
+  — Subtree announcement wire format and listener integration

--- a/transactions/0129.md
+++ b/transactions/0129.md
@@ -259,7 +259,9 @@ Subtree Announcement groups (`0xFFFB`) carry signed announcements of a subtree's
 transaction IDs and their ordering within the subtree's Merkle structure. The
 subtree ID is the Merkle root hash of the announced set. Listeners subscribe to
 this group to discover transaction batches for downstream filtering. The subtree
-announcement protocol is specified in [BRC-127](./0127.md).
+data frame format carried on this group is specified in [BRC-132](./0132.md);
+the SubtreeID-to-group mapping announcements on `0xFFFC` are specified in
+[BRC-127](./0127.md).
 
 ### Subtree Group Announcements
 
@@ -299,8 +301,10 @@ inter-domain distribution uses the SSM address `FF3E::B:FFFE`.
   concept referenced by the subtree announcement groups
 - [BRC-126: NACK Retransmission Protocol](./0126.md) — ADVERT beacon wire format
   and endpoint discovery
-- [BRC-127: Subtree Group Announcement Protocol](./0127.md) — Subtree
-  announcement wire format and listener integration
+- [BRC-127: Subtree Group Announcement Frame Format](./0127.md) —
+  SubtreeID-to-group mapping announcements on `0xFFFC`
+- [BRC-132: Multicast Subtree Data Frame Format](./0132.md) — subtree data
+  frames carried on the `0xFFFB` GroupSubtreeDataAnnounce group
 - BRC-139: Multicast Shard Manifest Announcement Protocol — distributes the
   active publisher source set used for SSM data-plane source discovery
 - [RFC 4607: Source-Specific Multicast for IP](https://www.rfc-editor.org/rfc/rfc4607)

--- a/transactions/0130.md
+++ b/transactions/0130.md
@@ -45,13 +45,13 @@ A BRC-130 fragment datagram consists of a 104-byte header followed by the
 fragment data. All multi-byte integers are big-endian.
 
 | Offset | Size | Align | Field          | Description                                               |
-| ------ | ---- | ----- | -------------- | --------------------------------------------------------- | --- | -------- | --- | -------------------- |
+| ------ | ---- | ----- | -------------- | --------------------------------------------------------- |
 | 0      | 4    | —     | Network Magic  | 0xE3E1F3E8 (BSV mainnet P2P magic)                        |
 | 4      | 2    | —     | Protocol Ver   | 0x02BF (703, BSV large-block baseline)                    |
 | 6      | 1    | —     | Frame Version  | 0x03 (BRC-130 fragment)                                   |
 | 7      | 1    | —     | Reserved       | Must be 0x00                                              |
 | 8      | 32   | 8B    | Transaction ID | SHA256d(reassembled payload); same on every fragment      |
-| 40     | 8    | 8B    | HashKey        | XXH64(senderIPv6                                          |     | groupIdx |     | subtreeID); per-flow |
+| 40     | 8    | 8B    | HashKey        | XXH64(senderIPv6 ∥ groupIdx ∥ subtreeID); per-flow        |
 | 48     | 8    | 8B    | SeqNum         | Per-flow monotonic counter; independent per fragment      |
 | 56     | 32   | 8B    | Subtree ID     | 32-byte batch identifier; zeros = unset                   |
 | 88     | 4    | 8B    | PayloadLen     | Size of this fragment's data bytes (uint32 BE)            |
@@ -87,7 +87,7 @@ version byte.
 
 The 32-byte double-SHA256 hash of the complete unfragmented payload:
 
-```
+```text
 TxID = SHA256(SHA256(reassembled_payload))
 ```
 
@@ -99,7 +99,7 @@ verify `SHA256(SHA256(payload)) == TxID`.
 
 An 8-byte stable per-flow identifier, computed by the proxy as:
 
-```
+```text
 HashKey = XXH64(senderIPv6[16B] ∥ groupIdx[4B BE] ∥ subtreeID[32B])
 ```
 
@@ -160,7 +160,7 @@ Must be `0x00000000`. Reserved for future protocol extensions.
 
 The slice of the original payload bytes corresponding to this fragment:
 
-```
+```text
 fragment[i].data = payload[i * fragDataSize : (i+1) * fragDataSize]
 ```
 
@@ -171,7 +171,7 @@ The last fragment carries the remaining bytes, which may be shorter than
 
 The fragment data size (`fragDataSize`) is derived from the configured path MTU:
 
-```
+```text
 fragDataSize = pathMTU - IPv6HeaderSize - UDPHeaderSize - BRC130HeaderSize
              = pathMTU - 40 - 8 - 104
              = pathMTU - 152

--- a/transactions/0130.md
+++ b/transactions/0130.md
@@ -49,7 +49,7 @@ fragment data. All multi-byte integers are big-endian.
 | 0      | 4    | —     | Network Magic  | 0xE3E1F3E8 (BSV mainnet P2P magic)                        |
 | 4      | 2    | —     | Protocol Ver   | 0x02BF (703, BSV large-block baseline)                    |
 | 6      | 1    | —     | Frame Version  | 0x03 (BRC-130 fragment)                                   |
-| 7      | 1    | —     | Reserved       | Must be 0x00                                              |
+| 7      | 1    | —     | MsgType        | Carried-through MsgType (byte 7); 0x00 for BRC-124/128    |
 | 8      | 32   | 8B    | Transaction ID | SHA256d(reassembled payload); same on every fragment      |
 | 40     | 8    | 8B    | HashKey        | XXH64(senderIPv6 ∥ groupIdx ∥ subtreeID); per-flow        |
 | 48     | 8    | 8B    | SeqNum         | Per-flow monotonic counter; independent per fragment      |
@@ -58,13 +58,14 @@ fragment data. All multi-byte integers are big-endian.
 | 92     | 4    | 4B    | OrigPayloadLen | Total unfragmented payload length (uint32 BE)             |
 | 96     | 2    | 2B    | FragIndex      | 0-based index of this fragment (uint16 BE)                |
 | 98     | 2    | 2B    | FragTotal      | Total number of fragments in this transaction (uint16 BE) |
-| 100    | 4    | 4B    | Reserved2      | Must be 0x00000000                                        |
+| 100    | 1    | —     | OrigFrameVer   | Original FrameVer before fragmentation; 0x00 ⇒ 0x02       |
+| 101    | 3    | —     | Reserved       | Must be 0x000000                                          |
 | 104    | \*   | —     | Fragment data  | Slice of the original payload (PayloadLen bytes)          |
 
 Bytes 0–91 are **layout-identical** to a BRC-124 frame header (`FrameVer=0x03`
-excepted). Existing infrastructure that inspects the Transaction ID, HashKey,
-SeqNum, or Subtree ID fields in a BRC-124 header will read correct values from a
-BRC-130 datagram at the same offsets.
+and the byte-7 `MsgType` excepted). Existing infrastructure that inspects the
+Transaction ID, HashKey, SeqNum, or Subtree ID fields in a BRC-124 header will
+read correct values from a BRC-130 datagram at the same offsets.
 
 ### Field Definitions
 
@@ -82,6 +83,15 @@ tools to classify fragment datagrams without modification.
 `0x03` — identifies this datagram as a BRC-130 fragment. Infrastructure that
 does not implement BRC-130 reassembly must silently discard datagrams with this
 version byte.
+
+#### MsgType (byte 7)
+
+The frame-type `MsgType` carried through from byte 7 of the original
+(pre-fragmentation) frame, so reassembly can reconstruct it. For fragmented
+BRC-124/128 transaction frames this byte is `0x00` (their byte 7 is reserved);
+for fragmented BRC-131 block frames it is `0x01`/`0x02` and for BRC-132 subtree
+frames `0x01`/`0x02`. Together with `OrigFrameVer` (byte 100) it fully restores
+the original header bytes 6–7 on reassembly.
 
 #### Transaction ID (bytes 8–39)
 
@@ -152,9 +162,16 @@ of the same transaction carry the same `FragTotal` value. Must be ≥ 1.
 `FragTotal = 1` is valid and means the payload was not split (degenerate case,
 used only for testing).
 
-#### Reserved2 (bytes 100–103)
+#### OrigFrameVer (byte 100)
 
-Must be `0x00000000`. Reserved for future protocol extensions.
+The `FrameVer` of the original frame before fragmentation (`0x02` BRC-124/128,
+`0x04` BRC-131, `0x05` BRC-132, `0x06` BRC-134). A value of `0x00` defaults to
+`0x02` (BRC-124). Listeners use it — together with the byte-7 `MsgType` — to
+reconstruct the correct synthetic frame on reassembly.
+
+#### Reserved (bytes 101–103)
+
+Must be `0x000000`. Reserved for future protocol extensions.
 
 ### Fragment Data (byte 104 onward)
 
@@ -263,12 +280,13 @@ E3E1F3E8          // Network Magic
 000007D0          // OrigPayloadLen = 2000 (0x7D0)
 0000              // FragIndex = 0
 0002              // FragTotal = 2
-00000000          // Reserved2
+00                // OrigFrameVer (0x00 = BRC-124)
+000000            // Reserved
 
 // Fragment data (1348 bytes: payload[0:1348])
 ```
 
-**Fragment 1 (760 bytes on wire):**
+**Fragment 1 (756 bytes on wire):**
 
 ```text
 // BRC-130 header (104 bytes)
@@ -280,11 +298,12 @@ E3E1F3E8
 <8B HashKey>      // Same flow HashKey
 <8B SeqNum>       // e.g. 0x0000000000000002
 <32B SubtreeID>
-000002AC          // PayloadLen = 652 (0x28C; last fragment: 2000 - 1348 = 652)
+0000028C          // PayloadLen = 652 (0x28C; last fragment: 2000 - 1348 = 652)
 000007D0          // OrigPayloadLen = 2000
 0001              // FragIndex = 1
 0002              // FragTotal = 2
-00000000          // Reserved2
+00                // OrigFrameVer (0x00 = BRC-124)
+000000            // Reserved
 
 // Fragment data (652 bytes: payload[1348:2000])
 ```

--- a/transactions/0130.md
+++ b/transactions/0130.md
@@ -4,7 +4,14 @@ Jeff Harris (jeff@lightweb.net)
 
 ## Abstract
 
-This BRC specifies a fragmentation extension to the BRC-124 Multicast Transaction Frame Format. When a BSV transaction payload exceeds the path MTU available on a multicast fabric, the proxy decomposes the payload into a sequence of fixed-size fragment datagrams. Listeners reassemble the fragments and verify the reconstructed payload against the transaction ID before forwarding. The fragment header is a strict superset of the BRC-124 header, enabling mixed-version infrastructure to identify and discard fragment frames it cannot process.
+This BRC specifies a fragmentation extension to the BRC-124 Multicast
+Transaction Frame Format. When a BSV transaction payload exceeds the path MTU
+available on a multicast fabric, the proxy decomposes the payload into a
+sequence of fixed-size fragment datagrams. Listeners reassemble the fragments
+and verify the reconstructed payload against the transaction ID before
+forwarding. The fragment header is a strict superset of the BRC-124 header,
+enabling mixed-version infrastructure to identify and discard fragment frames it
+cannot process.
 
 ## Copyright
 
@@ -12,46 +19,59 @@ This BRC is licensed under the Open BSV License.
 
 ## Motivation
 
-BSV transactions can be arbitrarily large. The 1500-byte Ethernet MTU imposes a hard limit on single-datagram UDP delivery; transactions exceeding ~1300 bytes of payload after IPv6 and UDP overhead cannot be transported in a single BRC-124 frame without IP fragmentation, which is unreliable on multicast paths and disabled by default on many fabrics.
+BSV transactions can be arbitrarily large. The 1500-byte Ethernet MTU imposes a
+hard limit on single-datagram UDP delivery; transactions exceeding ~1300 bytes
+of payload after IPv6 and UDP overhead cannot be transported in a single BRC-124
+frame without IP fragmentation, which is unreliable on multicast paths and
+disabled by default on many fabrics.
 
-Rather than rely on IP-layer fragmentation (which requires receiver kernel reassembly and breaks on many switch configurations), BRC-130 performs fragmentation at the application layer:
+Rather than rely on IP-layer fragmentation (which requires receiver kernel
+reassembly and breaks on many switch configurations), BRC-130 performs
+fragmentation at the application layer:
 
-1. The proxy slices the payload into _k_ equal-sized chunks and emits _k_ independent UDP datagrams.
-2. Each datagram carries a complete BRC-130 header that is layout-compatible with BRC-124, allowing existing firewall rules, packet classifiers, and traffic monitors to inspect the frame header fields.
-3. Listeners reassemble fragments keyed on the Transaction ID and verify the result with SHA256d before forwarding.
+1. The proxy slices the payload into _k_ equal-sized chunks and emits _k_
+   independent UDP datagrams.
+2. Each datagram carries a complete BRC-130 header that is layout-compatible
+   with BRC-124, allowing existing firewall rules, packet classifiers, and
+   traffic monitors to inspect the frame header fields.
+3. Listeners reassemble fragments keyed on the Transaction ID and verify the
+   result with SHA256d before forwarding.
 
 ## Specification
 
 ### Fragment Header Format (104 bytes)
 
-A BRC-130 fragment datagram consists of a 104-byte header followed by the fragment data. All multi-byte integers are big-endian.
+A BRC-130 fragment datagram consists of a 104-byte header followed by the
+fragment data. All multi-byte integers are big-endian.
 
-```text
-| Offset | Size | Align | Field           | Description                                           |
-|--------|------|-------|-----------------|-------------------------------------------------------|
-| 0      | 4    | —     | Network Magic   | 0xE3E1F3E8 (BSV mainnet P2P magic)                   |
-| 4      | 2    | —     | Protocol Ver    | 0x02BF (703, BSV large-block baseline)                |
-| 6      | 1    | —     | Frame Version   | 0x03 (BRC-130 fragment)                               |
-| 7      | 1    | —     | Reserved        | Must be 0x00                                          |
-| 8      | 32   | 8B    | Transaction ID  | SHA256d(reassembled payload); same on every fragment  |
-| 40     | 8    | 8B    | HashKey         | XXH64(senderIPv6 ∥ groupIdx ∥ subtreeID); per-flow   |
-| 48     | 8    | 8B    | SeqNum          | Per-flow monotonic counter; independent per fragment  |
-| 56     | 32   | 8B    | Subtree ID      | 32-byte batch identifier; zeros = unset               |
-| 88     | 4    | 8B    | PayloadLen      | Size of this fragment's data bytes (uint32 BE)        |
-| 92     | 4    | 4B    | OrigPayloadLen  | Total unfragmented payload length (uint32 BE)         |
-| 96     | 2    | 2B    | FragIndex       | 0-based index of this fragment (uint16 BE)            |
-| 98     | 2    | 2B    | FragTotal       | Total number of fragments in this transaction (uint16 BE)|
-| 100    | 4    | 4B    | Reserved2       | Must be 0x00000000                                    |
-| 104    | *    | —     | Fragment data   | Slice of the original payload (PayloadLen bytes)      |
-```
+| Offset | Size | Align | Field          | Description                                               |
+| ------ | ---- | ----- | -------------- | --------------------------------------------------------- | --- | -------- | --- | -------------------- |
+| 0      | 4    | —     | Network Magic  | 0xE3E1F3E8 (BSV mainnet P2P magic)                        |
+| 4      | 2    | —     | Protocol Ver   | 0x02BF (703, BSV large-block baseline)                    |
+| 6      | 1    | —     | Frame Version  | 0x03 (BRC-130 fragment)                                   |
+| 7      | 1    | —     | Reserved       | Must be 0x00                                              |
+| 8      | 32   | 8B    | Transaction ID | SHA256d(reassembled payload); same on every fragment      |
+| 40     | 8    | 8B    | HashKey        | XXH64(senderIPv6                                          |     | groupIdx |     | subtreeID); per-flow |
+| 48     | 8    | 8B    | SeqNum         | Per-flow monotonic counter; independent per fragment      |
+| 56     | 32   | 8B    | Subtree ID     | 32-byte batch identifier; zeros = unset                   |
+| 88     | 4    | 8B    | PayloadLen     | Size of this fragment's data bytes (uint32 BE)            |
+| 92     | 4    | 4B    | OrigPayloadLen | Total unfragmented payload length (uint32 BE)             |
+| 96     | 2    | 2B    | FragIndex      | 0-based index of this fragment (uint16 BE)                |
+| 98     | 2    | 2B    | FragTotal      | Total number of fragments in this transaction (uint16 BE) |
+| 100    | 4    | 4B    | Reserved2      | Must be 0x00000000                                        |
+| 104    | \*   | —     | Fragment data  | Slice of the original payload (PayloadLen bytes)          |
 
-Bytes 0–91 are **layout-identical** to a BRC-124 frame header (`FrameVer=0x03` excepted). Existing infrastructure that inspects the Transaction ID, HashKey, SeqNum, or Subtree ID fields in a BRC-124 header will read correct values from a BRC-130 datagram at the same offsets.
+Bytes 0–91 are **layout-identical** to a BRC-124 frame header (`FrameVer=0x03`
+excepted). Existing infrastructure that inspects the Transaction ID, HashKey,
+SeqNum, or Subtree ID fields in a BRC-124 header will read correct values from a
+BRC-130 datagram at the same offsets.
 
 ### Field Definitions
 
 #### Network Magic (bytes 0–3)
 
-`0xE3E1F3E8` — identical to BRC-124. Enables BSV firewall rules and monitoring tools to classify fragment datagrams without modification.
+`0xE3E1F3E8` — identical to BRC-124. Enables BSV firewall rules and monitoring
+tools to classify fragment datagrams without modification.
 
 #### Protocol Version (bytes 4–5)
 
@@ -59,7 +79,9 @@ Bytes 0–91 are **layout-identical** to a BRC-124 frame header (`FrameVer=0x03`
 
 #### Frame Version (byte 6)
 
-`0x03` — identifies this datagram as a BRC-130 fragment. Infrastructure that does not implement BRC-130 reassembly must silently discard datagrams with this version byte.
+`0x03` — identifies this datagram as a BRC-130 fragment. Infrastructure that
+does not implement BRC-130 reassembly must silently discard datagrams with this
+version byte.
 
 #### Transaction ID (bytes 8–39)
 
@@ -69,7 +91,9 @@ The 32-byte double-SHA256 hash of the complete unfragmented payload:
 TxID = SHA256(SHA256(reassembled_payload))
 ```
 
-The same TxID appears on every fragment of a transaction. It serves as both the reassembly key and the integrity proof: after reassembly, the listener must verify `SHA256(SHA256(payload)) == TxID`.
+The same TxID appears on every fragment of a transaction. It serves as both the
+reassembly key and the integrity proof: after reassembly, the listener must
+verify `SHA256(SHA256(payload)) == TxID`.
 
 #### HashKey (bytes 40–47)
 
@@ -79,35 +103,54 @@ An 8-byte stable per-flow identifier, computed by the proxy as:
 HashKey = XXH64(senderIPv6[16B] ∥ groupIdx[4B BE] ∥ subtreeID[32B])
 ```
 
-`XXH64` is the 64-bit xxHash algorithm (`github.com/cespare/xxhash/v2`). HashKey is the same for every BRC-124 and BRC-130 frame emitted by the same (sender, multicast-group, subtree-batch) flow. Senders set this field to 0; the proxy stamps it in-place.
+`XXH64` is the 64-bit xxHash algorithm (`github.com/cespare/xxhash/v2`). HashKey
+is the same for every BRC-124 and BRC-130 frame emitted by the same (sender,
+multicast-group, subtree-batch) flow. Senders set this field to 0; the proxy
+stamps it in-place.
 
-**Note:** For fragment datagrams, the proxy stamps an **independent** HashKey and SeqNum per fragment (i.e., each fragment is treated as a separate frame for gap-tracking purposes). This allows retransmission of individual lost fragments via the standard BRC-126 NACK mechanism without changes to the retry endpoint.
+**Note:** For fragment datagrams, the proxy stamps an **independent** HashKey
+and SeqNum per fragment (i.e., each fragment is treated as a separate frame for
+gap-tracking purposes). This allows retransmission of individual lost fragments
+via the standard BRC-126 NACK mechanism without changes to the retry endpoint.
 
 #### SeqNum (bytes 48–55)
 
-An 8-byte per-flow monotonic counter, starting at 1. The proxy increments the per-flow counter independently for each fragment datagram. Listeners detect gaps at the fragment granularity, enabling single-fragment retransmission.
+An 8-byte per-flow monotonic counter, starting at 1. The proxy increments the
+per-flow counter independently for each fragment datagram. Listeners detect gaps
+at the fragment granularity, enabling single-fragment retransmission.
 
 Senders set SeqNum to 0; the proxy stamps it before forwarding.
 
 #### Subtree ID (bytes 56–87)
 
-Identical to BRC-124. A 32-byte batch identifier shared by all transactions belonging to the same subtree (BRC-119 STUMP root). All-zero bytes indicate the field is unset.
+Identical to BRC-124. A 32-byte batch identifier shared by all transactions
+belonging to the same subtree (BRC-119 STUMP root). All-zero bytes indicate the
+field is unset.
 
 #### PayloadLen (bytes 88–91)
 
-The number of fragment data bytes carried by **this datagram** — not the total original payload length. Equals `min(fragDataSize, origPayloadLen - fragIndex * fragDataSize)` for the last fragment, and `fragDataSize` for all prior fragments.
+The number of fragment data bytes carried by **this datagram** — not the total
+original payload length. Equals
+`min(fragDataSize, origPayloadLen - fragIndex * fragDataSize)` for the last
+fragment, and `fragDataSize` for all prior fragments.
 
 #### OrigPayloadLen (bytes 92–95)
 
-The total length of the unfragmented payload in bytes. All fragments of the same transaction carry the same `OrigPayloadLen` value. Receivers use this to allocate a reassembly buffer of exactly the correct size.
+The total length of the unfragmented payload in bytes. All fragments of the same
+transaction carry the same `OrigPayloadLen` value. Receivers use this to
+allocate a reassembly buffer of exactly the correct size.
 
 #### FragIndex (bytes 96–97)
 
-The 0-based index of this fragment within the transaction. Values range from `0` to `FragTotal - 1`.
+The 0-based index of this fragment within the transaction. Values range from `0`
+to `FragTotal - 1`.
 
 #### FragTotal (bytes 98–99)
 
-The total number of fragments into which the payload was divided. All fragments of the same transaction carry the same `FragTotal` value. Must be ≥ 1. `FragTotal = 1` is valid and means the payload was not split (degenerate case, used only for testing).
+The total number of fragments into which the payload was divided. All fragments
+of the same transaction carry the same `FragTotal` value. Must be ≥ 1.
+`FragTotal = 1` is valid and means the payload was not split (degenerate case,
+used only for testing).
 
 #### Reserved2 (bytes 100–103)
 
@@ -121,7 +164,8 @@ The slice of the original payload bytes corresponding to this fragment:
 fragment[i].data = payload[i * fragDataSize : (i+1) * fragDataSize]
 ```
 
-The last fragment carries the remaining bytes, which may be shorter than `fragDataSize`.
+The last fragment carries the remaining bytes, which may be shorter than
+`fragDataSize`.
 
 ### Fragment Data Size
 
@@ -140,25 +184,40 @@ For jumbo frames (pathMTU = 9000): `fragDataSize = 8848 bytes`.
 
 A listener reassembles a fragmented transaction as follows:
 
-1. **Slot allocation.** On receipt of the first fragment for a TxID, allocate a reassembly slot containing a `OrigPayloadLen`-byte buffer, a received-fragment bitmask of `FragTotal` bits, and a TTL timer.
+1. **Slot allocation.** On receipt of the first fragment for a TxID, allocate a
+   reassembly slot containing a `OrigPayloadLen`-byte buffer, a
+   received-fragment bitmask of `FragTotal` bits, and a TTL timer.
 
-2. **Fragment placement.** Copy fragment data into the buffer at `offset = fragIndex * fragDataSize`. Mark the fragment index as received.
+2. **Fragment placement.** Copy fragment data into the buffer at
+   `offset = fragIndex * fragDataSize`. Mark the fragment index as received.
 
-3. **Completion check.** When all `FragTotal` fragment indices are marked received, proceed to verification.
+3. **Completion check.** When all `FragTotal` fragment indices are marked
+   received, proceed to verification.
 
-4. **Hash verification.** Compute `SHA256(SHA256(buffer))` and compare to the TxID. If they differ, drop the slot and increment `bsl_reassembly_hash_mismatch_total`.
+4. **Hash verification.** Compute `SHA256(SHA256(buffer))` and compare to the
+   TxID. If they differ, drop the slot and increment
+   `bsl_reassembly_hash_mismatch_total`.
 
-5. **Delivery.** Construct a synthetic BRC-124 frame (FrameVer = 0x02) carrying the reassembled payload and the TxID, HashKey, SeqNum, and SubtreeID from the first fragment received. Route the frame through the normal filter → egress → gap-tracking path.
+5. **Delivery.** Construct a synthetic BRC-124 frame (FrameVer = 0x02) carrying
+   the reassembled payload and the TxID, HashKey, SeqNum, and SubtreeID from the
+   first fragment received. Route the frame through the normal filter → egress →
+   gap-tracking path.
 
-6. **TTL eviction.** If a slot's TTL expires before all fragments arrive, discard the partial buffer and increment `bsl_reassembly_abandoned_total`. The default TTL is 10 seconds.
+6. **TTL eviction.** If a slot's TTL expires before all fragments arrive,
+   discard the partial buffer and increment `bsl_reassembly_abandoned_total`.
+   The default TTL is 10 seconds.
 
-7. **Slot limits.** A reassembly buffer implementation may enforce a maximum number of concurrent slots (default: 4096). When the limit is reached, the oldest incomplete slot is evicted to make room for the new TxID.
+7. **Slot limits.** A reassembly buffer implementation may enforce a maximum
+   number of concurrent slots (default: 4096). When the limit is reached, the
+   oldest incomplete slot is evicted to make room for the new TxID.
 
-8. **Duplicate fragments.** Duplicate fragments (same TxID + FragIndex) are silently ignored.
+8. **Duplicate fragments.** Duplicate fragments (same TxID + FragIndex) are
+   silently ignored.
 
 ### Reassembly Metrics
 
-Listeners implementing BRC-130 reassembly expose the following Prometheus counters:
+Listeners implementing BRC-130 reassembly expose the following Prometheus
+counters:
 
 | Metric                               | Description                                           |
 | ------------------------------------ | ----------------------------------------------------- |
@@ -185,7 +244,8 @@ Listeners implementing BRC-130 reassembly expose the following Prometheus counte
 
 ### Two-Fragment Transaction (1500-byte path MTU)
 
-A 2000-byte transaction payload is split into two fragments under a 1500-byte path MTU (`fragDataSize = 1348`):
+A 2000-byte transaction payload is split into two fragments under a 1500-byte
+path MTU (`fragDataSize = 1348`):
 
 **Fragment 0 (1452 bytes on wire):**
 
@@ -231,32 +291,38 @@ E3E1F3E8
 
 ## Compatibility
 
-- **BRC-12 (FrameVer 0x01) receivers:** Must discard datagrams with FrameVer 0x03.
-- **BRC-124 (FrameVer 0x02) receivers:** Must discard datagrams with FrameVer 0x03. BRC-130 fragments will not parse as valid BRC-124 frames because the `PayloadLen` field carries the fragment data size, not the full transaction length.
-- **BRC-130 receivers:** Implement the reassembly procedure above and deliver a synthetic BRC-124 frame to downstream consumers.
+- **BRC-12 (FrameVer 0x01) receivers:** Must discard datagrams with FrameVer
+  0x03.
+- **BRC-124 (FrameVer 0x02) receivers:** Must discard datagrams with FrameVer
+  0x03. BRC-130 fragments will not parse as valid BRC-124 frames because the
+  `PayloadLen` field carries the fragment data size, not the full transaction
+  length.
+- **BRC-130 receivers:** Implement the reassembly procedure above and deliver a
+  synthetic BRC-124 frame to downstream consumers.
 
-The BRC-130 header is intentionally layout-compatible with BRC-124 at bytes 0–91 so that packet classifiers, firewall rules, and monitoring tools that inspect common header fields (magic, version, TxID, HashKey, SeqNum, SubtreeID) work correctly on fragment datagrams without modification.
+The BRC-130 header is intentionally layout-compatible with BRC-124 at bytes 0–91
+so that packet classifiers, firewall rules, and monitoring tools that inspect
+common header fields (magic, version, TxID, HashKey, SeqNum, SubtreeID) work
+correctly on fragment datagrams without modification.
 
 ## References
 
-- [BRC-12: Raw Transaction Format](./0012.md) — Payload format for BSV transactions
-- [BRC-124: Multicast Transaction Frame Format](./0124.md) — Base frame format extended by this BRC
-- [BRC-119: SubTree Unified Merkle Path (STUMP) Format](./0119.md) — Defines the Subtree ID concept
-- [bitcoin-shard-common/frame](https://github.com/lightwebinc/bitcoin-shard-common/tree/main/frame) — Reference implementation (`EncodeFragment`, `DecodeFragment`, `IsFragment`)
-- [bitcoin-shard-proxy/forwarder](https://github.com/lightwebinc/bitcoin-shard-proxy/tree/main/forwarder) — Fragment sender (proxy side)
-- [bitcoin-shard-listener/reassembly](https://github.com/lightwebinc/bitcoin-shard-listener/tree/main/reassembly) — Fragment reassembly (listener side)
+- [BRC-12: Raw Transaction Format](./0012.md) — Payload format for BSV
+  transactions
+- [BRC-124: Multicast Transaction Frame Format](./0124.md) — Base frame format
+  extended by this BRC
+- [BRC-119: SubTree Unified Merkle Path (STUMP) Format](./0119.md) — Defines the
+  Subtree ID concept
 
 ## Constants Reference
 
-```text
-| Name               | Value | Hex    | Description                              |
-|--------------------|-------|--------|------------------------------------------|
-| FrameVerV3         | 3     | 0x03   | BRC-130 fragment frame version           |
-| HeaderSizeV3       | 104   | 0x68   | BRC-130 header size in bytes             |
-| IPv6HeaderSize     | 40    | 0x28   | IPv6 header overhead                     |
-| UDPHeaderSize      | 8     | 0x08   | UDP header overhead                      |
-| MinPathMTU         | 1280  | 0x500  | IPv6 minimum MTU (RFC 8200)              |
-| EthernetMTU        | 1500  | 0x5DC  | Standard Ethernet MTU                    |
-| JumboMTU           | 9000  | 0x2328 | Jumbo frame MTU                          |
-| DefaultFragDataSize| 1348  | 0x544  | fragDataSize at 1500-byte path MTU       |
-```
+| Name                | Value | Hex    | Description                        |
+| ------------------- | ----- | ------ | ---------------------------------- |
+| FrameVerV3          | 3     | 0x03   | BRC-130 fragment frame version     |
+| HeaderSizeV3        | 104   | 0x68   | BRC-130 header size in bytes       |
+| IPv6HeaderSize      | 40    | 0x28   | IPv6 header overhead               |
+| UDPHeaderSize       | 8     | 0x08   | UDP header overhead                |
+| MinPathMTU          | 1280  | 0x500  | IPv6 minimum MTU (RFC 8200)        |
+| EthernetMTU         | 1500  | 0x5DC  | Standard Ethernet MTU              |
+| JumboMTU            | 9000  | 0x2328 | Jumbo frame MTU                    |
+| DefaultFragDataSize | 1348  | 0x544  | fragDataSize at 1500-byte path MTU |

--- a/transactions/0131.md
+++ b/transactions/0131.md
@@ -4,7 +4,11 @@ Jeff Harris (jeff@lightweb.net)
 
 ## Abstract
 
-This BRC specifies the wire format for distributing block-level metadata over the IPv6 multicast fabric. A new frame version (`0x04`) reuses the BRC-124 92-byte header layout and carries either a block announcement (block header + coinbase TxID + subtree hashes) or a coinbase transaction, delivered to all subscribers via a dedicated control-plane multicast group (`FF0E::B:FFFE`).
+This BRC specifies the wire format for distributing block-level metadata over
+the IPv6 multicast fabric. A new frame version (`0x04`) reuses the BRC-124
+92-byte header layout and carries either a block announcement (block header +
+coinbase TxID + subtree hashes) or a coinbase transaction, delivered to all
+subscribers via a dedicated control-plane multicast group (`FF0E::B:FFFE`).
 
 ## Copyright
 
@@ -12,42 +16,56 @@ This BRC is licensed under the Open BSV License.
 
 ## Motivation
 
-The multicast fabric defined in BRC-124 shards transaction delivery across deterministic IPv6 multicast groups. Block events require a complementary distribution path:
+The multicast fabric defined in BRC-124 shards transaction delivery across
+deterministic IPv6 multicast groups. Block events require a complementary
+distribution path:
 
-1. **Block announcements** must reach every subscriber — miners, exchanges, and overlay services — so they can update block templates, advance chain state, and validate received transactions against the new tip.
-2. **Coinbase transactions** must be delivered to all subscribers regardless of shard assignment, since every node needs the coinbase to reconstruct the block Merkle root.
-3. Both events must carry the same sequencing and reliability guarantees (HashKey/SeqNum stamping and NACK-based retransmission) as ordinary transaction frames, so existing retry infrastructure works without modification.
+1. **Block announcements** must reach every subscriber — miners, exchanges, and
+   overlay services — so they can update block templates, advance chain state,
+   and validate received transactions against the new tip.
+2. **Coinbase transactions** must be delivered to all subscribers regardless of
+   shard assignment, since every node needs the coinbase to reconstruct the
+   block Merkle root.
+3. Both events must carry the same sequencing and reliability guarantees
+   (HashKey/SeqNum stamping and NACK-based retransmission) as ordinary
+   transaction frames, so existing retry infrastructure works without
+   modification.
 
-Defining a new `FrameVer` byte satisfies these requirements with minimal protocol surface: the BRC-124 header layout is fully preserved, the same proxy/listener/retry machinery applies, and the only routing change is substituting the shard-derived multicast group with the dedicated control group.
+Defining a new `FrameVer` byte satisfies these requirements with minimal
+protocol surface: the BRC-124 header layout is fully preserved, the same
+proxy/listener/retry machinery applies, and the only routing change is
+substituting the shard-derived multicast group with the dedicated control group.
 
 ## Specification
 
 ### Frame Header Format (92 bytes)
 
-The BRC-131 header is layout-identical to the BRC-124 header. All multi-byte integers are big-endian.
+The BRC-131 header is layout-identical to the BRC-124 header. All multi-byte
+integers are big-endian.
 
-```text
-| Offset | Size | Alignment | Field          | Description                                              |
-|--------|------|-----------|----------------|----------------------------------------------------------|
-| 0      | 4    | —         | Network Magic  | 0xE3E1F3E8 (BSV mainnet P2P magic)                       |
-| 4      | 2    | —         | Protocol Ver   | 0x02BF (703, BSV large-block baseline)                   |
-| 6      | 1    | —         | Frame Version  | 0x04 — BRC-131 block control                             |
-| 7      | 1    | —         | MsgType        | 0x01 = BlockAnnounce; 0x02 = CoinbaseTx                  |
-| 8      | 32   | 8-byte    | ContentID      | BlockHash (announce) or CoinbaseTxID (coinbase)          |
-| 40     | 8    | 8-byte    | HashKey        | XXH64(senderIPv6 ∥ 0xFFFE ∥ zeros); stamped by proxy    |
-| 48     | 8    | 8-byte    | SeqNum         | Per-sender monotonic counter; stamped by proxy           |
-| 56     | 32   | 8-byte    | Reserved32     | All zeros                                                |
-| 88     | 4    | 8-byte    | Payload Length | uint32 BE                                                |
-| 92     | *    | —         | Payload        | MsgType-specific (see below)                             |
-```
+| Offset | Size | Alignment | Field          | Description                                          |
+| ------ | ---- | --------- | -------------- | ---------------------------------------------------- |
+| 0      | 4    | —         | Network Magic  | 0xE3E1F3E8 (BSV mainnet P2P magic)                   |
+| 4      | 2    | —         | Protocol Ver   | 0x02BF (703, BSV large-block baseline)               |
+| 6      | 1    | —         | Frame Version  | 0x04 — BRC-131 block control                         |
+| 7      | 1    | —         | MsgType        | 0x01 = BlockAnnounce; 0x02 = CoinbaseTx              |
+| 8      | 32   | 8-byte    | ContentID      | BlockHash (announce) or CoinbaseTxID (coinbase)      |
+| 40     | 8    | 8-byte    | HashKey        | XXH64(senderIPv6 ∥ 0xFFFE ∥ zeros); stamped by proxy |
+| 48     | 8    | 8-byte    | SeqNum         | Per-sender monotonic counter; stamped by proxy       |
+| 56     | 32   | 8-byte    | Reserved32     | All zeros                                            |
+| 88     | 4    | 8-byte    | Payload Length | uint32 BE                                            |
+| 92     | \*   | —         | Payload        | MsgType-specific (see below)                         |
 
-**Distinction from BRC-124:** Byte 7 carries `MsgType` rather than `Reserved=0x00`. The 32 bytes at 56–87 are always zeros (no subtree ID; block frames address all subscribers).
+**Distinction from BRC-124:** Byte 7 carries `MsgType` rather than
+`Reserved=0x00`. The 32 bytes at 56–87 are always zeros (no subtree ID; block
+frames address all subscribers).
 
 ### Field Definitions
 
 #### Network Magic (bytes 0–3)
 
-The value `0xE3E1F3E8` (BSV mainnet P2P magic). Frames with incorrect magic are rejected.
+The value `0xE3E1F3E8` (BSV mainnet P2P magic). Frames with incorrect magic are
+rejected.
 
 #### Protocol Version (bytes 4–5)
 
@@ -55,36 +73,46 @@ The value `0xE3E1F3E8` (BSV mainnet P2P magic). Frames with incorrect magic are 
 
 #### Frame Version (byte 6)
 
-`0x04` for BRC-131 frames. Any other value causes the frame to be handled by a different decoder.
+`0x04` for BRC-131 frames. Any other value causes the frame to be handled by a
+different decoder.
 
 #### MsgType (byte 7)
 
 Identifies the payload type:
 
-| Value  | Constant           | Payload                                                     |
-|--------|--------------------|-------------------------------------------------------------|
-| `0x01` | `BlockMsgAnnounce` | Block header + CoinbaseTxID + subtree root hashes           |
-| `0x02` | `BlockMsgCoinbase` | Raw serialized coinbase transaction bytes                   |
+| Value  | Constant           | Payload                                           |
+| ------ | ------------------ | ------------------------------------------------- |
+| `0x01` | `BlockMsgAnnounce` | Block header + CoinbaseTxID + subtree root hashes |
+| `0x02` | `BlockMsgCoinbase` | Raw serialized coinbase transaction bytes         |
 
 Any other value is rejected.
 
 #### ContentID (bytes 8–39)
 
 A 32-byte identifier:
-- **BlockAnnounce:** the block hash in internal byte order (not reversed display order).
-- **CoinbaseTx:** SHA256d of the raw coinbase transaction bytes (the CoinbaseTxID).
+
+- **BlockAnnounce:** the block hash in internal byte order (not reversed display
+  order).
+- **CoinbaseTx:** SHA256d of the raw coinbase transaction bytes (the
+  CoinbaseTxID).
 
 #### HashKey (bytes 40–47)
 
-`uint64` big-endian. XXH64 of `(senderIPv6[16] ∥ ctrlGroupIdx[4] ∥ zeroSubtreeID[32])` where `ctrlGroupIdx = 0x0000FFFE` as a 4-byte big-endian value. Stamped in-place by the proxy if zero on arrival.
+`uint64` big-endian. XXH64 of
+`(senderIPv6[16] ∥ ctrlGroupIdx[4] ∥ zeroSubtreeID[32])` where
+`ctrlGroupIdx = 0x0000FFFE` as a 4-byte big-endian value. Stamped in-place by
+the proxy if zero on arrival.
 
 #### SeqNum (bytes 48–55)
 
-`uint64` big-endian. Monotonic per-sender counter for the `(HashKey, ctrlGroupIdx)` flow. Stamped in-place by the proxy if zero on arrival. Used by listeners and retry endpoints as the secondary cache key.
+`uint64` big-endian. Monotonic per-sender counter for the
+`(HashKey, ctrlGroupIdx)` flow. Stamped in-place by the proxy if zero on
+arrival. Used by listeners and retry endpoints as the secondary cache key.
 
 #### Reserved32 (bytes 56–87)
 
-All zero bytes. Block control frames have no subtree ID; the field is reserved for future use.
+All zero bytes. Block control frames have no subtree ID; the field is reserved
+for future use.
 
 #### Payload Length (bytes 88–91)
 
@@ -96,46 +124,58 @@ MsgType-specific (see below).
 
 ### BlockAnnounce Payload (MsgType 0x01)
 
-```text
-| Offset | Size    | Field         | Description                                        |
-|--------|---------|---------------|----------------------------------------------------|
-| 0      | 80      | BlockHeader   | Standard 80-byte BSV block header                  |
-| 80     | 32      | CoinbaseTxID  | SHA256d of the coinbase transaction (internal BO)  |
-| 112    | 4       | SubtreeCount  | Number of subtree root hashes (uint32 BE); ≥ 0     |
-| 116    | 32 × N  | SubtreeHashes | Ordered list of N subtree Merkle root hashes       |
-```
+| Offset | Size   | Field         | Description                                       |
+| ------ | ------ | ------------- | ------------------------------------------------- |
+| 0      | 80     | BlockHeader   | Standard 80-byte BSV block header                 |
+| 80     | 32     | CoinbaseTxID  | SHA256d of the coinbase transaction (internal BO) |
+| 112    | 4      | SubtreeCount  | Number of subtree root hashes (uint32 BE); ≥ 0    |
+| 116    | 32 × N | SubtreeHashes | Ordered list of N subtree Merkle root hashes      |
 
-**Minimum payload size:** 116 bytes (N = 0). **Total payload size:** 116 + 32 × N bytes.
+**Minimum payload size:** 116 bytes (N = 0). **Total payload size:** 116 + 32 ×
+N bytes.
 
-The `ContentID` in the frame header is the 32-byte block hash. The `SubtreeHashes` are the ordered Merkle roots of the sharded transaction subtrees included in this block, matching the producer's subtree enumeration. The count may be zero for empty blocks or blocks with no sharded subtrees.
+The `ContentID` in the frame header is the 32-byte block hash. The
+`SubtreeHashes` are the ordered Merkle roots of the sharded transaction subtrees
+included in this block, matching the producer's subtree enumeration. The count
+may be zero for empty blocks or blocks with no sharded subtrees.
 
 ### CoinbaseTx Payload (MsgType 0x02)
 
-The payload is the raw serialized coinbase transaction — the same encoding as a BRC-12 transaction payload (version LE32 + inputs + outputs + locktime LE32), with no additional envelope.
+The payload is the raw serialized coinbase transaction — the same encoding as a
+BRC-12 transaction payload (version LE32 + inputs + outputs + locktime LE32),
+with no additional envelope.
 
-The `ContentID` in the frame header is the SHA256d of these raw bytes (the CoinbaseTxID), identical to the `CoinbaseTxID` field in the corresponding `BlockAnnounce` frame.
+The `ContentID` in the frame header is the SHA256d of these raw bytes (the
+CoinbaseTxID), identical to the `CoinbaseTxID` field in the corresponding
+`BlockAnnounce` frame.
 
 ### Control-Plane Multicast Group
 
 BRC-131 frames are distributed exclusively on the **CtrlGroupControl** group:
 
-```text
-| Index  | Scope  | IPv6 Address    | Constant           |
-|--------|--------|-----------------|--------------------|
-| 0xFFFE | global | FF0E::B:FFFE    | CtrlGroupControl   |
-```
+| Index  | Scope  | IPv6 Address | Constant         |
+| ------ | ------ | ------------ | ---------------- |
+| 0xFFFE | global | FF0E::B:FFFE | CtrlGroupControl |
 
-The global scope (`FF0E`) ensures block announcements cross site boundaries. The group index `0xFFFE` is in the reserved control-plane range and is never used as a shard group for any `shard_bits` ≤ 15.
+The global scope (`FF0E`) ensures block announcements cross site boundaries. The
+group index `0xFFFE` is in the reserved control-plane range and is never used as
+a shard group for any `shard_bits` ≤ 15.
 
 ### Sequence Tracking and Retransmission
 
 BRC-131 frames use the same XXH64 hash-chain sequencing as BRC-124:
 
-- **HashKey** is computed as `XXH64(senderIPv6 ∥ ctrlGroupIdx ∥ zeroSubtreeID)` where `ctrlGroupIdx = 0x0000FFFE`.
-- **SeqNum** is a monotonic per-sender counter for the `(HashKey, ctrlGroupIdx)` flow.
+- **HashKey** is computed as
+  `XXH64(senderIPv6 ∥ ctrlGroupIdx ∥ zeroSubtreeID)` where
+  `ctrlGroupIdx = 0x0000FFFE`.
+- **SeqNum** is a monotonic per-sender counter for the `(HashKey, ctrlGroupIdx)`
+  flow.
 - The proxy stamps both fields in-place if `SeqNum == 0` on arrival.
-- Listeners detect gaps by comparing consecutive `SeqNum` values on the control flow and dispatch BRC-126 NACKs to retry endpoints.
-- Retry endpoints cache BRC-131 frames by `HashKey ∥ SeqNum` and retransmit to `FF0E::B:FFFE` on NACK. **The retransmit destination is the control group, not the shard group derived from ContentID.**
+- Listeners detect gaps by comparing consecutive `SeqNum` values on the control
+  flow and dispatch BRC-126 NACKs to retry endpoints.
+- Retry endpoints cache BRC-131 frames by `HashKey ∥ SeqNum` and retransmit to
+  `FF0E::B:FFFE` on NACK. **The retransmit destination is the control group, not
+  the shard group derived from ContentID.**
 
 ### TCP Transport
 
@@ -143,28 +183,33 @@ The read sequence is identical to BRC-124:
 
 1. Read 44 bytes (sufficient for legacy header or BRC-131 start).
 2. Inspect `FrameVer` at byte 6.
-   - **Version 0x04 (BRC-131):** read 48 more bytes to complete the 92-byte header; `PayLen` is at bytes 88–91.
+   - **Version 0x04 (BRC-131):** read 48 more bytes to complete the 92-byte
+     header; `PayLen` is at bytes 88–91.
 3. Read exactly `PayLen` bytes.
 4. Process the complete frame.
 
 ### Fragmentation (BRC-130 Extension)
 
-When `len(Payload) > fragDataSize`, the proxy fragments the frame using BRC-130. The `OrigFrameVer` field at byte 100 of the BRC-130 fragment header is set to `0x04`. The `MsgType` byte is preserved in the BRC-130 fragment's byte 7. Fragment gap tracking uses the `(HashKey, ctrlGroupIdx, zeroSubtreeID)` flow identically to BRC-124 fragments.
+When `len(Payload) > fragDataSize`, the proxy fragments the frame using BRC-130.
+The `OrigFrameVer` field at byte 100 of the BRC-130 fragment header is set to
+`0x04`. The `MsgType` byte is preserved in the BRC-130 fragment's byte 7.
+Fragment gap tracking uses the `(HashKey, ctrlGroupIdx, zeroSubtreeID)` flow
+identically to BRC-124 fragments.
 
-Block announcements for typical blocks fit well within a 9000-byte jumbo frame (116 + 32 × 128 = 4212 bytes for 128 subtrees). Fragmentation is primarily relevant for large `CoinbaseTx` payloads.
+Block announcements for typical blocks fit well within a 9000-byte jumbo frame
+(116 + 32 × 128 = 4212 bytes for 128 subtrees). Fragmentation is primarily
+relevant for large `CoinbaseTx` payloads.
 
 ### Error Handling
 
-```text
-| Condition                      | UDP Behavior  | TCP Behavior      |
-|--------------------------------|---------------|-------------------|
-| Bad magic                      | Silent drop   | Connection closed |
-| FrameVer ≠ 0x04                | Not BRC-131   | Not BRC-131       |
-| Unknown MsgType                | Silent drop   | Connection closed |
-| Payload length too large       | Silent drop   | Connection closed |
-| Truncated datagram             | Silent drop   | Connection closed |
-| SeqNum == 0 at listener        | Discard       | Discard           |
-```
+| Condition                | UDP Behavior | TCP Behavior      |
+| ------------------------ | ------------ | ----------------- |
+| Bad magic                | Silent drop  | Connection closed |
+| FrameVer ≠ 0x04          | Not BRC-131  | Not BRC-131       |
+| Unknown MsgType          | Silent drop  | Connection closed |
+| Payload length too large | Silent drop  | Connection closed |
+| Truncated datagram       | Silent drop  | Connection closed |
+| SeqNum == 0 at listener  | Discard      | Discard           |
 
 ## Examples
 
@@ -210,41 +255,38 @@ E3E1F3E8                                                          // Network Mag
 
 ## Alignment Verification
 
-```text
 | Field          | Offset | Offset % 8 |
-|----------------|--------|------------|
+| -------------- | ------ | ---------- |
 | ContentID      | 8      | 0 ✓        |
 | HashKey        | 40     | 0 ✓        |
 | SeqNum         | 48     | 0 ✓        |
 | Reserved32     | 56     | 0 ✓        |
 | Payload Length | 88     | 0 ✓        |
 | Payload        | 92     | 4          |
-```
 
 ## Constants Reference
 
-```text
-| Name                     | Value | Hex    | Description                                  |
-|--------------------------|-------|--------|----------------------------------------------|
-| FrameVerV4               | 4     | 0x04   | BRC-131 block control frame version          |
-| BlockMsgAnnounce         | 1     | 0x01   | MsgType: block announcement                  |
-| BlockMsgCoinbase         | 2     | 0x02   | MsgType: coinbase transaction                |
-| CtrlGroupControl         | 65534 | 0xFFFE | Control-plane group index for block frames   |
-| BlockHeaderSize          | 80    | 0x50   | Standard BSV block header size (bytes)       |
-| BlockAnnounceMinPayload  | 116   | 0x74   | Minimum BlockAnnounce payload (N=0 subtrees) |
-| HeaderSize               | 92    | 0x5C   | BRC-131 header size (identical to BRC-124)   |
-```
-
-## Implementations
-
-- **Go**: [bitcoin-shard-common/frame](https://github.com/lightwebinc/bitcoin-shard-common/tree/main/frame) — `EncodeBlock`, `DecodeBlock`, `IsBlockFrame`, `EncodeBlockAnnounce`, `DecodeBlockAnnounce`
-- **Services**: [bitcoin-shard-proxy](https://github.com/lightwebinc/bitcoin-shard-proxy), [bitcoin-shard-listener](https://github.com/lightwebinc/bitcoin-shard-listener), [bitcoin-retry-endpoint](https://github.com/lightwebinc/bitcoin-retry-endpoint) — block frame forwarding, caching, and retransmission
+| Name                    | Value | Hex    | Description                                  |
+| ----------------------- | ----- | ------ | -------------------------------------------- |
+| FrameVerV4              | 4     | 0x04   | BRC-131 block control frame version          |
+| BlockMsgAnnounce        | 1     | 0x01   | MsgType: block announcement                  |
+| BlockMsgCoinbase        | 2     | 0x02   | MsgType: coinbase transaction                |
+| CtrlGroupControl        | 65534 | 0xFFFE | Control-plane group index for block frames   |
+| BlockHeaderSize         | 80    | 0x50   | Standard BSV block header size (bytes)       |
+| BlockAnnounceMinPayload | 116   | 0x74   | Minimum BlockAnnounce payload (N=0 subtrees) |
+| HeaderSize              | 92    | 0x5C   | BRC-131 header size (identical to BRC-124)   |
 
 ## References
 
-- [BRC-12: Raw Transaction Format](../transactions/0012.md) — Coinbase payload encoding
-- [BRC-124: Multicast Transaction Frame Format](./0124.md) — Header layout reused by BRC-131
-- [BRC-126: Multicast Retransmission Protocol](./0126.md) — NACK/ACK/MISS used for block frame retransmission
-- [BRC-129: Multicast Group Address Assignments](./0129.md) — CtrlGroupControl index allocation
-- [BRC-130: Multicast Transaction Frame Fragmentation](./0130.md) — BRC-130 fragmentation with OrigFrameVer=0x04
-- [BRC-119: SubTree Unified Merkle Path (STUMP) Format](./0119.md) — Defines the subtree concept referenced in BlockAnnounce
+- [BRC-12: Raw Transaction Format](./0012.md) — Coinbase payload
+  encoding
+- [BRC-124: Multicast Transaction Frame Format](./0124.md) — Header layout
+  reused by BRC-131
+- [BRC-126: Multicast Retransmission Protocol](./0126.md) — NACK/ACK/MISS used
+  for block frame retransmission
+- [BRC-129: Multicast Group Address Assignments](./0129.md) — CtrlGroupControl
+  index allocation
+- [BRC-130: Multicast Transaction Frame Fragmentation](./0130.md) — BRC-130
+  fragmentation with OrigFrameVer=0x04
+- [BRC-119: SubTree Unified Merkle Path (STUMP) Format](./0119.md) — Defines the
+  subtree concept referenced in BlockAnnounce

--- a/transactions/0131.md
+++ b/transactions/0131.md
@@ -151,11 +151,11 @@ CoinbaseTxID), identical to the `CoinbaseTxID` field in the corresponding
 
 ### Control-Plane Multicast Group
 
-BRC-131 frames are distributed exclusively on the **CtrlGroupControl** group:
+BRC-131 frames are distributed exclusively on the **GroupBlockBroadcast** group:
 
-| Index  | Scope  | IPv6 Address | Constant         |
-| ------ | ------ | ------------ | ---------------- |
-| 0xFFFE | global | FF0E::B:FFFE | CtrlGroupControl |
+| Index  | Scope  | IPv6 Address | Constant            |
+| ------ | ------ | ------------ | ------------------- |
+| 0xFFFE | global | FF0E::B:FFFE | GroupBlockBroadcast |
 
 The global scope (`FF0E`) ensures block announcements cross site boundaries. The
 group index `0xFFFE` is in the reserved control-plane range and is never used as
@@ -165,9 +165,8 @@ a shard group for any `shard_bits` ≤ 15.
 
 BRC-131 frames use the same XXH64 hash-chain sequencing as BRC-124:
 
-- **HashKey** is computed as
-  `XXH64(senderIPv6 ∥ ctrlGroupIdx ∥ zeroSubtreeID)` where
-  `ctrlGroupIdx = 0x0000FFFE`.
+- **HashKey** is computed as `XXH64(senderIPv6 ∥ ctrlGroupIdx ∥ zeroSubtreeID)`
+  where `ctrlGroupIdx = 0x0000FFFE`.
 - **SeqNum** is a monotonic per-sender counter for the `(HashKey, ctrlGroupIdx)`
   flow.
 - The proxy stamps both fields in-place if `SeqNum == 0` on arrival.
@@ -271,21 +270,20 @@ E3E1F3E8                                                          // Network Mag
 | FrameVerV4              | 4     | 0x04   | BRC-131 block control frame version          |
 | BlockMsgAnnounce        | 1     | 0x01   | MsgType: block announcement                  |
 | BlockMsgCoinbase        | 2     | 0x02   | MsgType: coinbase transaction                |
-| CtrlGroupControl        | 65534 | 0xFFFE | Control-plane group index for block frames   |
+| GroupBlockBroadcast     | 65534 | 0xFFFE | Control-plane group index for block frames   |
 | BlockHeaderSize         | 80    | 0x50   | Standard BSV block header size (bytes)       |
 | BlockAnnounceMinPayload | 116   | 0x74   | Minimum BlockAnnounce payload (N=0 subtrees) |
 | HeaderSize              | 92    | 0x5C   | BRC-131 header size (identical to BRC-124)   |
 
 ## References
 
-- [BRC-12: Raw Transaction Format](./0012.md) — Coinbase payload
-  encoding
+- [BRC-12: Raw Transaction Format](./0012.md) — Coinbase payload encoding
 - [BRC-124: Multicast Transaction Frame Format](./0124.md) — Header layout
   reused by BRC-131
 - [BRC-126: Multicast Retransmission Protocol](./0126.md) — NACK/ACK/MISS used
   for block frame retransmission
-- [BRC-129: Multicast Group Address Assignments](./0129.md) — CtrlGroupControl
-  index allocation
+- [BRC-129: Multicast Group Address Assignments](./0129.md) —
+  GroupBlockBroadcast index allocation
 - [BRC-130: Multicast Transaction Frame Fragmentation](./0130.md) — BRC-130
   fragmentation with OrigFrameVer=0x04
 - [BRC-119: SubTree Unified Merkle Path (STUMP) Format](./0119.md) — Defines the

--- a/transactions/0131.md
+++ b/transactions/0131.md
@@ -50,7 +50,7 @@ integers are big-endian.
 | 6      | 1    | —         | Frame Version  | 0x04 — BRC-131 block control                         |
 | 7      | 1    | —         | MsgType        | 0x01 = BlockAnnounce; 0x02 = CoinbaseTx              |
 | 8      | 32   | 8-byte    | ContentID      | BlockHash (announce) or CoinbaseTxID (coinbase)      |
-| 40     | 8    | 8-byte    | HashKey        | XXH64(senderIPv6 ∥ 0xFFFE ∥ zeros); stamped by proxy |
+| 40     | 8    | 8-byte    | HashKey        | XXH64(senderIPv6 ∥ flowIdx ∥ zeros); proxy-stamped   |
 | 48     | 8    | 8-byte    | SeqNum         | Per-sender monotonic counter; stamped by proxy       |
 | 56     | 32   | 8-byte    | Reserved32     | All zeros                                            |
 | 88     | 4    | 8-byte    | Payload Length | uint32 BE                                            |
@@ -99,15 +99,22 @@ A 32-byte identifier:
 #### HashKey (bytes 40–47)
 
 `uint64` big-endian. XXH64 of
-`(senderIPv6[16] ∥ ctrlGroupIdx[4] ∥ zeroSubtreeID[32])` where
-`ctrlGroupIdx = 0x0000FFFE` as a 4-byte big-endian value. Stamped in-place by
-the proxy if zero on arrival.
+`(senderIPv6[16] ∥ flowIdx[4] ∥ zeroSubtreeID[32])` where `flowIdx` is a 4-byte
+big-endian value selected by `MsgType`, so the two payload types form
+independent flows on the shared egress group:
+
+- **BlockAnnounce** (`MsgType 0x01`): `flowIdx = 0x0000FFFE`
+  (`GroupBlockBroadcast`).
+- **CoinbaseTx** (`MsgType 0x02`): `flowIdx = 0x0000FFF8` (`GroupCoinbaseFlow`, a
+  virtual HashKey index — see [BRC-129](./0129.md) and [BRC-133](./0133.md)).
+
+Stamped in-place by the proxy if zero on arrival.
 
 #### SeqNum (bytes 48–55)
 
-`uint64` big-endian. Monotonic per-sender counter for the
-`(HashKey, ctrlGroupIdx)` flow. Stamped in-place by the proxy if zero on
-arrival. Used by listeners and retry endpoints as the secondary cache key.
+`uint64` big-endian. Monotonic per-sender counter for the `(HashKey, flowIdx)`
+flow. Stamped in-place by the proxy if zero on arrival. Used by listeners and
+retry endpoints as the secondary cache key.
 
 #### Reserved32 (bytes 56–87)
 
@@ -159,15 +166,16 @@ BRC-131 frames are distributed exclusively on the **GroupBlockBroadcast** group:
 
 The global scope (`FF0E`) ensures block announcements cross site boundaries. The
 group index `0xFFFE` is in the reserved control-plane range and is never used as
-a shard group for any `shard_bits` ≤ 15.
+a shard group for any `shard_bits` ≤ 12.
 
 ### Sequence Tracking and Retransmission
 
 BRC-131 frames use the same XXH64 hash-chain sequencing as BRC-124:
 
-- **HashKey** is computed as `XXH64(senderIPv6 ∥ ctrlGroupIdx ∥ zeroSubtreeID)`
-  where `ctrlGroupIdx = 0x0000FFFE`.
-- **SeqNum** is a monotonic per-sender counter for the `(HashKey, ctrlGroupIdx)`
+- **HashKey** is computed as `XXH64(senderIPv6 ∥ flowIdx ∥ zeroSubtreeID)` where
+  `flowIdx = 0x0000FFFE` for BlockAnnounce and `0x0000FFF8` for CoinbaseTx (see
+  the HashKey field definition).
+- **SeqNum** is a monotonic per-sender counter for the `(HashKey, flowIdx)`
   flow.
 - The proxy stamps both fields in-place if `SeqNum == 0` on arrival.
 - Listeners detect gaps by comparing consecutive `SeqNum` values on the control
@@ -192,7 +200,7 @@ The read sequence is identical to BRC-124:
 When `len(Payload) > fragDataSize`, the proxy fragments the frame using BRC-130.
 The `OrigFrameVer` field at byte 100 of the BRC-130 fragment header is set to
 `0x04`. The `MsgType` byte is preserved in the BRC-130 fragment's byte 7.
-Fragment gap tracking uses the `(HashKey, ctrlGroupIdx, zeroSubtreeID)` flow
+Fragment gap tracking uses the `(HashKey, flowIdx, zeroSubtreeID)` flow
 identically to BRC-124 fragments.
 
 Block announcements for typical blocks fit well within a 9000-byte jumbo frame
@@ -224,7 +232,7 @@ E3E1F3E8                                                          // Network Mag
 <8-byte HashKey>                                                  // Proxy-stamped XXH64
 <8-byte SeqNum>                                                   // Proxy-stamped monotonic
 0000000000000000000000000000000000000000000000000000000000000000  // Reserved32
-00000094                                                          // PayloadLen = 148 (116 + 2×16)
+000000B4                                                          // PayloadLen = 180 (116 + 2×32)
 
 // Payload (148 bytes)
 <80-byte block header>                                            // BlockHeader

--- a/transactions/0132.md
+++ b/transactions/0132.md
@@ -7,7 +7,7 @@ Jeff Harris (jeff@lightweb.net)
 This BRC defines frame version `0x05` for distributing complete Merkle subtree
 contents — transaction hashes and optional per-transaction metadata — over the
 IPv6 multicast fabric. Subtree data frames are delivered to all subscribers via
-the dedicated `CtrlGroupSubtreeAnnounce` multicast group (`FF0X::B:FFFB`),
+the dedicated `GroupSubtreeAnnounce` multicast group (`FF0X::B:FFFB`),
 independently of the per-shard groups used for individual transaction
 distribution.
 
@@ -34,17 +34,17 @@ contains.
 
 ### Multicast Group
 
-Subtree data frames are sent to the `CtrlGroupSubtreeAnnounce` group (index
+Subtree data frames are sent to the `GroupSubtreeAnnounce` group (index
 `0xFFFB`):
 
-| Index  | Scope  | Compressed Address | Constant                 |
-|--------|--------|--------------------|--------------------------|
-| 0xFFFB | site   | FF05::B:FFFB       | CtrlGroupSubtreeAnnounce |
-| 0xFFFB | org    | FF08::B:FFFB       | CtrlGroupSubtreeAnnounce |
-| 0xFFFB | global | FF0E::B:FFFB       | CtrlGroupSubtreeAnnounce |
+| Index  | Scope  | Compressed Address | Constant             |
+| ------ | ------ | ------------------ | -------------------- |
+| 0xFFFB | site   | FF05::B:FFFB       | GroupSubtreeAnnounce |
+| 0xFFFB | org    | FF08::B:FFFB       | GroupSubtreeAnnounce |
+| 0xFFFB | global | FF0E::B:FFFB       | GroupSubtreeAnnounce |
 
-Scope selection follows the `CtrlGroupBeacon` pattern defined in BRC-129.
-Operators select one or more scopes via the `-announce-scope` flag on listening
+Scope selection follows the `GroupBeacon` pattern defined in BRC-129. Operators
+select one or more scopes via the `-announce-scope` flag on listening
 components.
 
 ### Frame Header Format (92 bytes)
@@ -55,7 +55,7 @@ same offsets. The header is read using the same 44+48 two-step protocol as
 BRC-124 and BRC-131.
 
 | Offset | Size | Align | Field         | Value / Notes                                            |
-|--------|------|-------|---------------|----------------------------------------------------------|
+| ------ | ---- | ----- | ------------- | -------------------------------------------------------- |
 | 0      | 4    | —     | Network Magic | `0xE3E1F3E8` (BSV mainnet P2P magic)                     |
 | 4      | 2    | —     | Protocol Ver  | `0x02BF` (703, BSV large-block baseline)                 |
 | 6      | 1    | —     | Frame Version | `0x05` — BRC-132 subtree data                            |
@@ -65,7 +65,7 @@ BRC-124 and BRC-131.
 | 48     | 8    | 8B    | SeqNum        | Monotonic counter per (sender, SubtreeID); proxy-stamped |
 | 56     | 32   | 8B    | LayoutPad32   | All zeros; retained for uniform `HeaderSize = 92`        |
 | 88     | 4    | 8B    | PayloadLen    | Payload size in bytes (uint32 BE)                        |
-| 92     | *    | —     | Payload       | MsgType-specific subtree data (see §Payload Format)      |
+| 92     | \*   | —     | Payload       | MsgType-specific subtree data (see §Payload Format)      |
 
 **Key distinctions from BRC-124:**
 
@@ -81,7 +81,7 @@ BRC-124 and BRC-131.
 ### MsgType Values
 
 | MsgType | Constant               | Node Size | Description                             |
-|---------|------------------------|-----------|-----------------------------------------|
+| ------- | ---------------------- | --------- | --------------------------------------- |
 | `0x01`  | `SubtreeMsgHashesOnly` | 32 bytes  | TxHashes only (network transfer format) |
 | `0x02`  | `SubtreeMsgFullNodes`  | 48 bytes  | TxHash + Fee + Size per node            |
 
@@ -95,7 +95,7 @@ and a conflict set.
 #### Common Prefix (24 bytes)
 
 | Offset | Size | Field          | Description                                     |
-|--------|------|----------------|-------------------------------------------------|
+| ------ | ---- | -------------- | ----------------------------------------------- |
 | 0      | 8    | TotalFees      | Aggregate fee sum for the subtree (uint64 BE)   |
 | 8      | 8    | TotalSizeBytes | Aggregate serialised tx size (uint64 BE, bytes) |
 | 16     | 8    | NodeCount      | Number of transaction nodes (uint64 BE)         |
@@ -103,7 +103,7 @@ and a conflict set.
 #### MsgType 0x01 — HashesOnly
 
 | Offset       | Size   | Field                     |
-|--------------|--------|---------------------------|
+| ------------ | ------ | ------------------------- |
 | 24           | 32 × N | TxHashes                  |
 | 24 + 32N     | 8      | ConflictCount (uint64 BE) |
 | 24 + 32N + 8 | 32 × M | ConflictHashes            |
@@ -113,7 +113,7 @@ Maximum size at 1M nodes, 0 conflicts: 24 + 32 × 1,048,576 + 8 ≈ **32 MB**.
 #### MsgType 0x02 — FullNodes
 
 | Offset       | Size   | Field                                            |
-|--------------|--------|--------------------------------------------------|
+| ------------ | ------ | ------------------------------------------------ |
 | 24           | 48 × N | Nodes: TxHash (32B) ∥ Fee (8B BE) ∥ Size (8B BE) |
 | 24 + 48N     | 8      | ConflictCount (uint64 BE)                        |
 | 24 + 48N + 8 | 32 × M | ConflictHashes                                   |
@@ -139,7 +139,7 @@ using BRC-130:
 Fragment counts at MTU 9000 (fragDataSize = 8848 bytes):
 
 | Subtree size                  | Fragments |
-|-------------------------------|-----------|
+| ----------------------------- | --------- |
 | ~32 MB (HashesOnly, 1M nodes) | ~3,793    |
 | ~48 MB (FullNodes, 1M nodes)  | ~5,689    |
 
@@ -178,7 +178,7 @@ After reassembly, optional Merkle-root recomputation verifies the SubtreeID:
 ### Error Handling
 
 | Condition                      | Action                                         |
-|--------------------------------|------------------------------------------------|
+| ------------------------------ | ---------------------------------------------- |
 | `raw[6] != 0x05`               | Not BRC-132; handled by other decoders         |
 | Bad magic                      | Silent drop                                    |
 | Unknown MsgType                | Drop; `ErrBadSubtreeMsg`                       |
@@ -190,11 +190,11 @@ After reassembly, optional Merkle-root recomputation verifies the SubtreeID:
 ## Constants Reference
 
 | Name                           | Value | Hex      | Description                                 |
-|--------------------------------|-------|----------|---------------------------------------------|
+| ------------------------------ | ----- | -------- | ------------------------------------------- |
 | `FrameVerV5`                   | 5     | `0x05`   | BRC-132 subtree data frame version          |
 | `SubtreeMsgHashesOnly`         | 1     | `0x01`   | MsgType: TxHashes only (32B per node)       |
 | `SubtreeMsgFullNodes`          | 2     | `0x02`   | MsgType: TxHash + Fee + Size (48B per node) |
-| `CtrlGroupSubtreeAnnounce`     | 65531 | `0xFFFB` | Subtree data multicast group index          |
+| `GroupSubtreeAnnounce`         | 65531 | `0xFFFB` | Subtree data multicast group index          |
 | `HeaderSize`                   | 92    | `0x5C`   | BRC-132 header size (identical to BRC-124)  |
 | `SubtreeDataPayloadHeaderSize` | 24    | `0x18`   | Fixed metadata prefix size                  |
 | `SubtreeNodeHashSize`          | 32    | `0x20`   | Node size in HashesOnly payload             |
@@ -211,7 +211,7 @@ After reassembly, optional Merkle-root recomputation verifies the SubtreeID:
 - [BRC-127: Subtree Group Announcement](../peer-to-peer/0127.md) —
   SubtreeID→GroupID metadata; distinct from BRC-132 data delivery
 - [BRC-129: Multicast Group Address Assignments](../peer-to-peer/0129.md) —
-  Group index allocations; `0xFFFB` = CtrlGroupSubtreeAnnounce
+  Group index allocations; `0xFFFB` = GroupSubtreeAnnounce
 - [BRC-130: Multicast Frame Fragmentation](./0130.md) — Fragmentation for large
   subtree payloads; `OrigFrameVer = 0x05`
 - [BRC-131: Block Announcement Protocol](./0131.md) — `FrameVerV4` pattern

--- a/transactions/0132.md
+++ b/transactions/0132.md
@@ -7,7 +7,7 @@ Jeff Harris (jeff@lightweb.net)
 This BRC defines frame version `0x05` for distributing complete Merkle subtree
 contents — transaction hashes and optional per-transaction metadata — over the
 IPv6 multicast fabric. Subtree data frames are delivered to all subscribers via
-the dedicated `GroupSubtreeAnnounce` multicast group (`FF0X::B:FFFB`),
+the dedicated `GroupSubtreeDataAnnounce` multicast group (`FF0X::B:FFFB`),
 independently of the per-shard groups used for individual transaction
 distribution.
 
@@ -34,14 +34,14 @@ contains.
 
 ### Multicast Group
 
-Subtree data frames are sent to the `GroupSubtreeAnnounce` group (index
+Subtree data frames are sent to the `GroupSubtreeDataAnnounce` group (index
 `0xFFFB`):
 
-| Index  | Scope  | Compressed Address | Constant             |
-| ------ | ------ | ------------------ | -------------------- |
-| 0xFFFB | site   | FF05::B:FFFB       | GroupSubtreeAnnounce |
-| 0xFFFB | org    | FF08::B:FFFB       | GroupSubtreeAnnounce |
-| 0xFFFB | global | FF0E::B:FFFB       | GroupSubtreeAnnounce |
+| Index  | Scope  | Compressed Address | Constant                 |
+| ------ | ------ | ------------------ | ------------------------ |
+| 0xFFFB | site   | FF05::B:FFFB       | GroupSubtreeDataAnnounce |
+| 0xFFFB | org    | FF08::B:FFFB       | GroupSubtreeDataAnnounce |
+| 0xFFFB | global | FF0E::B:FFFB       | GroupSubtreeDataAnnounce |
 
 Scope selection follows the `GroupBeacon` pattern defined in BRC-129. Operators
 select one or more scopes via the `-announce-scope` flag on listening
@@ -194,7 +194,7 @@ After reassembly, optional Merkle-root recomputation verifies the SubtreeID:
 | `FrameVerV5`                   | 5     | `0x05`   | BRC-132 subtree data frame version          |
 | `SubtreeMsgHashesOnly`         | 1     | `0x01`   | MsgType: TxHashes only (32B per node)       |
 | `SubtreeMsgFullNodes`          | 2     | `0x02`   | MsgType: TxHash + Fee + Size (48B per node) |
-| `GroupSubtreeAnnounce`         | 65531 | `0xFFFB` | Subtree data multicast group index          |
+| `GroupSubtreeDataAnnounce`     | 65531 | `0xFFFB` | Subtree data multicast group index          |
 | `HeaderSize`                   | 92    | `0x5C`   | BRC-132 header size (identical to BRC-124)  |
 | `SubtreeDataPayloadHeaderSize` | 24    | `0x18`   | Fixed metadata prefix size                  |
 | `SubtreeNodeHashSize`          | 32    | `0x20`   | Node size in HashesOnly payload             |
@@ -206,12 +206,12 @@ After reassembly, optional Merkle-root recomputation verifies the SubtreeID:
   definition and Merkle subtree structure
 - [BRC-124: Multicast Transaction Frame Format](./0124.md) — Base header layout
   reused by BRC-132
-- [BRC-126: Multicast Retransmission Protocol](../peer-to-peer/0126.md) —
+- [BRC-126: BSV Multicast NACK Retransmission Protocol](./0126.md) —
   NACK-based reliability used for subtree frame retransmission
-- [BRC-127: Subtree Group Announcement](../peer-to-peer/0127.md) —
+- [BRC-127: Multicast Subtree Group Announcement Frame Format](./0127.md) —
   SubtreeID→GroupID metadata; distinct from BRC-132 data delivery
-- [BRC-129: Multicast Group Address Assignments](../peer-to-peer/0129.md) —
-  Group index allocations; `0xFFFB` = GroupSubtreeAnnounce
+- [BRC-129: IPv6 Multicast Group Address Assignments](./0129.md) —
+  Group index allocations; `0xFFFB` = GroupSubtreeDataAnnounce
 - [BRC-130: Multicast Frame Fragmentation](./0130.md) — Fragmentation for large
   subtree payloads; `OrigFrameVer = 0x05`
 - [BRC-131: Block Announcement Protocol](./0131.md) — `FrameVerV4` pattern

--- a/transactions/0133.md
+++ b/transactions/0133.md
@@ -4,7 +4,11 @@ Jeff Harris (jeff@lightweb.net)
 
 ## Abstract
 
-This BRC defines the policy and wire mechanism for distributing coinbase transactions over the IPv6 multicast fabric. Coinbase transactions are carried as a dedicated message type within BRC-131 block control frames and delivered to all subscribers via the control-plane multicast group, independently of the shard groups used for ordinary transaction distribution.
+This BRC defines the policy and wire mechanism for distributing coinbase
+transactions over the IPv6 multicast fabric. Coinbase transactions are carried
+as a dedicated message type within BRC-131 block control frames and delivered to
+all subscribers via the control-plane multicast group, independently of the
+shard groups used for ordinary transaction distribution.
 
 ## Copyright
 
@@ -12,13 +16,20 @@ This BRC is licensed under the Open BSV License.
 
 ## Motivation
 
-The multicast fabric shards ordinary transactions across per-shard multicast groups based on the top bits of each transaction's TxID. Coinbase transactions cannot be sharded this way because:
+The multicast fabric shards ordinary transactions across per-shard multicast
+groups based on the top bits of each transaction's TxID. Coinbase transactions
+cannot be sharded this way because:
 
-1. **Universal relevance** — the coinbase TxID is included in every block announcement and is required to verify the block's Merkle root.
-2. **Fee aggregation** — coinbase outputs pay the block subsidy and miner fee aggregations that downstream systems need to validate template construction.
-3. **Unpredictable placement** — no subscriber can predict which shard a coinbase TxID would hash to before the block is found.
+1. **Universal relevance** — the coinbase TxID is included in every block
+   announcement and is required to verify the block's Merkle root.
+2. **Fee aggregation** — coinbase outputs pay the block subsidy and miner fee
+   aggregations that downstream systems need to validate template construction.
+3. **Unpredictable placement** — no subscriber can predict which shard a
+   coinbase TxID would hash to before the block is found.
 
-BRC-133 addresses this by routing coinbase frames to the **CtrlGroupControl** group (`FF0E::B:FFFE`), a global control channel that all subscribers join unconditionally.
+BRC-133 addresses this by routing coinbase frames to the **CtrlGroupControl**
+group (`FF0E::B:FFFE`), a global control channel that all subscribers join
+unconditionally.
 
 ## Specification
 
@@ -30,73 +41,57 @@ Coinbase frames are delivered on the **CtrlGroupControl** group:
 | -------- | ------ | ------------------ | ------------------ |
 | `0xFFFE` | global | `FF0E::B:FFFE`     | `CtrlGroupControl` |
 
-The global scope (`FF0E`) ensures coinbase transactions cross site boundaries. The group index `0xFFFE` is in the reserved control-plane range and never overlaps with data-plane shard groups (maximum shard group index is `0x7FFF` for `shard_bits=15`).
+The global scope (`FF0E`) ensures coinbase transactions cross site boundaries.
+The group index `0xFFFE` is in the reserved control-plane range and never
+overlaps with data-plane shard groups (maximum shard group index is `0x7FFF` for
+`shard_bits=15`).
 
 ### Wire Format
 
-Coinbase transactions are carried as BRC-131 frames (FrameVer `0x04`) with `MsgType = 0x02` (`BlockMsgCoinbase`).
+Coinbase transactions are carried as BRC-131 frames (FrameVer `0x04`) with
+`MsgType = 0x02` (`BlockMsgCoinbase`).
 
 | Offset | Size | Field        | Value                                                 |
 | ------ | ---- | ------------ | ----------------------------------------------------- |
 | 6      | 1    | FrameVersion | `0x04` (BRC-131)                                      |
 | 7      | 1    | MsgType      | `0x02` = `BlockMsgCoinbase`                           |
 | 8      | 32   | ContentID    | CoinbaseTxID — SHA256d of the raw coinbase tx bytes   |
-| 40     | 8    | HashKey      | XXH64(senderIPv6 ∥ 0xFFFE ∥ zeros); stamped by proxy  |
+| 40     | 8    | HashKey      | XXH64(senderIPv6  0xFFFE | zeros); stamped by proxy  |
 | 48     | 8    | SeqNum       | Monotonic per-sender counter; stamped by proxy        |
 | 56     | 32   | LayoutPad32  | All zeros                                             |
-| 88     | 4    | PayloadLen   | Length of the raw coinbase transaction bytes           |
-| 92     | *    | Payload      | Raw serialised coinbase transaction (no P2P envelope) |
+| 88     | 4    | PayloadLen   | Length of the raw coinbase transaction bytes          |
+| 92     | \*   | Payload      | Raw serialised coinbase transaction (no P2P envelope) |
 
-**Payload encoding:** The payload is a raw BSV serialised transaction — version (4 bytes LE), input vector, output vector, locktime (4 bytes LE) — identical to the encoding used in BRC-12/BRC-124 frames.
+**Payload encoding:** The payload is a raw BSV serialised transaction — version
+(4 bytes LE), input vector, output vector, locktime (4 bytes LE) — identical to
+the encoding used in BRC-12/BRC-124 frames.
 
 ### Sequencing and Retransmission
 
-Coinbase frames participate in the same NACK-based reliability mechanism as BRC-124 shard frames:
+Coinbase frames participate in the same NACK-based reliability mechanism as
+BRC-124 shard frames:
 
-- The proxy stamps `HashKey = XXH64(senderIPv6 ∥ 0xFFFE ∥ zeros)` and `SeqNum` (monotonic per sender) in-place before forwarding. If the frame arrives pre-stamped (`SeqNum != 0`), it is forwarded verbatim.
-- Listeners observe `(ctrlGroupIdx=0xFFFE, zeroSubtreeID, HashKey, SeqNum, ContentID)` for gap detection and dispatch NACKs to retry endpoints on gap.
-- Retry endpoints join `FF0E::B:FFFE` and cache coinbase frames by `HashKey ∥ SeqNum`. On NACK, the frame is retransmitted to `FF0E::B:FFFE`.
-
-### Proxy Forwarding Rules
-
-1. **Receive** — BRC-131 frames (FrameVer `0x04`) are accepted over UDP or TCP ingress. The proxy detects version byte `0x04` before dispatching to `ProcessBlock`.
-2. **Decode** — `frame.DecodeBlock` validates Magic, FrameVer, MsgType, and PayLen. Invalid MsgType values are dropped.
-3. **Stamp** — If `SeqNum == 0`, stamp HashKey and SeqNum in-place using `(senderIPv6, 0xFFFE, zeros)` flow key.
-4. **Fragment** — If `len(Payload) > fragDataSize`, fragment via BRC-130 with `OrigFrameVer = 0x04`.
-5. **Forward** — Write frame to `FF0E::B:FFFE:<egressPort>` on all egress interfaces.
-
-### Listener Processing Rules
-
-1. **Detection** — `frame.IsBlockFrame(raw)` checks Magic and `raw[6] == 0x04`.
-2. **Decode** — `frame.DecodeBlock` returns a `BlockFrame` with `MsgType`, `ContentID`, `HashKey`, `SeqNum`, and `Payload`.
-3. **Egress** — The frame (or payload only in strip-header mode) is forwarded downstream.
-4. **Gap tracking** — `Tracker.Observe(0xFFFE, zeroSubtreeID, HashKey, SeqNum, ContentID)` when `SeqNum != 0`.
-5. **Filtering** — Coinbase frames bypass all shard/subtree filters; every subscriber receives every coinbase frame.
+- The proxy stamps `HashKey = XXH64(senderIPv6 | 0xFFFE | zeros)` and `SeqNum`
+  (monotonic per sender) in-place before forwarding. If the frame arrives
+  pre-stamped (`SeqNum != 0`), it is forwarded verbatim.
+- Listeners observe
+  `(ctrlGroupIdx=0xFFFE, zeroSubtreeID, HashKey, SeqNum, ContentID)` for gap
+  detection and dispatch NACKs to retry endpoints on gap.
+- Retry endpoints join `FF0E::B:FFFE` and cache coinbase frames by
+  `HashKey ∥ SeqNum`. On NACK, the frame is retransmitted to `FF0E::B:FFFE`.
 
 ### Relationship to BRC-131 Block Announcements
 
-A `BlockAnnounce` frame (BRC-131, MsgType `0x01`) is sent first and carries the `CoinbaseTxID` in its payload. The separate `BlockMsgCoinbase` frame then carries the full raw coinbase bytes. Subscribers that only need to verify the Merkle root may use the `CoinbaseTxID` from the announce frame without waiting for the coinbase frame itself.
+A `BlockAnnounce` frame (BRC-131, MsgType `0x01`) is sent first and carries the
+`CoinbaseTxID` in its payload. The separate `BlockMsgCoinbase` frame then
+carries the full raw coinbase bytes. Subscribers that only need to verify the
+Merkle root may use the `CoinbaseTxID` from the announce frame without waiting
+for the coinbase frame itself.
 
-The two frame types share the same `HashKey` per sender but have independent `SeqNum` sequences (they are distinct flows within the `(sender, 0xFFFE, zeros)` namespace because their ContentIDs differ). Gap tracking treats them as separate objects.
-
-### Error Handling
-
-| Condition                      | Action                                                                              |
-| ------------------------------ | ----------------------------------------------------------------------------------- |
-| `raw[6] != 0x04`              | Not BRC-131; handled by other decoders                                              |
-| Bad magic                      | Silent drop                                                                         |
-| PayloadLen exceeds buffer      | Drop; `io.ErrUnexpectedEOF`                                                        |
-| Datagram shorter than 92 bytes | Drop; `ErrTooShort`                                                                 |
-| SeqNum == 0                    | Frame not yet proxy-stamped; listener skips gap tracking but still forwards         |
-
-## Infrastructure Impact
-
-| Component              | Change                                                                            |
-| ---------------------- | --------------------------------------------------------------------------------- |
-| bitcoin-shard-proxy    | `ProcessBlock` handles MsgType `0x02`; routes to `CtrlGroupControl`               |
-| bitcoin-shard-listener | `processBlockFrame` handles MsgType `0x02`; gap tracking on ctrl flow             |
-| bitcoin-retry-endpoint | Joins `FF0E::B:FFFE`; caches and retransmits BRC-131 frames regardless of MsgType |
-| bitcoin-shard-common   | `BlockMsgCoinbase = 0x02` constant; `DecodeBlock` validates MsgType               |
+The two frame types share the same `HashKey` per sender but have independent
+`SeqNum` sequences (they are distinct flows within the `(sender, 0xFFFE, zeros)`
+namespace because their ContentIDs differ). Gap tracking treats them as separate
+objects.
 
 ## Constants Reference
 
@@ -108,10 +103,7 @@ The two frame types share the same `HashKey` per sender but have independent `Se
 
 ## References
 
-- [BRC-124: Multicast Transaction Frame Format](./0124.md) — base header layout reused by BRC-131
-- [BRC-134: Chained Anchor Transaction Frames](./0134.md) — another control-group transaction type
-
-## Implementations
-
-- **Go**: [bitcoin-shard-common/frame](https://github.com/lightwebinc/bitcoin-shard-common/tree/main/frame) — `DecodeBlock`, `IsBlockFrame`, `BlockMsgCoinbase`
-- **Services**: [bitcoin-shard-proxy](https://github.com/lightwebinc/bitcoin-shard-proxy), [bitcoin-shard-listener](https://github.com/lightwebinc/bitcoin-shard-listener) — Network multicast infrastructure
+- [BRC-124: Multicast Transaction Frame Format](./0124.md) — base header layout
+  reused by BRC-131
+- [BRC-134: Chained Anchor Transaction Frames](./0134.md) — another
+  control-group transaction type

--- a/transactions/0133.md
+++ b/transactions/0133.md
@@ -27,7 +27,7 @@ cannot be sharded this way because:
 3. **Unpredictable placement** — no subscriber can predict which shard a
    coinbase TxID would hash to before the block is found.
 
-BRC-133 addresses this by routing coinbase frames to the **CtrlGroupControl**
+BRC-133 addresses this by routing coinbase frames to the **GroupBlockBroadcast**
 group (`FF0E::B:FFFE`), a global control channel that all subscribers join
 unconditionally.
 
@@ -35,11 +35,11 @@ unconditionally.
 
 ### Control-Plane Multicast Group
 
-Coinbase frames are delivered on the **CtrlGroupControl** group:
+Coinbase frames are delivered on the **GroupBlockBroadcast** group:
 
-| Index    | Scope  | Compressed Address | Constant           |
-| -------- | ------ | ------------------ | ------------------ |
-| `0xFFFE` | global | `FF0E::B:FFFE`     | `CtrlGroupControl` |
+| Index    | Scope  | Compressed Address | Constant              |
+| -------- | ------ | ------------------ | --------------------- |
+| `0xFFFE` | global | `FF0E::B:FFFE`     | `GroupBlockBroadcast` |
 
 The global scope (`FF0E`) ensures coinbase transactions cross site boundaries.
 The group index `0xFFFE` is in the reserved control-plane range and never
@@ -52,11 +52,11 @@ Coinbase transactions are carried as BRC-131 frames (FrameVer `0x04`) with
 `MsgType = 0x02` (`BlockMsgCoinbase`).
 
 | Offset | Size | Field        | Value                                                 |
-| ------ | ---- | ------------ | ----------------------------------------------------- |
+| ------ | ---- | ------------ | ----------------------------------------------------- | ------------------------ |
 | 6      | 1    | FrameVersion | `0x04` (BRC-131)                                      |
 | 7      | 1    | MsgType      | `0x02` = `BlockMsgCoinbase`                           |
 | 8      | 32   | ContentID    | CoinbaseTxID — SHA256d of the raw coinbase tx bytes   |
-| 40     | 8    | HashKey      | XXH64(senderIPv6  0xFFFE | zeros); stamped by proxy  |
+| 40     | 8    | HashKey      | XXH64(senderIPv6 0xFFFE                               | zeros); stamped by proxy |
 | 48     | 8    | SeqNum       | Monotonic per-sender counter; stamped by proxy        |
 | 56     | 32   | LayoutPad32  | All zeros                                             |
 | 88     | 4    | PayloadLen   | Length of the raw coinbase transaction bytes          |
@@ -95,11 +95,11 @@ objects.
 
 ## Constants Reference
 
-| Name               | Value    | Description                         |
-| ------------------ | -------- | ----------------------------------- |
-| `FrameVerV4`       | `0x04`   | BRC-131 block control frame version |
-| `BlockMsgCoinbase` | `0x02`   | MsgType: raw coinbase transaction   |
-| `CtrlGroupControl` | `0xFFFE` | Block control multicast group index |
+| Name                  | Value    | Description                         |
+| --------------------- | -------- | ----------------------------------- |
+| `FrameVerV4`          | `0x04`   | BRC-131 block control frame version |
+| `BlockMsgCoinbase`    | `0x02`   | MsgType: raw coinbase transaction   |
+| `GroupBlockBroadcast` | `0xFFFE` | Block control multicast group index |
 
 ## References
 

--- a/transactions/0133.md
+++ b/transactions/0133.md
@@ -43,8 +43,8 @@ Coinbase frames are delivered on the **GroupBlockBroadcast** group:
 
 The global scope (`FF0E`) ensures coinbase transactions cross site boundaries.
 The group index `0xFFFE` is in the reserved control-plane range and never
-overlaps with data-plane shard groups (maximum shard group index is `0x7FFF` for
-`shard_bits=15`).
+overlaps with data-plane shard groups (maximum shard group index is `0x0FFF` for
+`shard_bits=12`).
 
 ### Wire Format
 
@@ -52,11 +52,11 @@ Coinbase transactions are carried as BRC-131 frames (FrameVer `0x04`) with
 `MsgType = 0x02` (`BlockMsgCoinbase`).
 
 | Offset | Size | Field        | Value                                                 |
-| ------ | ---- | ------------ | ----------------------------------------------------- | ------------------------ |
+| ------ | ---- | ------------ | ----------------------------------------------------- |
 | 6      | 1    | FrameVersion | `0x04` (BRC-131)                                      |
 | 7      | 1    | MsgType      | `0x02` = `BlockMsgCoinbase`                           |
 | 8      | 32   | ContentID    | CoinbaseTxID — SHA256d of the raw coinbase tx bytes   |
-| 40     | 8    | HashKey      | XXH64(senderIPv6 0xFFFE                               | zeros); stamped by proxy |
+| 40     | 8    | HashKey      | XXH64(senderIPv6 ∥ 0xFFF8 ∥ zeros); stamped by proxy  |
 | 48     | 8    | SeqNum       | Monotonic per-sender counter; stamped by proxy        |
 | 56     | 32   | LayoutPad32  | All zeros                                             |
 | 88     | 4    | PayloadLen   | Length of the raw coinbase transaction bytes          |
@@ -71,11 +71,15 @@ the encoding used in BRC-12/BRC-124 frames.
 Coinbase frames participate in the same NACK-based reliability mechanism as
 BRC-124 shard frames:
 
-- The proxy stamps `HashKey = XXH64(senderIPv6 | 0xFFFE | zeros)` and `SeqNum`
-  (monotonic per sender) in-place before forwarding. If the frame arrives
-  pre-stamped (`SeqNum != 0`), it is forwarded verbatim.
+- The proxy stamps `HashKey = XXH64(senderIPv6 ∥ 0xFFF8 ∥ zeros)` and `SeqNum`
+  (monotonic per sender on the coinbase flow) in-place before forwarding. The
+  virtual index `0xFFF8` (`GroupCoinbaseFlow`) is never used as an actual
+  multicast destination — it appears only in the HashKey computation to give
+  coinbase frames an independent flow identity from BRC-131 block announces,
+  which share the same egress multicast group. If the frame arrives pre-stamped
+  (`SeqNum != 0`), it is forwarded verbatim.
 - Listeners observe
-  `(ctrlGroupIdx=0xFFFE, zeroSubtreeID, HashKey, SeqNum, ContentID)` for gap
+  `(coinbaseFlowIdx=0xFFF8, zeroSubtreeID, HashKey, SeqNum, ContentID)` for gap
   detection and dispatch NACKs to retry endpoints on gap.
 - Retry endpoints join `FF0E::B:FFFE` and cache coinbase frames by
   `HashKey ∥ SeqNum`. On NACK, the frame is retransmitted to `FF0E::B:FFFE`.
@@ -88,18 +92,21 @@ carries the full raw coinbase bytes. Subscribers that only need to verify the
 Merkle root may use the `CoinbaseTxID` from the announce frame without waiting
 for the coinbase frame itself.
 
-The two frame types share the same `HashKey` per sender but have independent
-`SeqNum` sequences (they are distinct flows within the `(sender, 0xFFFE, zeros)`
-namespace because their ContentIDs differ). Gap tracking treats them as separate
-objects.
+`BlockAnnounce` and `BlockMsgCoinbase` form **separate flows** on the proxy.
+BlockAnnounce frames use a `HashKey` derived from `(sender, 0xFFFE, zeros)`;
+Coinbase frames use a `HashKey` derived from `(sender, 0xFFF8, zeros)`. Each
+flow therefore has its own monotonic `SeqNum` counter, its own `HashKey` value,
+and is gap-tracked independently by listeners — even though both egress to the
+same `FF0E::B:FFFE` multicast destination.
 
 ## Constants Reference
 
-| Name                  | Value    | Description                         |
-| --------------------- | -------- | ----------------------------------- |
-| `FrameVerV4`          | `0x04`   | BRC-131 block control frame version |
-| `BlockMsgCoinbase`    | `0x02`   | MsgType: raw coinbase transaction   |
-| `GroupBlockBroadcast` | `0xFFFE` | Block control multicast group index |
+| Name                  | Value    | Description                                                                    |
+| --------------------- | -------- | ------------------------------------------------------------------------------ |
+| `FrameVerV4`          | `0x04`   | BRC-131 block control frame version                                            |
+| `BlockMsgCoinbase`    | `0x02`   | MsgType: raw coinbase transaction                                              |
+| `GroupBlockBroadcast` | `0xFFFE` | Block control multicast group index (egress)                                   |
+| `GroupCoinbaseFlow`   | `0xFFF8` | Virtual HashKey ingredient; coinbase flow identity (never a multicast address) |
 
 ## References
 

--- a/transactions/0134.md
+++ b/transactions/0134.md
@@ -32,7 +32,7 @@ sharded this way because:
    confirmed before use; they need only to be visible and valid. Wide visibility
    is the primary requirement.
 
-BRC-134 addresses this by routing anchor frames to the **CtrlGroupControl**
+BRC-134 addresses this by routing anchor frames to the **GroupBlockBroadcast**
 group (`FF0E::B:FFFE`), the same global control channel used for block headers
 and coinbase transactions (BRC-131, BRC-133). All subscribers join this group
 unconditionally.
@@ -41,11 +41,11 @@ unconditionally.
 
 ### Control-Plane Multicast Group
 
-Anchor frames are delivered on the **CtrlGroupControl** group:
+Anchor frames are delivered on the **GroupBlockBroadcast** group:
 
-| Index    | Scope  | Compressed Address | Constant           |
-| -------- | ------ | ------------------ | ------------------ |
-| `0xFFFE` | global | `FF0E::B:FFFE`     | `CtrlGroupControl` |
+| Index    | Scope  | Compressed Address | Constant              |
+| -------- | ------ | ------------------ | --------------------- |
+| `0xFFFE` | global | `FF0E::B:FFFE`     | `GroupBlockBroadcast` |
 
 The global scope (`FF0E`) ensures anchor transactions cross site boundaries and
 reach all geographically distributed subscribers. The group index `0xFFFE` is in
@@ -89,7 +89,7 @@ BRC-124 shard frames:
 - The proxy stamps `HashKey = XXH64(senderIPv6 ∥ 0xFFF9 ∥ zeros)` and `SeqNum`
   (monotonic per sender) in-place before forwarding. The virtual index `0xFFF9`
   gives anchor frames an independent flow identity from BRC-131 block frames,
-  which both travel on the same `CtrlGroupControl` multicast address. If the
+  which both travel on the same `GroupBlockBroadcast` multicast address. If the
   frame arrives pre-stamped (`SeqNum != 0`), it is forwarded verbatim.
 - Listeners observe
   `(anchorGroupIdx=0xFFF9, zeroSubtreeID, HashKey, SeqNum, TxID)` for gap
@@ -99,10 +99,10 @@ BRC-124 shard frames:
 
 ## Constants Reference
 
-| Name               | Value    | Description                                                       |
-| ------------------ | -------- | ----------------------------------------------------------------- |
-| `FrameVerV6`       | `0x06`   | BRC-134 chained anchor transaction frame version                  |
-| `CtrlGroupControl` | `0xFFFE` | Control-plane multicast group index (shared with BRC-131/BRC-133) |
+| Name                  | Value    | Description                                                       |
+| --------------------- | -------- | ----------------------------------------------------------------- |
+| `FrameVerV6`          | `0x06`   | BRC-134 chained anchor transaction frame version                  |
+| `GroupBlockBroadcast` | `0xFFFE` | Control-plane multicast group index (shared with BRC-131/BRC-133) |
 
 ## References
 

--- a/transactions/0134.md
+++ b/transactions/0134.md
@@ -99,10 +99,11 @@ BRC-124 shard frames:
 
 ## Constants Reference
 
-| Name                  | Value    | Description                                                       |
-| --------------------- | -------- | ----------------------------------------------------------------- |
-| `FrameVerV6`          | `0x06`   | BRC-134 chained anchor transaction frame version                  |
-| `GroupBlockBroadcast` | `0xFFFE` | Control-plane multicast group index (shared with BRC-131/BRC-133) |
+| Name                  | Value    | Description                                                                  |
+| --------------------- | -------- | ---------------------------------------------------------------------------- |
+| `FrameVerV6`          | `0x06`   | BRC-134 chained anchor transaction frame version                             |
+| `GroupBlockBroadcast` | `0xFFFE` | Control-plane multicast group index (shared with BRC-131/BRC-133)            |
+| `GroupAnchorFlow`     | `0xFFF9` | Virtual HashKey ingredient; anchor flow identity (never a multicast address) |
 
 ## References
 

--- a/transactions/0134.md
+++ b/transactions/0134.md
@@ -50,7 +50,7 @@ Anchor frames are delivered on the **GroupBlockBroadcast** group:
 The global scope (`FF0E`) ensures anchor transactions cross site boundaries and
 reach all geographically distributed subscribers. The group index `0xFFFE` is in
 the reserved control-plane range and never overlaps with data-plane shard groups
-(maximum shard group index is `0x7FFF` for `shard_bits=15`).
+(maximum shard group index is `0x0FFF` for `shard_bits=12`).
 
 ### Frame Header Format (92 bytes)
 

--- a/transactions/0134.md
+++ b/transactions/0134.md
@@ -4,7 +4,11 @@ Jeff Harris (jeff@lightweb.net)
 
 ## Abstract
 
-This BRC defines a new frame version (`0x06`) for distributing chained anchor transactions over the IPv6 multicast fabric. An anchor transaction is the root (first) transaction in a chain of dependent transactions. Because all subsequent transactions in the chain reference the anchor as an input, every subscriber must receive it regardless of which shard its TxID would otherwise hash to.
+This BRC defines a new frame version (`0x06`) for distributing chained anchor
+transactions over the IPv6 multicast fabric. An anchor transaction is the root
+(first) transaction in a chain of dependent transactions. Because all subsequent
+transactions in the chain reference the anchor as an input, every subscriber
+must receive it regardless of which shard its TxID would otherwise hash to.
 
 ## Copyright
 
@@ -12,14 +16,26 @@ This BRC is licensed under the Open BSV License.
 
 ## Motivation
 
-The multicast fabric shards ordinary transactions across per-shard multicast groups based on the top bits of each TxID. Chained anchor transactions cannot be sharded this way because:
+The multicast fabric shards ordinary transactions across per-shard multicast
+groups based on the top bits of each TxID. Chained anchor transactions cannot be
+sharded this way because:
 
-1. **Dependency root** — all dependent (chained) transactions in the set reference the anchor's TxID as an input. A subscriber that misses the anchor cannot validate any dependent transaction in the chain.
-2. **Unpredictable placement** — the anchor's TxID is not known in advance by subscribers; they cannot pre-join the correct shard group.
-3. **Cross-shard span** — the chain may span many shards. The anchor itself might hash to shard 0 while dependents are spread across shards 1–15. Every subscriber needs the anchor irrespective of which shards they follow.
-4. **Visibility over confirmation** — anchor transactions do not need to be confirmed before use; they need only to be visible and valid. Wide visibility is the primary requirement.
+1. **Dependency root** — all dependent (chained) transactions in the set
+   reference the anchor's TxID as an input. A subscriber that misses the anchor
+   cannot validate any dependent transaction in the chain.
+2. **Unpredictable placement** — the anchor's TxID is not known in advance by
+   subscribers; they cannot pre-join the correct shard group.
+3. **Cross-shard span** — the chain may span many shards. The anchor itself
+   might hash to shard 0 while dependents are spread across shards 1–15. Every
+   subscriber needs the anchor irrespective of which shards they follow.
+4. **Visibility over confirmation** — anchor transactions do not need to be
+   confirmed before use; they need only to be visible and valid. Wide visibility
+   is the primary requirement.
 
-BRC-134 addresses this by routing anchor frames to the **CtrlGroupControl** group (`FF0E::B:FFFE`), the same global control channel used for block headers and coinbase transactions (BRC-131, BRC-133). All subscribers join this group unconditionally.
+BRC-134 addresses this by routing anchor frames to the **CtrlGroupControl**
+group (`FF0E::B:FFFE`), the same global control channel used for block headers
+and coinbase transactions (BRC-131, BRC-133). All subscribers join this group
+unconditionally.
 
 ## Specification
 
@@ -31,72 +47,55 @@ Anchor frames are delivered on the **CtrlGroupControl** group:
 | -------- | ------ | ------------------ | ------------------ |
 | `0xFFFE` | global | `FF0E::B:FFFE`     | `CtrlGroupControl` |
 
-The global scope (`FF0E`) ensures anchor transactions cross site boundaries and reach all geographically distributed subscribers. The group index `0xFFFE` is in the reserved control-plane range and never overlaps with data-plane shard groups (maximum shard group index is `0x7FFF` for `shard_bits=15`).
+The global scope (`FF0E`) ensures anchor transactions cross site boundaries and
+reach all geographically distributed subscribers. The group index `0xFFFE` is in
+the reserved control-plane range and never overlaps with data-plane shard groups
+(maximum shard group index is `0x7FFF` for `shard_bits=15`).
 
 ### Frame Header Format (92 bytes)
 
-The BRC-134 header is **layout-identical** to BRC-124. Infrastructure components that inspect the Magic, HashKey, or SeqNum fields read correct values at the same offsets.
+The BRC-134 header is **layout-identical** to BRC-124. Infrastructure components
+that inspect the Magic, HashKey, or SeqNum fields read correct values at the
+same offsets.
 
-| Offset | Size | Align | Field       | Value / Notes                                             |
-| ------ | ---- | ----- | ----------- | --------------------------------------------------------- |
-| 0      | 4    | —     | Network Magic | `0xE3E1F3E8` (BSV mainnet P2P magic)                    |
-| 4      | 2    | —     | Protocol Ver  | `0x02BF` (703, BSV large-block baseline)                |
-| 6      | 1    | —     | Frame Version | **`0x06`** — BRC-134 anchor transaction                 |
-| 7      | 1    | —     | Reserved      | `0x00`                                                  |
-| 8      | 32   | 8B    | TxID          | SHA256d of the anchor transaction (internal byte order) |
-| 40     | 8    | 8B    | HashKey       | XXH64(senderIPv6 ∥ 0xFFFE ∥ zeros); stamped by proxy    |
+| Offset | Size | Align | Field         | Value / Notes                                             |
+| ------ | ---- | ----- | ------------- | --------------------------------------------------------- |
+| 0      | 4    | —     | Network Magic | `0xE3E1F3E8` (BSV mainnet P2P magic)                      |
+| 4      | 2    | —     | Protocol Ver  | `0x02BF` (703, BSV large-block baseline)                  |
+| 6      | 1    | —     | Frame Version | **`0x06`** — BRC-134 anchor transaction                   |
+| 7      | 1    | —     | Reserved      | `0x00`                                                    |
+| 8      | 32   | 8B    | TxID          | SHA256d of the anchor transaction (internal byte order)   |
+| 40     | 8    | 8B    | HashKey       | XXH64(senderIPv6 ∥ 0xFFF9 ∥ zeros); stamped by proxy      |
 | 48     | 8    | 8B    | SeqNum        | Monotonic per-sender counter; stamped by proxy; 0 = unset |
-| 56     | 32   | 8B    | LayoutPad32   | All zeros (no subtree scope for anchor frames)          |
-| 88     | 4    | —     | PayloadLen    | Size of anchor transaction payload in bytes (uint32 BE) |
-| 92     | *    | —     | Payload       | Raw serialised anchor transaction (no P2P envelope)     |
+| 56     | 32   | 8B    | LayoutPad32   | All zeros (no subtree scope for anchor frames)            |
+| 88     | 4    | —     | PayloadLen    | Size of anchor transaction payload in bytes (uint32 BE)   |
+| 92     | \*   | —     | Payload       | Raw serialised anchor transaction (no P2P envelope)       |
 
-**Key distinction from BRC-124:** the version byte at offset 6 is `0x06` rather than `0x02`. All other field offsets and sizes are identical. The `LayoutPad32` field at bytes 56–87 is always zeros — anchor frames have no subtree scope. The field is kept for layout uniformity: the proxy TCP reader, stamping path, listener, and retry endpoint all share the single `HeaderSize` constant.
+**Key distinction from BRC-124:** the version byte at offset 6 is `0x06` rather
+than `0x02`. All other field offsets and sizes are identical. The `LayoutPad32`
+field at bytes 56–87 is always zeros — anchor frames have no subtree scope. The
+field is kept for layout uniformity: the proxy TCP reader, stamping path,
+listener, and retry endpoint all share the single `HeaderSize` constant.
 
-**Payload encoding:** The payload is a raw BSV serialised transaction — version (4 bytes LE), input vector, output vector, locktime (4 bytes LE) — identical to the encoding used in BRC-12/BRC-124 frames.
+**Payload encoding:** The payload is a raw BSV serialised transaction — version
+(4 bytes LE), input vector, output vector, locktime (4 bytes LE) — identical to
+the encoding used in BRC-12/BRC-124 frames.
 
 ### Sequencing and Retransmission
 
-BRC-134 frames participate in the same NACK-based reliability mechanism as BRC-124 shard frames:
+BRC-134 frames participate in the same NACK-based reliability mechanism as
+BRC-124 shard frames:
 
-- The proxy stamps `HashKey = XXH64(senderIPv6 ∥ 0xFFFE ∥ zeros)` and `SeqNum` (monotonic per sender) in-place before forwarding. If the frame arrives pre-stamped (`SeqNum != 0`), it is forwarded verbatim.
-- Listeners observe `(ctrlGroupIdx=0xFFFE, zeroSubtreeID, HashKey, SeqNum, TxID)` for gap detection and dispatch NACKs to retry endpoints on gap.
-- Retry endpoints join `FF0E::B:FFFE` and cache BRC-134 frames by `HashKey ∥ SeqNum`. On NACK, the frame is retransmitted to `FF0E::B:FFFE`.
-
-### Proxy Forwarding Rules
-
-1. **Receive** — BRC-134 frames are accepted over UDP or TCP ingress. The proxy detects version byte `0x06` before dispatching to `ProcessAnchor`.
-2. **Decode** — `frame.DecodeAnchor` validates Magic, FrameVer, and PayLen. Invalid frames are dropped.
-3. **Stamp** — If `SeqNum == 0`, stamp HashKey and SeqNum in-place using `(senderIPv6, 0xFFFE, zeros)` flow key.
-4. **Forward** — Write frame verbatim to `FF0E::B:FFFE:<egressPort>` on all egress interfaces.
-
-BRC-130 fragmentation is not defined for BRC-134. Anchor transactions are expected to be small (a typical BSV transaction). If fragmentation support becomes necessary it will be defined in a future revision.
-
-### Listener Processing Rules
-
-1. **Detection** — `frame.IsAnchorFrame(raw)` checks Magic and `raw[6] == 0x06`.
-2. **Decode** — `frame.DecodeAnchor` returns a `*Frame` with `Version=FrameVerV6`, `TxID`, `HashKey`, `SeqNum`, `SubtreeID` (zeros), and `Payload`.
-3. **Egress** — The frame (or payload only in strip-header mode) is forwarded downstream.
-4. **Gap tracking** — `Tracker.Observe(0xFFFE, zeroSubtreeID, HashKey, SeqNum, TxID)` when `SeqNum != 0`.
-5. **Filtering** — Anchor frames bypass all shard/subtree filters; every subscriber receives every anchor frame.
-
-### Error Handling
-
-| Condition                      | Action                                                                              |
-| ------------------------------ | ----------------------------------------------------------------------------------- |
-| `raw[6] != 0x06`              | Not BRC-134; handled by other decoders                                              |
-| Bad magic                      | Silent drop                                                                         |
-| PayloadLen exceeds buffer      | Drop; `io.ErrUnexpectedEOF`                                                        |
-| Datagram shorter than 92 bytes | Drop; `ErrTooShort`                                                                 |
-| SeqNum == 0                    | Frame not yet proxy-stamped; listener skips gap tracking but still forwards         |
-
-## Infrastructure Impact
-
-| Component              | Change                                                                                                                |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| bitcoin-shard-proxy    | UDP worker and TCP ingress: version `0x06` → `ProcessAnchor`; new `ProcessAnchor` method routes to `CtrlGroupControl` |
-| bitcoin-shard-listener | `IsAnchorFrame` dispatch; new `processAnchorFrame` method; gap tracking on ctrl flow                                  |
-| bitcoin-retry-endpoint | Joins `FF0E::B:FFFE`; caches and retransmits FrameVerV6 frames                                                       |
-| bitcoin-shard-common   | `FrameVerV6 = 0x06` constant; `DecodeAnchor`; `IsAnchorFrame`                                                        |
+- The proxy stamps `HashKey = XXH64(senderIPv6 ∥ 0xFFF9 ∥ zeros)` and `SeqNum`
+  (monotonic per sender) in-place before forwarding. The virtual index `0xFFF9`
+  gives anchor frames an independent flow identity from BRC-131 block frames,
+  which both travel on the same `CtrlGroupControl` multicast address. If the
+  frame arrives pre-stamped (`SeqNum != 0`), it is forwarded verbatim.
+- Listeners observe
+  `(anchorGroupIdx=0xFFF9, zeroSubtreeID, HashKey, SeqNum, TxID)` for gap
+  detection and dispatch NACKs to retry endpoints on gap.
+- Retry endpoints join `FF0E::B:FFFE` and cache BRC-134 frames by
+  `HashKey ∥ SeqNum`. On NACK, the frame is retransmitted to `FF0E::B:FFFE`.
 
 ## Constants Reference
 
@@ -107,10 +106,7 @@ BRC-130 fragmentation is not defined for BRC-134. Anchor transactions are expect
 
 ## References
 
-- [BRC-124: Multicast Transaction Frame Format](./0124.md) — base header layout reused by BRC-134
-- [BRC-133: Coinbase Transaction Delivery](./0133.md) — another control-group transaction type using BRC-131
-
-## Implementations
-
-- **Go**: [bitcoin-shard-common/frame](https://github.com/lightwebinc/bitcoin-shard-common/tree/main/frame) — `DecodeAnchor`, `IsAnchorFrame`, `FrameVerV6`
-- **Services**: [bitcoin-shard-proxy](https://github.com/lightwebinc/bitcoin-shard-proxy), [bitcoin-shard-listener](https://github.com/lightwebinc/bitcoin-shard-listener) — Network multicast infrastructure
+- [BRC-124: Multicast Transaction Frame Format](./0124.md) — base header layout
+  reused by BRC-134
+- [BRC-133: Coinbase Transaction Delivery](./0133.md) — another control-group
+  transaction type using BRC-131

--- a/transactions/0135.md
+++ b/transactions/0135.md
@@ -244,7 +244,7 @@ E3E1F3E8                                                          // Network Mag
 02BF                                                              // Protocol Version
 07                                                                // Frame Version (BRC-135)
 00                                                                // Reserved
-0000000000000000001a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d  // BlockHash
+00000000000000000001a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3  // BlockHash
 00112233AABBCCDD                                                  // HashKey (XXH64 of emitter flow)
 0000000000000001                                                  // SeqNum (1)
 0000000000000000000000000000000000000000000000000000000000000000  // LayoutPad32 (zeros)

--- a/transactions/0135.md
+++ b/transactions/0135.md
@@ -54,8 +54,8 @@ subscribers would receive the split frame on the control channel they already
 subscribe to.
 
 When multicast egress is enabled, the emitter sends BRC-135 frames to the
-`CtrlGroupBlockHeader` index (`0xFFFA`) on the egress scope, typically a
-different scope or group-id from the ingress fabric:
+`GroupBlockHeader` index (`0xFFFA`) on the egress scope, typically a different
+scope or group-id from the ingress fabric:
 
 | Index  | Scope           | Compressed Address      | Notes                            |
 | ------ | --------------- | ----------------------- | -------------------------------- |
@@ -78,7 +78,7 @@ All multi-byte integers are big-endian.
 | 6      | 1    | —         | Frame Version | 0x07 — BRC-135 block header                               |
 | 7      | 1    | —         | Reserved      | 0x00                                                      |
 | 8      | 32   | 8-byte    | BlockHash     | SHA256d of the 80-byte block header (internal byte order) |
-| 40     | 8    | 8-byte    | HashKey       | XXH64(emitterIPv6 ∥ 0xFFFE ∥ zeros); stamped by emitter |
+| 40     | 8    | 8-byte    | HashKey       | XXH64(emitterIPv6 ∥ 0xFFFE ∥ zeros); stamped by emitter   |
 | 48     | 8    | 8-byte    | SeqNum        | Monotonic per-emitter counter; stamped by emitter         |
 | 56     | 32   | 8-byte    | LayoutPad32   | All zeros (no subtree scope for block headers)            |
 | 88     | 4    | —         | PayloadLen    | 0x00000050 (80 = fixed block header size, uint32 BE)      |
@@ -124,7 +124,7 @@ A stable per-emitter flow identifier computed as:
 HashKey = XXH64(emitterIPv6 [16 bytes] ∥ 0x0000FFFE [4 bytes BE] ∥ zeros [32 bytes])
 ```
 
-The `0xFFFE` group index is `CtrlGroupControl`, the same control-plane index
+The `0xFFFE` group index is `GroupBlockBroadcast`, the same control-plane index
 used by BRC-131/133/134. The 32 zero bytes correspond to the absent SubtreeID.
 The HashKey is constant for the lifetime of the emitter process.
 
@@ -263,16 +263,16 @@ aabbccdd00112233...                                               // MerkleRoot 
 
 - [BRC-124: Multicast Transaction Frame Format](./0124.md) — Base header layout
   reused by BRC-135
-- [BRC-131: Block Announcement Frame Format](./0131.md)
-  — Source of the 80-byte block header extracted by the emitter
-- [BRC-133: Coinbase Transaction Frame Format](./0133.md)
-  — Companion control-plane frame type
-- [BRC-134: Anchor Transaction Frame Format](./0134.md)
-  — Companion control-plane frame type
-- [BRC-126: Retransmission Protocol](./0126.md)
-  — NACK/ACK/MISS used for upstream block frame retransmission
-- [BRC-129: Multicast Group Address Assignments](./0129.md)
-  — Control-plane group index allocations
+- [BRC-131: Block Announcement Frame Format](./0131.md) — Source of the 80-byte
+  block header extracted by the emitter
+- [BRC-133: Coinbase Transaction Frame Format](./0133.md) — Companion
+  control-plane frame type
+- [BRC-134: Anchor Transaction Frame Format](./0134.md) — Companion
+  control-plane frame type
+- [BRC-126: Retransmission Protocol](./0126.md) — NACK/ACK/MISS used for
+  upstream block frame retransmission
+- [BRC-129: Multicast Group Address Assignments](./0129.md) — Control-plane
+  group index allocations
 
 ## Constants Reference
 
@@ -281,6 +281,6 @@ aabbccdd00112233...                                               // MerkleRoot 
 | FrameVerV7           | 7     | 0x07   | BRC-135 block header frame version                |
 | BlockHeaderPayload   | 80    | 0x50   | Fixed payload size (standard BSV block header)    |
 | BlockHeaderFrameSize | 172   | 0xAC   | Total frame size (92 + 80)                        |
-| CtrlGroupBlockHeader | 65530 | 0xFFFA | Block header egress channel (BRC-135 mc-egress)   |
-| CtrlGroupControl     | 65534 | 0xFFFE | Control group index (shared with BRC-131/133/134) |
+| GroupBlockHeader     | 65530 | 0xFFFA | Block header egress channel (BRC-135 mc-egress)   |
+| GroupBlockBroadcast  | 65534 | 0xFFFE | Control group index (shared with BRC-131/133/134) |
 | HeaderSize           | 92    | 0x5C   | BRC-135 header size (identical to BRC-124)        |

--- a/transactions/0135.md
+++ b/transactions/0135.md
@@ -54,12 +54,12 @@ subscribers would receive the split frame on the control channel they already
 subscribe to.
 
 When multicast egress is enabled, the emitter sends BRC-135 frames to the
-`CtrlGroupControl` index (`0xFFFE`) on the egress scope, typically a different
-scope or group-id from the ingress fabric:
+`CtrlGroupBlockHeader` index (`0xFFFA`) on the egress scope, typically a
+different scope or group-id from the ingress fabric:
 
 | Index  | Scope           | Compressed Address      | Notes                            |
 | ------ | --------------- | ----------------------- | -------------------------------- |
-| 0xFFFE | egress (varies) | FF05::<egress-gid>:FFFE | Emitter multicast egress channel |
+| 0xFFFA | egress (varies) | FF05::<egress-gid>:FFFA | Emitter multicast egress channel |
 
 The egress group-id is set independently of the fabric group-id. This ensures
 BRC-135 frames reach only downstream consumers, not peer fabric subscribers or
@@ -78,7 +78,7 @@ All multi-byte integers are big-endian.
 | 6      | 1    | —         | Frame Version | 0x07 — BRC-135 block header                               |
 | 7      | 1    | —         | Reserved      | 0x00                                                      |
 | 8      | 32   | 8-byte    | BlockHash     | SHA256d of the 80-byte block header (internal byte order) |
-| 40     | 8    | 8-byte    | HashKey       | XXH64(emitterIPv6 ∥ 0xFFFE ∥ zeros); stamped by emitter   |
+| 40     | 8    | 8-byte    | HashKey       | XXH64(emitterIPv6 ∥ 0xFFFE ∥ zeros); stamped by emitter |
 | 48     | 8    | 8-byte    | SeqNum        | Monotonic per-emitter counter; stamped by emitter         |
 | 56     | 32   | 8-byte    | LayoutPad32   | All zeros (no subtree scope for block headers)            |
 | 88     | 4    | —         | PayloadLen    | 0x00000050 (80 = fixed block header size, uint32 BE)      |
@@ -263,15 +263,15 @@ aabbccdd00112233...                                               // MerkleRoot 
 
 - [BRC-124: Multicast Transaction Frame Format](./0124.md) — Base header layout
   reused by BRC-135
-- [BRC-131: Block Announcement Frame Format](https://github.com/lightwebinc/bitcoin-multicast/blob/main/docs/brc-131-block-announcements.md)
+- [BRC-131: Block Announcement Frame Format](./0131.md)
   — Source of the 80-byte block header extracted by the emitter
-- [BRC-133: Coinbase Transaction Frame Format](https://github.com/lightwebinc/bitcoin-multicast/blob/main/docs/brc-133-coinbase-delivery.md)
+- [BRC-133: Coinbase Transaction Frame Format](./0133.md)
   — Companion control-plane frame type
-- [BRC-134: Anchor Transaction Frame Format](https://github.com/lightwebinc/bitcoin-multicast/blob/main/docs/brc-134-anchor-transactions.md)
+- [BRC-134: Anchor Transaction Frame Format](./0134.md)
   — Companion control-plane frame type
-- [BRC-126: Retransmission Protocol](https://github.com/lightwebinc/bitcoin-multicast/blob/main/docs/brc-126-retransmission-protocol.md)
+- [BRC-126: Retransmission Protocol](./0126.md)
   — NACK/ACK/MISS used for upstream block frame retransmission
-- [BRC-129: Multicast Group Address Assignments](https://github.com/lightwebinc/bitcoin-multicast/blob/main/docs/brc-129-multicast-addressing.md)
+- [BRC-129: Multicast Group Address Assignments](./0129.md)
   — Control-plane group index allocations
 
 ## Constants Reference
@@ -281,5 +281,6 @@ aabbccdd00112233...                                               // MerkleRoot 
 | FrameVerV7           | 7     | 0x07   | BRC-135 block header frame version                |
 | BlockHeaderPayload   | 80    | 0x50   | Fixed payload size (standard BSV block header)    |
 | BlockHeaderFrameSize | 172   | 0xAC   | Total frame size (92 + 80)                        |
+| CtrlGroupBlockHeader | 65530 | 0xFFFA | Block header egress channel (BRC-135 mc-egress)   |
 | CtrlGroupControl     | 65534 | 0xFFFE | Control group index (shared with BRC-131/133/134) |
 | HeaderSize           | 92    | 0x5C   | BRC-135 header size (identical to BRC-124)        |


### PR DESCRIPTION
### This pull request:

Amends or corrects an existing standard, without the need for creating a new one

### Summary

Various issues were found with the previously submitted PRs. Instead of individual fixes, I've rolled them all up into one branch.

## Protocol additions

- SSM addressing mode (BRC-129) — adds Source-Specific Multicast (FF3x::/32, RFC 4607) as an opt-in transport alongside ASM, with (S,G) join rules and source discovery; global scope is SSM-only per RFC 8815.
- NACK proxying (BRC-126) — cross-domain gap recovery: downstream endpoints forward cache-miss NACKs one hop upstream via a new Proxied flag, served unicast.
- Virtual HashKey indices (BRC-129) — documents GroupCoinbaseFlow (0xFFF8) and GroupAnchorFlow (0xFFF9) so coinbase/anchor frames form independent flows while sharing the 0xFFFE egress group.

## Naming standardization

- Control-plane constants renamed Ctrl*/CtrlGroup* → Group* prefix across the suite.
- Subtree channels disambiguated: 0xFFFB (BRC-132 subtree data) → GroupSubtreeDataAnnounce; 0xFFFC (BRC-127 subtree→group bindings) → GroupSubtreeGroupAnnounce / SubtreeGroupAnnounce datagram. BRC-127 retitled "Multicast Subtree Group Announcement Frame Format." (Matches the reference-code rename shipped in shard-common v0.13.5 and dependents.)
- BRC-137 → BRC-139 shard-manifest reference corrected in BRC-129.

## Cross-BRC inconsistency fixes

- BRC-130 fragment header: byte 7 Reserved→MsgType, bytes 100–103 Reserved2→OrigFrameVer+reserved — matches frag.go and the BRC-131/132 fragmentation refs that already depended on these fields.
- BRC-131 HashKey: coinbase (MsgType 0x02) now correctly uses flow index 0xFFF8, not 0xFFFE (matches BRC-133/129 and forwarder.go).
- BRC-129: 0xFFFB attribution corrected from BRC-127 → BRC-132.
- BRC-132: three broken ../peer-to-peer/ reference links fixed to ./.
- Corrections: BRC-124 MagicBSV decimal (3811983336→3823236072); shard_bits ≤ 15→≤ 12 (BRC-131); example arithmetic in BRC-130 (fragment length) and BRC-131 (116 + 2×32); ScopeSite constant; missing GroupAnchorFlow constant in BRC-134.
- Markdown table realignment and code-fence language tags throughout.

## Files

transactions/0124,0126,0127,0128,0129,0130,0131,0132,0133,0134,0135.md
