### PR TITLE
BRC-126 retransmission throttling update

### DIFF
--- a/transactions/0126.md
+++ b/transactions/0126.md
@@ -5,8 +5,8 @@ Jeff Harris (jeff@lightweb.net)
 ## Abstract
 
 This BRC specifies the NACK-based retransmission and endpoint discovery protocol
-for the BSV multicast transaction distribution pipeline. It defines four UDP
-datagram formats — ADVERT, NACK, MISS, and ACK — along with
+for the BSV multicast transaction distribution pipeline. It defines five UDP
+datagram formats — ADVERT, NACK, MISS, ACK, and THROTTLED — along with
 tier/preference-based endpoint selection, an escalation state machine, and
 configurable retransmit modes. The protocol operates on top of the BRC-124
 data-plane and enables reliable gap recovery without requiring connection state
@@ -35,11 +35,15 @@ This BRC adds the reliability layer that allows listeners to recover those gaps:
 3. **ACK/MISS responses** — every NACK receives a deterministic 16-byte
    response; ACK confirms retransmit dispatched, MISS triggers immediate
    escalation.
-4. **Endpoint discovery** — retry endpoints periodically multicast a 56-byte
+4. **THROTTLED signalling** — an optional 16-byte honest-congestion response
+   lets a rate-limited endpoint tell the listener to hold a gap briefly and
+   retry the same endpoint, rather than time out and escalate, when a repair
+   for that gap is already in flight.
+5. **Endpoint discovery** — retry endpoints periodically multicast a 56-byte
    ADVERT beacon; listeners maintain a dynamic registry sorted by tier and
    preference, with no manual configuration required in well-connected
    deployments.
-5. **Flood prevention** — deduplication and fill-suppression mechanisms prevent
+6. **Flood prevention** — deduplication and fill-suppression mechanisms prevent
    retransmit storms at scale.
 
 ## Specification
@@ -60,12 +64,13 @@ messages and are distinct from the data-frame version codes (`0x01`–`0x07`).
 
 ### MsgType Values
 
-| MsgType | Name   | Size | Direction                     |
-| ------- | ------ | ---- | ----------------------------- |
-| `0x10`  | NACK   | 64 B | Listener → Retry endpoint     |
-| `0x11`  | MISS   | 16 B | Retry endpoint → Listener     |
-| `0x12`  | ACK    | 16 B | Retry endpoint → Listener     |
-| `0x20`  | ADVERT | 56 B | Retry endpoint → Beacon group |
+| MsgType | Name      | Size | Direction                     |
+| ------- | --------- | ---- | ----------------------------- |
+| `0x10`  | NACK      | 64 B | Listener → Retry endpoint     |
+| `0x11`  | MISS      | 16 B | Retry endpoint → Listener     |
+| `0x12`  | ACK       | 16 B | Retry endpoint → Listener     |
+| `0x13`  | THROTTLED | 16 B | Retry endpoint → Listener     |
+| `0x20`  | ADVERT    | 56 B | Retry endpoint → Beacon group |
 
 ---
 
@@ -231,6 +236,44 @@ cancelling it.
 
 ---
 
+### THROTTLED Response (`MsgType 0x13`) — 16 bytes
+
+Sent unicast to the NACK source when the request was rejected by an
+honest-congestion rate-limit tier — per-gap (per-`SeqNum`), per-flow
+(per-`HashKey`), or per-group (per `groupIdx`). THROTTLED is a flow-control
+signal, **not** a failure: the endpoint is healthy, and for a per-gap throttle a
+retransmit for this exact gap was likely just dispatched and is propagating over
+the multicast data plane. On receipt the listener MUST hold the gap for the
+hinted backoff and retry the **same** endpoint; it MUST NOT escalate to another
+endpoint and MUST NOT count the throttle as a recovery failure.
+
+| Offset | Size | Field    | Description                                                  |
+| ------ | ---- | -------- | ------------------------------------------------------------ |
+| 0      | 4    | Magic    | `0xE3E1F3E8`                                                 |
+| 4      | 2    | ProtoVer | `0x02BF`                                                    |
+| 6      | 1    | MsgType  | `0x13` (THROTTLED)                                           |
+| 7      | 1    | Flags    | Low nibble (bits 0–3) = backoff-hint bucket; bits 4–7 reserved, must be `0` |
+| 8      | 8    | SeqNum   | Echo of the throttled request's `StartSeq`                  |
+
+**Backoff hint.** The suggested hold is `ThrottleHintBase << bucket`, where
+`ThrottleHintBase = 125 ms` and `bucket` is the Flags low nibble. Endpoints
+SHOULD use bucket `2` (~500 ms) for a per-gap throttle, bucket `3` (~1 s) for a
+per-flow throttle, and bucket `4` (~2 s) for a per-group throttle — broader
+scopes back off longer. Listeners SHOULD apply jitter to the computed hold and
+MAY clamp it to a local maximum. The gap's absolute TTL remains the upper bound,
+and a multicast repair arriving via the data plane cancels the gap regardless.
+
+**Emission rules.** THROTTLED is OPTIONAL and disabled by default; the reference
+implementation gates it behind `-rl-throttle-response`. It is a load-shedding
+refinement for high-fan-out deployments — listeners that never receive it simply
+fall back to timeout plus exponential backoff. An endpoint MUST NOT send
+THROTTLED in response to a flood-tier (per-source-IP) rejection: that tier sheds
+abusive or spoofed-source load, and answering it would permit reflection. The
+16-byte THROTTLED response is smaller than the 64-byte NACK, so the protocol is
+never a bandwidth amplifier regardless.
+
+---
+
 ### Tier / Preference Model
 
 Retry endpoints are organised into tiers representing proximity to the
