### PR TITLE
[Fix] remove deprecated/invalid hash-chain sequencing description

### DIFF
--- a/transactions/0124.md
+++ b/transactions/0124.md
@@ -15,9 +15,8 @@ This BRC is licensed under the Open BSV License.
 As BSV transaction throughput scales to billions of transactions per second, efficient distribution infrastructure becomes critical. IPv6 multicast provides a scalable one-to-many transport mechanism, but globally scalable transaction distribution requires:
 
 1. **Deterministic sharding** — routing transactions to specific multicast groups based on transaction ID
-2. **Sequence tracking** — detecting and recovering from frame loss via hash-chain NACK-based retransmission
-3. **Subtree identification** — filtering batches of related transactions at the network layer
-4. **Flow identification** — stable per-flow hashing for gap tracking and NACK-based retransmission
+2. **Subtree identification** — filtering batches of related transactions at the network layer
+3. **Flow and Sequence tracking** — stable per-flow hashing and monotonic sequencing for gap tracking and NACK-based retransmission
 
 This frame format addresses these requirements while maintaining compatibility with the existing BRC-12 transaction payload format. It uses a 92-byte header that provides the metadata necessary for high-throughput multicast distribution with best-effort reliability, complementing the legacy 44-byte header defined in BRC-12.
 


### PR DESCRIPTION
### This pull request:

Amends or corrects an existing standard, without the need for creating a new one

### Summary

Please forgive the repeated BRC fixes. This one is an artifact of earlier work that was deprecated and invalidated as not scalable. The offending information is removed for clarity and to avoid implementation issues.

### Changes:

- Removed hash-chain sequencing description.