@@ -261,15 +304,19 @@ listener advances to the next position.
        ▼
   ┌────────────────┐
   │ NACKED(Tier-K) │  NACK sent to current (tier, preference) endpoint
-  └───┬────┬───┬───┘
-      │    │   │
-      │    │   └── Timeout ──► exponential backoff; retry next sweep
-      │    │
-      │    └── MISS ──► advance to next endpoint at same tier (Preference DESC);
-      │                 if tier exhausted, escalate to Tier K+1;
-      │                 retry IMMEDIATELY (no backoff on MISS)
-      │
-      └── ACK ──► gap entry cancelled; done
+  └─┬───┬────┬───┬─┘
+    │   │    │   │
+    │   │    │   └── Timeout ──► exponential backoff; retry next sweep
+    │   │    │
+    │   │    └── THROTTLED ──► hold the SAME endpoint for the hinted backoff
+    │   │                      (ThrottleHintBase << bucket, jittered);
+    │   │                      do NOT escalate, do NOT count a failed round
+    │   │
+    │   └── MISS ──► advance to next endpoint at same tier (Preference DESC);
+    │                if tier exhausted, escalate to Tier K+1;
+    │                retry IMMEDIATELY (no backoff on MISS)
+    │
+    └── ACK ──► gap entry cancelled; done
 
   Any state ──► FILLED (multicast repair arrived via data plane)
                gap entry cancelled; in-flight NACK socket times out harmlessly
@@ -278,6 +325,9 @@ listener advances to the next position.
 - **ACK received:** Cancel gap entry. No further NACKs sent for this gap.
 - **MISS received:** Advance to next endpoint at same tier by Preference; if
   tier exhausted, move to next tier; retry immediately.
+- **THROTTLED received:** Hold the gap for the hinted backoff (jittered) and
+  retry the **same** endpoint; do not escalate and do not consume the retry
+  budget. The endpoint is healthy and a repair is likely already propagating.
 - **Timeout:** Apply exponential backoff (capped at `nack-backoff-max`); retry
   on next sweeper tick.
 - **Multicast fill:** The data-plane receive goroutine calls `Tracker.Fill()`
@@ -321,6 +371,7 @@ Retransmit behavior is controlled by flags on the retry endpoint:
 | `-retransmit-unicast`   | `false` | Retransmit frame unicast to NACK source            |
 | `-suppress-miss`        | `false` | Do not send MISS response on cache miss            |
 | `-suppress-ack`         | `false` | Do not send ACK response on cache hit              |
+| `-rl-throttle-response` | `false` | Reply to honest-congestion rate-limit drops (per-gap/per-flow/per-group) with a THROTTLED hint; the flood (per-IP) tier stays silent |
 
 **Deployment profiles:**
 
@@ -338,6 +389,7 @@ Retransmit behavior is controlled by flags on the retry endpoint:
 | Mechanism               | Component      | Effect                                                              |
 | ----------------------- | -------------- | ------------------------------------------------------------------- |
 | Cache TTL (60 s)        | Retry endpoint | Frames expire naturally; bounds retransmit window                   |
+| THROTTLED hint          | Retry endpoint | Optional; honest-congestion tiers park the listener's gap instead of dropping silently, avoiding wasted timeout + escalation |
 | `Tracker.Fill()`        | Listener       | Multicast repair cancels all pending NACKs for a gap                |
 | Jitter hold-off         | Listener       | Randomised delay before first NACK suppresses correlated duplicates |
 | Exponential backoff     | Listener       | Reduces NACK rate on persistent or repeated gaps                    |
@@ -406,6 +458,18 @@ E3E1F3E8                                  // Network Magic
 00000000000004D3                          // SeqNum of retransmitted frame (1235)
 ```
 
+### THROTTLED Response (16 bytes)
+
+Per-gap throttle (bucket `2`, ~500 ms hold) echoing the requested `SeqNum=1235`:
+
+```text
+E3E1F3E8                                  // Network Magic
+02BF                                      // Protocol Version
+13                                        // MsgType = THROTTLED
+02                                        // Flags = backoff bucket 2 (~500 ms)
+00000000000004D3                          // SeqNum echo (1235)
+```
+
 ---
 
 ## References
@@ -426,6 +490,7 @@ E3E1F3E8                                  // Network Magic
 | `MsgTypeNACK`           | 16         | `0x10`       | NACK request                           |
 | `MsgTypeMISS`           | 17         | `0x11`       | MISS response                          |
 | `MsgTypeACK`            | 18         | `0x12`       | ACK response                           |
+| `MsgTypeTHROTTLED`      | 19         | `0x13`       | THROTTLED congestion-control response  |
 | `MsgTypeADVERT`         | 32         | `0x20`       | Endpoint advertisement beacon          |
 | `ScopeSite`             | 5          | `0x05`       | Site-local beacon scope                |
 | `ScopeOrg`              | 8          | `0x08`       | Organisation beacon scope              |
@@ -443,3 +508,7 @@ E3E1F3E8                                  // Network Magic
 | `DefaultBeaconInterval` | 60         | —            | Default ADVERT send interval (s)       |
 | `DefaultCacheTTL`       | 60         | —            | Default frame cache TTL (s)            |
 | `TierStaticSeed`        | 255        | `0xFF`       | Tier assigned to static seed endpoints |
+| `ThrottleHintBase`      | 125 ms     | —            | THROTTLED backoff unit; hold = `ThrottleHintBase << bucket` |
+| `ThrottleBucketGap`     | 2          | `0x02`       | THROTTLED bucket: per-gap throttle (~500 ms) |
+| `ThrottleBucketFlow`    | 3          | `0x03`       | THROTTLED bucket: per-flow throttle (~1 s) |
+| `ThrottleBucketGroup`   | 4          | `0x04`       | THROTTLED bucket: per-group throttle (~2 s) |

--- a/transactions/0126.md
+++ b/transactions/0126.md
@@ -263,14 +263,14 @@ scopes back off longer. Listeners SHOULD apply jitter to the computed hold and
 MAY clamp it to a local maximum. The gap's absolute TTL remains the upper bound,
 and a multicast repair arriving via the data plane cancels the gap regardless.
 
-**Emission rules.** THROTTLED is OPTIONAL and disabled by default; the reference
-implementation gates it behind `-rl-throttle-response`. It is a load-shedding
-refinement for high-fan-out deployments — listeners that never receive it simply
-fall back to timeout plus exponential backoff. An endpoint MUST NOT send
-THROTTLED in response to a flood-tier (per-source-IP) rejection: that tier sheds
-abusive or spoofed-source load, and answering it would permit reflection. The
-16-byte THROTTLED response is smaller than the 64-byte NACK, so the protocol is
-never a bandwidth amplifier regardless.
+**Emission rules.** THROTTLED is OPTIONAL and SHOULD default to disabled; an
+endpoint MAY be configured to emit it. It is a load-shedding refinement for
+high-fan-out deployments — listeners that never receive it simply fall back to
+timeout plus exponential backoff. An endpoint MUST NOT send THROTTLED in
+response to a flood-tier (per-source-IP) rejection: that tier sheds abusive or
+spoofed-source load, and answering it would permit reflection. The 16-byte
+THROTTLED response is smaller than the 64-byte NACK, so the protocol is never a
+bandwidth amplifier regardless.
 
 ---
 
@@ -371,7 +371,6 @@ Retransmit behavior is controlled by flags on the retry endpoint:
 | `-retransmit-unicast`   | `false` | Retransmit frame unicast to NACK source            |
 | `-suppress-miss`        | `false` | Do not send MISS response on cache miss            |
 | `-suppress-ack`         | `false` | Do not send ACK response on cache hit              |
-| `-rl-throttle-response` | `false` | Reply to honest-congestion rate-limit drops (per-gap/per-flow/per-group) with a THROTTLED hint; the flood (per-IP) tier stays silent |
 
 **Deployment profiles:**
 


### PR DESCRIPTION
### This pull request:

Amends or corrects an existing standard, without the need for creating a new one

### Summary

Adds a fifth BRC-126 control message, **THROTTLED** (`MsgType 0x13`, 16 bytes): an optional response a retry endpoint sends when a NACK is rejected by an honest-congestion rate-limit tier (per-gap, per-flow, or per-group).

Today those tiers drop silently, so a listener waits out its full timeout and escalates to another endpoint — even though the original endpoint is healthy and a repair for that gap is usually already on its way. THROTTLED carries a backoff hint that tells the listener to briefly hold the gap and retry the **same** endpoint, without escalating or spending its retry budget.

The change is additive and backward-compatible: THROTTLED is optional and defaults to disabled, and listeners that never receive it keep using the existing timeout-and-backoff path.

**Changes to `transactions/0126.md`**
- New THROTTLED response section: wire format, backoff-hint encoding (`ThrottleHintBase = 125 ms`, hold = `ThrottleHintBase << bucket`; buckets 2/3/4 for per-gap/per-flow/per-group), and emission rules
- MsgType table, abstract, motivation, escalation state machine, flood-prevention table, and constants reference updated to include THROTTLED
- Added a THROTTLED example datagram

**Anti-abuse:** the per-source-IP flood tier never emits THROTTLED (it could enable reflection of spoofed sources), and the 16-byte response is smaller than the 64-byte NACK that triggers it, so it can never act as a bandwidth amplifier.

